### PR TITLE
Fix/agentflows-marketplace

### DIFF
--- a/apps/web/app/(Main UI)/sidekick-studio/(minimal-layout)/agentcanvas/[chatflowid]/page.tsx
+++ b/apps/web/app/(Main UI)/sidekick-studio/(minimal-layout)/agentcanvas/[chatflowid]/page.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
-
 import View from '@/views/canvas/index'
+
+interface ViewProps {
+    chatflowid: string
+}
 
 const Page = ({ params }: { params: { chatflowid: string } }) => {
     return (

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -255,6 +255,12 @@ const saveChatflow = async (newChatFlow: ChatFlow): Promise<any> => {
         const appServer = getRunningExpressApp()
         let dbResponse: ChatFlow
 
+        // If this is a template, remove the id before saving
+        if ((newChatFlow as any).isTemplate) {
+            const { id, isTemplate, ...chatflowWithoutId } = newChatFlow as any
+            newChatFlow = chatflowWithoutId
+        }
+
         // Check if the chatflow already exists
         if (newChatFlow.id) {
             const existingChatflow = await appServer.AppDataSource.getRepository(ChatFlow).findOne({


### PR DESCRIPTION
This PR introduces several improvements to template handling in the marketplace:

Key Changes:
- Added prefix system for template IDs to prevent collisions between different template types:
  - Chatflow: 'cf_'
  - Tool: 'tool_'
  - Agentflow: 'af_'
  - AnswerAI: 'ai_'
- Improved template loading from both database and file system
- Added isTemplate flag to identify file-based templates
- Implemented ID cleanup when saving templates to prevent duplicate IDs
- Fixed template search functionality to work with new prefixed IDs
- Added TypeScript interface for View props in canvas page

Technical Details:
- Database templates retain their UUID format
- File-based templates now use prefixed incremental IDs
- Template search now strips prefixes before UUID validation
- Added logic to remove template ID when saving to prevent conflicts