### PR TITLE
Release 11.26 - Integrated Fixes for Tag Splitting, Loader Delete, and Removing Analyze Chatflow Tab

### DIFF
--- a/packages-answers/ui/src/SidekickSelect.tsx
+++ b/packages-answers/ui/src/SidekickSelect.tsx
@@ -344,7 +344,7 @@ const SidekickSelect: React.FC<SidekickSelectProps> = ({ sidekicks: defaultSidek
         }
         allCategories.top.concat(allCategories.more).forEach((category) => {
             counts[category] = combinedSidekicks.filter(
-                (s) => s.chatflow.category === category || s.chatflow.categories?.includes(category)
+                (s) => s.chatflow.category === category || s.chatflow.categories?.includes(category) || s.categories?.includes(category)
             ).length
         })
         return counts
@@ -376,7 +376,7 @@ const SidekickSelect: React.FC<SidekickSelectProps> = ({ sidekicks: defaultSidek
     }
 
     const visibleTabs = useMemo(() => {
-        const topTabs = allCategories.top
+        const topTabs = allCategories.top?.map((category) => category.split(';').join(' | '))
         if (!topTabs.includes(activeTab) && allCategories.more.includes(activeTab)) {
             return [...topTabs, activeTab]
         }
@@ -439,7 +439,11 @@ const SidekickSelect: React.FC<SidekickSelectProps> = ({ sidekicks: defaultSidek
                 case 'all':
                     return true
                 default:
-                    return sidekick.chatflow.categories?.includes(tabValue) || sidekick.chatflow.category === tabValue
+                    return (
+                        sidekick.chatflow.categories?.includes(tabValue) ||
+                        sidekick.chatflow.category === tabValue ||
+                        sidekick.categories?.includes(tabValue)
+                    )
             }
         }
 
@@ -489,11 +493,15 @@ const SidekickSelect: React.FC<SidekickSelectProps> = ({ sidekicks: defaultSidek
                                 </SidekickTitle>
                                 <Box sx={{ display: 'flex', flexWrap: 'wrap', width: '100%', gap: 1 }}>
                                     {sidekick.categories?.length > 0 && sidekick.categories?.map ? (
-                                        <Tooltip title={sidekick.categories.join(', ')}>
+                                        <Tooltip
+                                            title={sidekick.categories
+                                                .map((category: string, index: number) => category.trim().split(';').join(', '))
+                                                .join(', ')}
+                                        >
                                             <Chip
                                                 // icon={<CategoryIcon />}
                                                 label={sidekick.categories
-                                                    .map((category: string, index: number) => category.trim())
+                                                    .map((category: string, index: number) => category.trim().split(';').join(' | '))
                                                     .join(' | ')}
                                                 size='small'
                                                 variant='outlined'
@@ -638,7 +646,17 @@ const SidekickSelect: React.FC<SidekickSelectProps> = ({ sidekicks: defaultSidek
                         disabled={categoryCounts.recent === 0}
                     /> */}
                     {visibleTabs.map((category: string) => (
-                        <Tab key={`${category}-tab`} label={category} value={category} disabled={categoryCounts[category] === 0} />
+                        <Tab
+                            key={`${category}-tab`}
+                            label={category}
+                            value={category}
+                            disabled={categoryCounts[category] === 0}
+                            style={{
+                                textWrap: 'nowrap',
+                                maxWidth: 'fit-content',
+                                display: 'inline-block'
+                            }}
+                        />
                     ))}
                     {allCategories.more.length > 0 && (
                         <Tab

--- a/packages-answers/utils/src/findSidekicksForChat.ts
+++ b/packages-answers/utils/src/findSidekicksForChat.ts
@@ -62,22 +62,28 @@ export async function findSidekicksForChat(user: User) {
         if (response.ok) {
             const result = await response.json()
 
-            const sidekicks: Sidekick[] = result.map((chatflow: any) => ({
-                id: chatflow.id || '',
-                label: chatflow.name || '',
-                visibility: chatflow.visibility || [],
-                chatflow: chatflow,
-                answersConfig: chatflow.answersConfig,
-                chatflowId: chatflow.id || '',
-                chatflowDomain: chatflowDomain,
-                chatbotConfig: parseChatbotConfig(chatflow.chatbotConfig),
-                flowData: parseFlowData(chatflow.flowData),
-                isRecent: userChats.some((chat) => chat.chatflowId === chatflow.id),
-                category: chatflow.category,
-                categories: chatflow.categories || chatflow.category ? [chatflow.category] : [],
-                isAvailable: chatflow.isPublic || chatflow.visibility.includes('Organization'),
-                isFavorite: false // This will be managed client-side
-            }))
+            const sidekicks: Sidekick[] = result.map((chatflow: any) => {
+                const categories = (chatflow.categories || chatflow.category ? [chatflow.category] : [])
+                    .filter(Boolean)
+                    .map((c) => c.trim().split(';'))
+                    .flat()
+                return {
+                    id: chatflow.id || '',
+                    label: chatflow.name || '',
+                    visibility: chatflow.visibility || [],
+                    chatflow: chatflow,
+                    answersConfig: chatflow.answersConfig,
+                    chatflowId: chatflow.id || '',
+                    chatflowDomain: chatflowDomain,
+                    chatbotConfig: parseChatbotConfig(chatflow.chatbotConfig),
+                    flowData: parseFlowData(chatflow.flowData),
+                    isRecent: userChats.some((chat) => chat.chatflowId === chatflow.id),
+                    category: chatflow.category,
+                    categories,
+                    isAvailable: chatflow.isPublic || chatflow.visibility.includes('Organization'),
+                    isFavorite: false // This will be managed client-side
+                }
+            })
 
             return {
                 sidekicks,
@@ -95,7 +101,10 @@ export async function findSidekicksForChat(user: User) {
 }
 
 function getUniqueCategories(sidekicks: Sidekick[]) {
-    const categories = [...new Set(sidekicks.map((s) => s.category))].filter(Boolean)
+    const categories = [...new Set(sidekicks.map((s) => s.category))]
+        .filter(Boolean)
+        .map((c) => c.trim().split(';'))
+        .flat()
     const topCategories = categories.slice(0, 3)
     const moreCategories = categories.slice(3)
 

--- a/packages/ui/src/ui-component/dialog/ChatflowConfigurationDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ChatflowConfigurationDialog.jsx
@@ -7,7 +7,6 @@ import SpeechToText from '@/ui-component/extended/SpeechToText'
 import RateLimit from '@/ui-component/extended/RateLimit'
 import AllowedDomains from '@/ui-component/extended/AllowedDomains'
 import ChatFeedback from '@/ui-component/extended/ChatFeedback'
-import AnalyseFlow from '@/ui-component/extended/AnalyseFlow'
 import StarterPrompts from '@/ui-component/extended/StarterPrompts'
 import Leads from '@/ui-component/extended/Leads'
 import VisibilitySettings from '@/ui-component/extended/VisibilitySettings'
@@ -42,10 +41,10 @@ const CHATFLOW_CONFIGURATION_TABS = [
         label: 'Allowed Domains',
         id: 'allowedDomains'
     },
-    {
-        label: 'Analyse Chatflow',
-        id: 'analyseChatflow'
-    },
+    // {
+    //     label: 'Analyse Chatflow',
+    //     id: 'analyseChatflow'
+    // },
     {
         label: 'Leads',
         id: 'leads'
@@ -129,7 +128,7 @@ const ChatflowConfigurationDialog = ({ show, dialogProps, onCancel }) => {
                         {item.id === 'speechToText' ? <SpeechToText dialogProps={dialogProps} /> : null}
                         {item.id === 'chatFeedback' ? <ChatFeedback dialogProps={dialogProps} /> : null}
                         {item.id === 'allowedDomains' ? <AllowedDomains dialogProps={dialogProps} /> : null}
-                        {item.id === 'analyseChatflow' ? <AnalyseFlow dialogProps={dialogProps} /> : null}
+                        {/* {item.id === 'analyseChatflow' ? <AnalyseFlow dialogProps={dialogProps} /> : null} */}
                         {item.id === 'leads' ? <Leads dialogProps={dialogProps} /> : null}
                         {item.id === 'visibilitySettings' ? <VisibilitySettings dialogProps={dialogProps} /> : null}
                         {item.id === 'generalSettings' ? <GeneralSettings dialogProps={dialogProps} /> : null}

--- a/packages/ui/src/views/docstore/DeleteDocStoreDialog.jsx
+++ b/packages/ui/src/views/docstore/DeleteDocStoreDialog.jsx
@@ -226,7 +226,7 @@ const DeleteDocStoreDialog = ({ show, dialogProps, onCancel, onDelete }) => {
                 <Button onClick={onCancel} color='primary'>
                     Cancel
                 </Button>
-                <Button variant='contained' onClick={() => onDelete(dialogProps.type, removeFromVS)} color='error'>
+                <Button variant='contained' onClick={() => onDelete(dialogProps.type, dialogProps.loaderId, removeFromVS)} color='error'>
                     Delete
                 </Button>
             </DialogActions>

--- a/packages/ui/src/views/docstore/DocumentStoreDetail.jsx
+++ b/packages/ui/src/views/docstore/DocumentStoreDetail.jsx
@@ -186,7 +186,7 @@ const DocumentStoreDetails = () => {
         }
     }
 
-    const onDocStoreDelete = async (type, removeFromVectorStore) => {
+    const onDocStoreDelete = async (type, loaderId, removeFromVectorStore) => {
         setBackdropLoading(true)
         if (type === 'STORE') {
             if (removeFromVectorStore) {
@@ -230,7 +230,7 @@ const DocumentStoreDetails = () => {
             }
         } else if (type === 'LOADER') {
             try {
-                const deleteResp = await documentsApi.deleteLoaderFromStore(storeId, file.id)
+                const deleteResp = await documentsApi.deleteLoaderFromStore(storeId, loaderId)
                 setBackdropLoading(false)
                 if (deleteResp.data) {
                     enqueueSnackbar({
@@ -274,7 +274,8 @@ const DocumentStoreDetails = () => {
             description: `Delete Loader ${file.loaderName} ? This will delete all the associated document chunks.`,
             vectorStoreConfig,
             recordManagerConfig,
-            type: 'LOADER'
+            type: 'LOADER',
+            loaderId: file.id
         }
 
         setDeleteDocStoreDialogProps(props)


### PR DESCRIPTION
This PR introduces a bundle of essential fixes which were made across multiple project files. Here are the highlights:

Implemented a split functionality for the categories, as well as for the chatflow category in findSidekicksForChat file. This enhances the creation of tabs and filtering functionalities, reducing the complexity in categories management [Commit: 59a70b896d1bf9b1ea0cce558f824fd3df7b25cd].

Rectified the bug in the delete function of the Document Store by introducing loaderId into deleteDocStoreDialogueProps. This helps in identifying and deleting the correct loader from the Document Store [Commit: c2c850ded995b313875ce244e947c4f0edea3a07].

The "Analyze Chatflow" tab and its component from ChatflowConfigurationDialog.jsx have been disabled due to changes in requirements. This will help to simplify the UI and meet the current needs of the user base [Commit: 59ff8489e326df5ff8d216891b2d89373c9fb6c6].
