### PR TITLE
fix: cited sources do not open

### DIFF
--- a/packages-answers/ui/package.json
+++ b/packages-answers/ui/package.json
@@ -61,6 +61,7 @@
         "react-markdown": "^8.0.7",
         "react-syntax-highlighter": "^15.5.0",
         "react-window": "^1.8.9",
+        "remark-gfm": "^3.0.1",
         "stripe": "^12.17.0",
         "swr": "^2.2.0",
         "types": "workspace:*",

--- a/packages-answers/ui/src/Message/Message.tsx
+++ b/packages-answers/ui/src/Message/Message.tsx
@@ -31,6 +31,7 @@ import FeedbackModal from '@ui/FeedbackModal'
 import { AppService, Document, Message } from 'types'
 import { Rating } from 'db/generated/prisma-client'
 import { CircularProgress, Tooltip } from '@mui/material'
+import remarkGfm from 'remark-gfm'
 
 interface MessageExtra {
     prompt?: string
@@ -263,6 +264,7 @@ export const MessageCard = ({
                                         }}
                                     >
                                         <ReactMarkdown
+                                            remarkPlugins={[remarkGfm]}
                                             components={{
                                                 p: (paragraph: any) => {
                                                     const { node } = paragraph
@@ -310,6 +312,12 @@ export const MessageCard = ({
                                                     }
                                                     return <p>{paragraph.children}</p>
                                                 },
+
+                                                a: ({ node, ...props }) => (
+                                                    <a {...props} target='_blank' rel='noopener noreferrer'>
+                                                        {props.children}
+                                                    </a>
+                                                ),
 
                                                 code({ node, inline, className, children, ...props }) {
                                                     const codeExample = String(children).replace(/\n$/, '')


### PR DESCRIPTION
Added remark-gfm plugin to ReactMakdown component in packages-answers\ui\src\Message\Message.tsx just like flowise  and tweaked anchor tag to open in new tab for cited links