### PR TITLE
Add browser_ext_config Column to chat_flow Table

### DIFF
--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -95,7 +95,7 @@ export interface IChatFlow {
     organizationId: string
     displayMode?: string
     embeddedUrl?: string
-    browser_ext_config?: string
+    browserExtConfig?: string
 }
 
 export interface IChatMessage {

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -95,6 +95,7 @@ export interface IChatFlow {
     organizationId: string
     displayMode?: string
     embeddedUrl?: string
+    browser_ext_config?: string
 }
 
 export interface IChatMessage {

--- a/packages/server/src/database/entities/ChatFlow.ts
+++ b/packages/server/src/database/entities/ChatFlow.ts
@@ -65,7 +65,7 @@ export class ChatFlow implements IChatFlow {
     type?: ChatflowType
 
     @Column({ nullable: true, type: 'jsonb' })
-    browser_ext_config?: string
+    browserExtConfig?: string
 
     @Index()
     @Column({ type: 'text', nullable: true })

--- a/packages/server/src/database/entities/ChatFlow.ts
+++ b/packages/server/src/database/entities/ChatFlow.ts
@@ -64,6 +64,9 @@ export class ChatFlow implements IChatFlow {
     @Column({ nullable: true, type: 'text' })
     type?: ChatflowType
 
+    @Column({ nullable: true, type: 'jsonb' })
+    browser_ext_config?: string
+
     @Index()
     @Column({ type: 'text', nullable: true })
     parentChatflowId?: string

--- a/packages/server/src/database/migrations/mariadb/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/mariadb/1746508019300-AddBrowserExtConfig.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
+    name = 'AddBrowserExtConfig1746508019300'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'browser_ext_config')
+        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`browser_ext_config\` LONGTEXT`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`browser_ext_config\``)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/mariadb/1746508019300-AddBrowserExtConfig.ts
@@ -4,11 +4,11 @@ export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
     name = 'AddBrowserExtConfig1746508019300'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        const columnExists = await queryRunner.hasColumn('chat_flow', 'browser_ext_config')
-        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`browser_ext_config\` LONGTEXT`)
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'browserExtConfig')
+        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`browserExtConfig\` LONGTEXT`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`browser_ext_config\``)
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`browserExtConfig\``)
     }
 }

--- a/packages/server/src/database/migrations/mysql/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/mysql/1746508019300-AddBrowserExtConfig.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
+    name = 'AddBrowserExtConfig1746508019300'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'browser_ext_config')
+        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`browser_ext_config\` JSON`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`browser_ext_config\``)
+    }
+}

--- a/packages/server/src/database/migrations/mysql/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/mysql/1746508019300-AddBrowserExtConfig.ts
@@ -4,11 +4,11 @@ export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
     name = 'AddBrowserExtConfig1746508019300'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        const columnExists = await queryRunner.hasColumn('chat_flow', 'browser_ext_config')
-        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`browser_ext_config\` JSON`)
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'browserExtConfig')
+        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`browserExtConfig\` JSON`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`browser_ext_config\``)
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`browserExtConfig\``)
     }
 }

--- a/packages/server/src/database/migrations/postgres/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/postgres/1746508019300-AddBrowserExtConfig.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
+    name = 'AddBrowserExtConfig1746508019300'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN "browser_ext_config" JSONB`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_flow" DROP COLUMN "browser_ext_config"`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/postgres/1746508019300-AddBrowserExtConfig.ts
@@ -4,10 +4,10 @@ export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
     name = 'AddBrowserExtConfig1746508019300'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN "browser_ext_config" JSONB`)
+        await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN "browserExtConfig" JSONB`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "chat_flow" DROP COLUMN "browser_ext_config"`)
+        await queryRunner.query(`ALTER TABLE "chat_flow" DROP COLUMN "browserExtConfig"`)
     }
 }

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -50,6 +50,7 @@ import { AddFollowUpPrompts1726666309552 } from './1726666309552-AddFollowUpProm
 import { AddTypeToAssistant1733011290987 } from './1733011290987-AddTypeToAssistant'
 import { UpdateUserUniqueAuth0Id1741898609435 } from './1741898609435-UpdateUserUniqueAuth0Id'
 import { AppCsvRuns1744553414309 } from './1744553414309-AddAppCsvRuns'
+import { AddBrowserExtConfig1746508019300 } from './1746508019300-AddBrowserExtConfig'
 
 export const postgresMigrations = [
     Init1693891895163,
@@ -103,5 +104,6 @@ export const postgresMigrations = [
     AddFollowUpPrompts1726666309552,
     AddTypeToAssistant1733011290987,
     UpdateUserUniqueAuth0Id1741898609435,
-    AppCsvRuns1744553414309
+    AppCsvRuns1744553414309,
+    AddBrowserExtConfig1746508019300
 ]

--- a/packages/server/src/database/migrations/sqlite/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/sqlite/1746508019300-AddBrowserExtConfig.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
+    name = 'AddBrowserExtConfig1746508019300'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'browser_ext_config')
+        if (!columnExists) await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN "browser_ext_config" TEXT`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_flow" DROP COLUMN "browser_ext_config"`)
+    }
+}

--- a/packages/server/src/database/migrations/sqlite/1746508019300-AddBrowserExtConfig.ts
+++ b/packages/server/src/database/migrations/sqlite/1746508019300-AddBrowserExtConfig.ts
@@ -4,11 +4,11 @@ export class AddBrowserExtConfig1746508019300 implements MigrationInterface {
     name = 'AddBrowserExtConfig1746508019300'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        const columnExists = await queryRunner.hasColumn('chat_flow', 'browser_ext_config')
-        if (!columnExists) await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN "browser_ext_config" TEXT`)
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'browserExtConfig')
+        if (!columnExists) await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN "browserExtConfig" TEXT`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "chat_flow" DROP COLUMN "browser_ext_config"`)
+        await queryRunner.query(`ALTER TABLE "chat_flow" DROP COLUMN "browserExtConfig"`)
     }
 }


### PR DESCRIPTION
This change introduces a new optional field browser_ext_config to the chat_flow table to support additional browser extension configuration data.

The browser_ext_config column is added as a JSON or JSONB type depending on the database (MySQL, PostgreSQL, SQLite) to store extended configuration data.
Migration files are included for each supported database to add and remove the browser_ext_config column.
The change updates the IChatFlow interface and the ChatFlow entity to include the new field.
This update enhances the flexibility of chat flow configurations by allowing browser extension-specific settings to be stored and retrieved as needed.