### PR TITLE
AAI-335 - Hotfix - Add user context to backend service methods for access control and auditing

### DIFF
--- a/packages/server/src/controllers/billing/index.ts
+++ b/packages/server/src/controllers/billing/index.ts
@@ -168,7 +168,7 @@ const saveChatflow = async (req: Request, res: Response, next: NextFunction) => 
 const importChatflows = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const chatflows: Partial<ChatFlow>[] = req.body.Chatflows
-        const apiResponse = await chatflowsService.importChatflows(chatflows)
+        const apiResponse = await chatflowsService.importChatflows(req.user!, chatflows)
         return res.json(apiResponse)
     } catch (error) {
         next(error)
@@ -201,7 +201,7 @@ const updateChatflow = async (req: Request, res: Response, next: NextFunction) =
         const rateLimiterManager = RateLimiterManager.getInstance()
         await rateLimiterManager.updateRateLimiter(updateChatFlow)
 
-        const apiResponse = await chatflowsService.updateChatflow(chatflow, updateChatFlow)
+        const apiResponse = await chatflowsService.updateChatflow(chatflow, updateChatFlow, req.user!)
 
         // TODO: Abstract sending to AnswerAI through events endpoint and move to service
         const ANSWERAI_DOMAIN = req.auth?.payload.answersDomain ?? process.env.ANSWERAI_DOMAIN ?? 'https://beta.theanswer.ai'

--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -156,7 +156,7 @@ const saveChatflow = async (req: Request, res: Response, next: NextFunction) => 
 const importChatflows = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const chatflows: Partial<ChatFlow>[] = req.body.Chatflows
-        const apiResponse = await chatflowsService.importChatflows(chatflows)
+        const apiResponse = await chatflowsService.importChatflows(req.user!, chatflows)
         return res.json(apiResponse)
     } catch (error) {
         next(error)
@@ -189,7 +189,7 @@ const updateChatflow = async (req: Request, res: Response, next: NextFunction) =
         const rateLimiterManager = RateLimiterManager.getInstance()
         await rateLimiterManager.updateRateLimiter(updateChatFlow)
 
-        const apiResponse = await chatflowsService.updateChatflow(chatflow, updateChatFlow)
+        const apiResponse = await chatflowsService.updateChatflow(chatflow, updateChatFlow, req.user!)
 
         // TODO: Abstract sending to AnswerAI through events endpoint and move to service
         const ANSWERAI_DOMAIN = req.auth?.payload.answersDomain ?? process.env.ANSWERAI_DOMAIN ?? 'https://beta.theanswer.ai'

--- a/packages/server/src/controllers/documentstore/index.ts
+++ b/packages/server/src/controllers/documentstore/index.ts
@@ -26,7 +26,7 @@ const createDocumentStore = async (req: Request, res: Response, next: NextFuncti
 
 const getAllDocumentStores = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const apiResponse = await documentStoreService.getAllDocumentStores(req.user?.id!, req.user?.organizationId!)
+        const apiResponse = await documentStoreService.getAllDocumentStores(req.user?.id!, req.user?.organizationId!, req.user)
         return res.json(DocumentStoreDTO.fromEntities(apiResponse))
     } catch (error) {
         next(error)
@@ -64,7 +64,12 @@ const getDocumentStoreById = async (req: Request, res: Response, next: NextFunct
                 `Error: documentStoreController.getDocumentStoreById - id not provided!`
             )
         }
-        const apiResponse = await documentStoreService.getDocumentStoreById(req.params.id, req.user?.id!, req.user?.organizationId!)
+        const apiResponse = await documentStoreService.getDocumentStoreById(
+            req.params.id,
+            req.user?.id!,
+            req.user?.organizationId!,
+            req.user
+        )
         if (apiResponse && apiResponse.whereUsed) {
             apiResponse.whereUsed = JSON.stringify(
                 await documentStoreService.getUsedChatflowNames(apiResponse, req.user?.id!, req.user?.organizationId!)

--- a/packages/server/src/controllers/export-import/index.ts
+++ b/packages/server/src/controllers/export-import/index.ts
@@ -13,7 +13,7 @@ const exportData = async (req: Request, res: Response, next: NextFunction) => {
 const importData = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const importData = req.body
-        await exportImportService.importData(importData)
+        await exportImportService.importData(importData, req.user!)
         return res.json({ message: 'success' })
     } catch (error) {
         next(error)

--- a/packages/server/src/controllers/nodes/index.ts
+++ b/packages/server/src/controllers/nodes/index.ts
@@ -82,7 +82,7 @@ const executeCustomFunction = async (req: Request, res: Response, next: NextFunc
                 `Error: nodesController.executeCustomFunction - body not provided!`
             )
         }
-        const apiResponse = await nodesService.executeCustomFunction(req.body, req.user?.id!, req.user?.organizationId!)
+        const apiResponse = await nodesService.executeCustomFunction(req.body, req.user?.id!, req.user?.organizationId!, req.user)
         return res.json(apiResponse)
     } catch (error) {
         next(error)

--- a/packages/server/src/middlewares/authentication/enforceAbility.ts
+++ b/packages/server/src/middlewares/authentication/enforceAbility.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
-import { EntityTarget } from 'typeorm'
+import { EntityTarget, IsNull } from 'typeorm'
 import path from 'path'
 
 // Define interfaces for better type safety
@@ -169,10 +169,16 @@ async function adminHasAccess(repository: any, resourceId: string, organizationI
     // Use more efficient query but maintain original behavior
     return (
         (await repository.findOne({
-            where: {
-                id: resourceId,
-                organizationId
-            },
+            where: [
+                {
+                    id: resourceId,
+                    organizationId
+                },
+                {
+                    id: resourceId,
+                    organizationId: IsNull()
+                }
+            ],
             select: ['id'] // Only need to check existence
         })) !== null
     )

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -17,7 +17,7 @@ import checkOwnership from '../../utils/checkOwnership'
 import { Organization } from '../../database/entities/Organization'
 import { Chat } from '../../database/entities/Chat'
 import { FLOWISE_METRIC_COUNTERS, FLOWISE_COUNTER_STATUS } from '../../Interface.Metrics'
-import { QueryRunner } from 'typeorm'
+import { IsNull, QueryRunner } from 'typeorm'
 
 // Check if chatflow valid for streaming
 const checkIfChatflowIsValidForStreaming = async (chatflowId: string): Promise<any> => {
@@ -96,7 +96,10 @@ const deleteChatflow = async (chatflowId: string, user: IUser | undefined): Prom
 
         // First, try to find the chatflow
         const chatflow = await appServer.AppDataSource.getRepository(ChatFlow).findOne({
-            where: { id: chatflowId, ...(permissions?.includes('org:manage') ? { organizationId } : { userId, organizationId }) }
+            where: {
+                id: chatflowId,
+                ...(permissions?.includes('org:manage') ? [{ organizationId }, { organizationId: IsNull() }] : { userId, organizationId })
+            }
         })
 
         if (!chatflow) {
@@ -246,7 +249,8 @@ const getChatflowById = async (chatflowId: string, user?: IUser): Promise<any> =
 
         // For authenticated users, check permissions
         if (user) {
-            const isUserOrgAdmin = user.permissions?.includes('org:manage') && user.organizationId === dbResponse.organizationId
+            const isUserOrgAdmin = user.permissions?.includes('org:manage')
+            // && (user.organizationId === dbResponse.organizationId || !!dbResponse.organizationId)
             const isUsersChatflow = dbResponse.userId === user.id
             const isChatflowPublic = dbResponse.isPublic
             const hasChatflowOrgVisibility = dbResponse.visibility?.includes(ChatflowVisibility.ORGANIZATION)
@@ -348,7 +352,7 @@ const saveChatflow = async (newChatFlow: ChatFlow): Promise<any> => {
     }
 }
 
-const importChatflows = async (newChatflows: Partial<ChatFlow>[], queryRunner?: QueryRunner): Promise<any> => {
+const importChatflows = async (user: IUser, newChatflows: Partial<ChatFlow>[], queryRunner?: QueryRunner): Promise<any> => {
     try {
         const appServer = getRunningExpressApp()
         const repository = queryRunner ? queryRunner.manager.getRepository(ChatFlow) : appServer.AppDataSource.getRepository(ChatFlow)
@@ -383,6 +387,8 @@ const importChatflows = async (newChatflows: Partial<ChatFlow>[], queryRunner?: 
                 newChatflow.name += ' (1)'
             }
             newChatflow.flowData = JSON.stringify(JSON.parse(flowData))
+            newChatflow.userId = user?.id
+            newChatflow.organizationId = user?.organizationId
             return newChatflow
         })
 
@@ -398,7 +404,7 @@ const importChatflows = async (newChatflows: Partial<ChatFlow>[], queryRunner?: 
     }
 }
 
-const updateChatflow = async (chatflow: ChatFlow, updateChatFlow: ChatFlow): Promise<any> => {
+const updateChatflow = async (chatflow: ChatFlow, updateChatFlow: ChatFlow, user: IUser): Promise<any> => {
     try {
         const appServer = getRunningExpressApp()
 
@@ -412,10 +418,10 @@ const updateChatflow = async (chatflow: ChatFlow, updateChatFlow: ChatFlow): Pro
         // Update chatbotConfig with new displayMode and embeddedUrl if provided
         if (updateChatFlow.chatbotConfig) {
             const updatedConfig = JSON.parse(updateChatFlow.chatbotConfig)
-            if (updatedConfig.displayMode !== undefined) {
+            if (updatedConfig?.displayMode !== undefined) {
                 existingChatbotConfig.displayMode = updatedConfig.displayMode
             }
-            if (updatedConfig.embeddedUrl !== undefined) {
+            if (updatedConfig?.embeddedUrl !== undefined) {
                 existingChatbotConfig.embeddedUrl = updatedConfig.embeddedUrl
             }
         }
@@ -425,7 +431,10 @@ const updateChatflow = async (chatflow: ChatFlow, updateChatFlow: ChatFlow): Pro
         updateChatFlow.visibility = Array.from(
             new Set([...(updateChatFlow.visibility ?? []), ...[ChatflowVisibility.PRIVATE, ChatflowVisibility.ANSWERAI]])
         )
-        const newDbChatflow = appServer.AppDataSource.getRepository(ChatFlow).merge(chatflow, updateChatFlow)
+        const newDbChatflow = appServer.AppDataSource.getRepository(ChatFlow).merge(chatflow, {
+            ...updateChatFlow,
+            organizationId: user.organizationId
+        })
         await _checkAndUpdateDocumentStoreUsage(newDbChatflow)
 
         const dbResponse = await appServer.AppDataSource.getRepository(ChatFlow).save(newDbChatflow)

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -33,7 +33,8 @@ import {
     MODE,
     IOverrideConfig,
     IExecutePreviewLoader,
-    DocumentStoreDTO
+    DocumentStoreDTO,
+    IUser
 } from '../../Interface'
 import { DocumentStoreFileChunk } from '../../database/entities/DocumentStoreFileChunk'
 import { v4 as uuidv4 } from 'uuid'
@@ -48,7 +49,7 @@ import { Document } from '@langchain/core/documents'
 import { UpsertHistory } from '../../database/entities/UpsertHistory'
 import { cloneDeep, omit } from 'lodash'
 import { DOCUMENTSTORE_TOOL_DESCRIPTION_PROMPT_GENERATOR } from '../../utils/prompt'
-import { DataSource } from 'typeorm'
+import { DataSource, FindOptionsWhere } from 'typeorm'
 import { Telemetry } from '../../utils/telemetry'
 import { INPUT_PARAMS_TYPE, OMIT_QUEUE_JOB_DATA } from '../../utils/constants'
 
@@ -68,12 +69,22 @@ const createDocumentStore = async (newDocumentStore: DocumentStore, userId: stri
     }
 }
 
-const getAllDocumentStores = async (userId: string, organizationId: string) => {
+const getAllDocumentStores = async (userId: string, organizationId: string, user?: IUser) => {
     try {
         const appServer = getRunningExpressApp()
-        const entities = await appServer.AppDataSource.getRepository(DocumentStore).find({
-            where: { userId, organizationId }
-        })
+        let entities
+
+        if (user?.permissions?.includes('org:manage')) {
+            // Admin users can see all document stores in their organization
+            entities = await appServer.AppDataSource.getRepository(DocumentStore).find({
+                where: { organizationId }
+            })
+        } else {
+            // Regular users can only see their own document stores
+            entities = await appServer.AppDataSource.getRepository(DocumentStore).find({
+                where: { userId, organizationId }
+            })
+        }
         return entities
     } catch (error) {
         throw new InternalFlowiseError(
@@ -145,14 +156,30 @@ const deleteLoaderFromDocumentStore = async (storeId: string, loaderId: string, 
     }
 }
 
-const getDocumentStoreById = async (storeId: string, userId: string, organizationId: string) => {
+const getDocumentStoreById = async (storeId: string, userId: string, organizationId: string, user?: IUser) => {
     try {
         const appServer = getRunningExpressApp()
-        const entity = await appServer.AppDataSource.getRepository(DocumentStore).findOneBy({
-            id: storeId,
-            userId,
-            organizationId
-        })
+        let queryOptions: FindOptionsWhere<DocumentStore> = {
+            id: storeId
+        }
+
+        if (!user?.permissions?.includes('org:manage')) {
+            // Regular users can only see their own document stores
+            queryOptions = {
+                ...queryOptions,
+                userId,
+                organizationId
+            }
+        } else {
+            // Admin users can see all document stores in their organization
+            queryOptions = {
+                ...queryOptions,
+                organizationId
+            }
+        }
+
+        const entity = await appServer.AppDataSource.getRepository(DocumentStore).findOneBy(queryOptions)
+
         if (!entity) {
             throw new InternalFlowiseError(
                 StatusCodes.NOT_FOUND,

--- a/packages/server/src/services/export-import/index.ts
+++ b/packages/server/src/services/export-import/index.ts
@@ -82,17 +82,16 @@ const exportData = async (exportInput: ExportInput, user: IUser): Promise<{ File
     }
 }
 
-const importData = async (importData: ExportData) => {
+const importData = async (importData: ExportData, user: IUser) => {
     try {
         const appServer = getRunningExpressApp()
         const queryRunner = appServer.AppDataSource.createQueryRunner()
-
         try {
             await queryRunner.startTransaction()
 
             if (importData.Tool.length > 0) await toolsService.importTools(importData.Tool, queryRunner)
-            if (importData.ChatFlow.length > 0) await chatflowService.importChatflows(importData.ChatFlow, queryRunner)
-            if (importData.AgentFlow.length > 0) await chatflowService.importChatflows(importData.AgentFlow, queryRunner)
+            if (importData.ChatFlow.length > 0) await chatflowService.importChatflows(user, importData.ChatFlow, queryRunner)
+            if (importData.AgentFlow.length > 0) await chatflowService.importChatflows(user, importData.AgentFlow, queryRunner)
             if (importData.Variable.length > 0) await variableService.importVariables(importData.Variable, queryRunner)
             if (importData.Assistant.length > 0) await assistantService.importAssistants(importData.Assistant, queryRunner)
 

--- a/packages/server/src/services/nodes/index.ts
+++ b/packages/server/src/services/nodes/index.ts
@@ -89,7 +89,7 @@ const getSingleNodeIcon = async (nodeName: string) => {
 const getSingleNodeAsyncOptions = async (
     nodeName: string,
     requestBody: any,
-    user: { id: string; organizationId?: string; roles?: string[] } | undefined
+    user: { id: string; organizationId?: string; roles?: string[]; permissions?: string[] } | undefined
 ): Promise<any> => {
     try {
         const appServer = getRunningExpressApp()
@@ -104,7 +104,8 @@ const getSingleNodeAsyncOptions = async (
                     databaseEntities: databaseEntities,
                     userId: user?.id,
                     organizationId: user?.organizationId,
-                    isAdmin: user?.roles?.includes('Admin')
+                    isAdmin: user?.roles?.includes('Admin'),
+                    isOrgAdmin: user?.permissions?.includes('org:manage')
                 })
 
                 return dbResponse
@@ -123,7 +124,7 @@ const getSingleNodeAsyncOptions = async (
 }
 
 // execute custom function node
-const executeCustomFunction = async (requestBody: any, userId: string, organizationId: string) => {
+const executeCustomFunction = async (requestBody: any, userId: string, organizationId: string, user?: { permissions?: string[] }) => {
     try {
         const appServer = getRunningExpressApp()
         const body = requestBody
@@ -149,7 +150,8 @@ const executeCustomFunction = async (requestBody: any, userId: string, organizat
                     databaseEntities,
                     logger,
                     userId,
-                    organizationId
+                    organizationId,
+                    isOrgAdmin: user?.permissions?.includes('org:manage')
                 }
 
                 const returnData = await newNodeInstance.init(nodeData, '', options)


### PR DESCRIPTION
## PR Title

Add user context to backend service methods for access control and auditing

## Description

This PR updates several backend controller and service methods to pass the authenticated `req.user` object through to core logic. This enables fine-grained access control and organizational scoping in downstream services.

## Changes

### Controllers

- **chatflows**  
  - `importChatflows` now calls `chatflowsService.importChatflows(req.user, chatflows)`
  - `updateChatflow` now calls `chatflowsService.updateChatflow(chatflow, updateChatFlow, req.user)`

- **billing**  
  - Same changes as chatflows

- **documentstore**  
  - `getAllDocumentStores` and `getDocumentStoreById` now include `req.user` in service calls

- **export-import**  
  - `importData` now calls `exportImportService.importData(data, req.user)`

- **nodes**  
  - `executeCustomFunction` now calls `nodesService.executeCustomFunction(..., req.user)`

### Services

- **chatflowsService**  
  - `importChatflows(user, chatflows)` assigns `userId` and `organizationId`
  - `updateChatflow(chatflow, updateChatFlow, user)` merges `organizationId` context
  - Added `IsNull()` fallback to support visibility scoping

- **documentStoreService**  
  - `getAllDocumentStores`: org admins (`org:manage`) can access all org records
  - `getDocumentStoreById`: now conditionally checks org admin permissions and applies appropriate filters

- **nodesService**  
  - `executeCustomFunction` now receives `user` to determine org-level permissions

## Notes

This change is required to support future audit logging and permission-aware logic across shared resources.

Support Ticket: AAI-335
