### PR TITLE
fix: Persist chat messages in internal chat using local storage

### DIFF
--- a/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
@@ -13,7 +13,6 @@ import { cloneDeep } from 'lodash'
 // material-ui
 import {
     Button,
-    Tooltip,
     ListItemButton,
     Box,
     Stack,
@@ -38,7 +37,7 @@ import userPNG from '@/assets/images/account.png'
 import msgEmptySVG from '@/assets/images/message_empty.svg'
 import multiagent_supervisorPNG from '@/assets/images/multiagent_supervisor.png'
 import multiagent_workerPNG from '@/assets/images/multiagent_worker.png'
-import { IconTool, IconDeviceSdCard, IconFileExport, IconEraser, IconX, IconDownload, IconPaperclip } from '@tabler/icons-react'
+import { IconTool, IconDeviceSdCard, IconFileExport, IconX, IconDownload, IconPaperclip } from '@tabler/icons-react'
 
 // Project import
 import { MemoizedReactMarkdown } from '@/ui-component/markdown/MemoizedReactMarkdown'
@@ -953,11 +952,12 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
                             />
                         </div>
                         <div style={{ flex: 1 }}></div>
-                        {stats.totalMessages > 0 && (
+                        {/* TODO: Add this back in when we have a better use case for it
+                         {stats.totalMessages > 0 && (
                             <Button color='error' variant='outlined' onClick={() => onDeleteMessages()} startIcon={<IconEraser />}>
                                 Delete Messages
                             </Button>
-                        )}
+                        )} */}
                     </div>
                     <div
                         style={{
@@ -1070,7 +1070,7 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
                                                 </div>
                                             )}
                                         </div>
-                                        <div
+                                        {/* <div
                                             style={{
                                                 display: 'flex',
                                                 flexDirection: 'column',
@@ -1100,7 +1100,7 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
                                                     </h5>
                                                 </Tooltip>
                                             )}
-                                        </div>
+                                        </div> */}
                                     </div>
                                 )}
                                 <div

--- a/packages/ui/src/views/chatmessage/ChatPopUp.jsx
+++ b/packages/ui/src/views/chatmessage/ChatPopUp.jsx
@@ -90,8 +90,9 @@ export const ChatPopUp = ({ chatflowid, isAgentCanvas }) => {
         if (isConfirmed) {
             try {
                 const objChatDetails = getLocalStorageChatflow(chatflowid)
-                if (!objChatDetails.chatId) return
                 await chatmessageApi.deleteChatmessage(chatflowid, { chatId: objChatDetails.chatId, chatType: 'INTERNAL' })
+                localStorage.removeItem(`${chatflowid}_INTERNAL_chatId`)
+                if (!objChatDetails.chatId) return
                 removeLocalStorageChatHistory(chatflowid)
                 resetChatDialog()
                 enqueueSnackbar({


### PR DESCRIPTION

This pull request addresses an issue with chat message persistence in the internal chat functionality. The fix ensures that the current chat is properly maintained between sessions by leveraging local storage.

### Changes made:
- Store and retrieve chat IDs in local storage using a consistent key format (`${chatflowid}_INTERNAL_chatId`)
- Properly initialize chat with existing messages instead of appending to empty state
- Add checks to prevent unnecessary chat ID updates
- Remove the delete messages button from the ViewMessagesDialog component (commented out for future use)
- Ensure chat message deletion properly cleans up local storage entries
- Fix chat component to request messages with the correct chat ID
