### PR TITLE
Add centralized subscription modal

### DIFF
--- a/packages-answers/ui/src/AppDrawer.tsx
+++ b/packages-answers/ui/src/AppDrawer.tsx
@@ -31,14 +31,11 @@ import ContactSupport from '@mui/icons-material/ContactSupport'
 import AssessmentIcon from '@mui/icons-material/Assessment'
 import { useHelpChatContext } from './HelpChatContext' // Import the context
 import { ExportImportMenuItems } from './components/ExportImportComponent'
+import { useSubscriptionDialog } from './SubscriptionDialogContext'
 
 import dynamic from 'next/dynamic'
 import ChatDrawer from './ChatDrawer'
-
-const PurchaseSubscription = dynamic(() => import('./billing/PurchaseSubscription'), { ssr: false })
-const Dialog = dynamic(() => import('@mui/material/Dialog'), { ssr: false })
-const DialogContent = dynamic(() => import('@mui/material/DialogContent'), { ssr: false })
-const DialogTitle = dynamic(() => import('@mui/material/DialogTitle'), { ssr: false })
+import StarIcon from '@mui/icons-material/Star'
 
 const drawerWidth = 240
 
@@ -89,7 +86,7 @@ export const AppDrawer = ({ session, flagsmithState }: any) => {
     const user = session?.user
     const [drawerOpen, setDrawerOpen] = useState(false)
     const [submenuOpen, setSubmenuOpen] = useState('')
-    const [subscriptionDialogOpen, setSubscriptionDialogOpen] = useState(false)
+    const { openDialog: openSubscriptionDialog, closeDialog: closeSubscriptionDialog } = useSubscriptionDialog()
     const pathname = usePathname()
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
     const flags = useFlags(['chatflow:use', 'chatflow:manage', 'org:manage'])
@@ -199,12 +196,8 @@ export const AppDrawer = ({ session, flagsmithState }: any) => {
     }
 
     const handleSubscriptionOpen = () => {
-        setSubscriptionDialogOpen(true)
+        openSubscriptionDialog()
         handleClose()
-    }
-
-    const handleSubscriptionClose = () => {
-        setSubscriptionDialogOpen(false)
     }
 
     return (
@@ -355,30 +348,33 @@ export const AppDrawer = ({ session, flagsmithState }: any) => {
                         </Box>
                     ))}
 
-                    {/* <ListItem disablePadding>
-                        <ListItemButton
-                            onClick={handleSubscriptionOpen}
-                            sx={{ bgcolor: 'primary.main', '&:hover': { bgcolor: 'primary.dark' }, borderRadius: 1, mb: 1 }}
-                        >
-                            <ListItemIcon>
-                                <StarIcon sx={{ color: '#fff' }} />
-                            </ListItemIcon>
-                            <Typography
-                                sx={{
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    textTransform: 'capitalize',
-                                    display: '-webkit-box',
-                                    WebkitBoxOrient: 'vertical',
-                                    WebkitLineClamp: '1',
-                                    flex: '1',
-                                    color: '#fff'
-                                }}
+
+                    {!user?.subscription && (
+                        <ListItem disablePadding>
+                            <ListItemButton
+                                onClick={handleSubscriptionOpen}
+                                sx={{ bgcolor: 'primary.main', '&:hover': { bgcolor: 'primary.dark' }, borderRadius: 1, mb: 1 }}
                             >
-                                Buy Credits
-                            </Typography>
-                        </ListItemButton>
-                    </ListItem> */}
+                                <ListItemIcon>
+                                    <StarIcon sx={{ color: '#fff' }} />
+                                </ListItemIcon>
+                                <Typography
+                                    sx={{
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        textTransform: 'capitalize',
+                                        display: '-webkit-box',
+                                        WebkitBoxOrient: 'vertical',
+                                        WebkitLineClamp: '1',
+                                        flex: '1',
+                                        color: '#fff'
+                                    }}
+                                >
+                                    Upgrade Plan
+                                </Typography>
+                            </ListItemButton>
+                        </ListItem>
+                    )}
 
                     <ListItem disablePadding sx={{ display: 'block' }}>
                         <Box
@@ -483,20 +479,6 @@ export const AppDrawer = ({ session, flagsmithState }: any) => {
                     </ListItem>
                 </List>
             </Drawer>
-            <Dialog
-                open={subscriptionDialogOpen}
-                onClose={handleSubscriptionClose}
-                fullWidth
-                maxWidth='md'
-                aria-labelledby='subscription-dialog-title'
-            >
-                <DialogTitle sx={{ fontSize: '1rem' }} id='subscription-dialog-title'>
-                    Upgrade your plan
-                </DialogTitle>
-                <DialogContent>
-                    <PurchaseSubscription />
-                </DialogContent>
-            </Dialog>
         </>
     )
 }

--- a/packages-answers/ui/src/AppLayout/AppLayout.Client.tsx
+++ b/packages-answers/ui/src/AppLayout/AppLayout.Client.tsx
@@ -18,6 +18,9 @@ const HelpChatProvider = dynamic(() => import('../HelpChatContext').then((mod) =
     ssr: false
 })
 const AppDrawer = dynamic(() => import('../AppDrawer'))
+const SubscriptionDialogProvider = dynamic(() => import('../SubscriptionDialogContext').then((mod) => mod.SubscriptionDialogProvider), {
+    ssr: false
+})
 
 import React from 'react'
 
@@ -64,20 +67,22 @@ export default function AppLayout({
                     <ThemeProvider theme={darkModeTheme}>
                         <CssBaseline enableColorScheme />
                         <GlobalStyles />
-                        <div style={{ display: 'flex', height: '100vh', width: '100vw', overflow: 'hidden', overflowY: 'auto' }}>
-                            {!noDrawer && <AppDrawer params={params} session={session} flagsmithState={flagsmithState} />}
-                            <div style={{ flex: 1, position: 'relative', overflow: 'auto' }}>
-                                <div style={{ width: '100%', position: 'relative' }}>{children}</div>
+                        <SubscriptionDialogProvider>
+                            <div style={{ display: 'flex', height: '100vh', width: '100vw', overflow: 'hidden', overflowY: 'auto' }}>
+                                {!noDrawer && <AppDrawer params={params} session={session} flagsmithState={flagsmithState} />}
+                                <div style={{ flex: 1, position: 'relative', overflow: 'auto' }}>
+                                    <div style={{ width: '100%', position: 'relative' }}>{children}</div>
+                                </div>
+                                <React.Suspense fallback={<div>Loading...</div>}>
+                                    <HelpChatProvider>
+                                        <HelpChatDrawer
+                                            apiHost='https://lr-production.studio.theanswer.ai'
+                                            chatflowid='e24d5572-a27a-40b9-83fe-19a376535b9d'
+                                        />
+                                    </HelpChatProvider>
+                                </React.Suspense>
                             </div>
-                            <React.Suspense fallback={<div>Loading...</div>}>
-                                <HelpChatProvider>
-                                    <HelpChatDrawer
-                                        apiHost='https://lr-production.studio.theanswer.ai'
-                                        chatflowid='e24d5572-a27a-40b9-83fe-19a376535b9d'
-                                    />
-                                </HelpChatProvider>
-                            </React.Suspense>
-                        </div>
+                        </SubscriptionDialogProvider>
                     </ThemeProvider>
                     {/* </Auth0Provider> */}
                 </FlagsmithProvider>

--- a/packages-answers/ui/src/ChatRoom.tsx
+++ b/packages-answers/ui/src/ChatRoom.tsx
@@ -4,6 +4,7 @@ import type { Message, Sidekick } from 'types'
 import ChatFeedbackContentDialog from './../../../packages/ui/src/ui-component/dialog/ChatFeedbackContentDialog'
 import { useAnswers } from './AnswersContext'
 import RefreshIcon from '@mui/icons-material/Refresh'
+import { useSubscriptionDialog } from './SubscriptionDialogContext'
 
 import dynamic from 'next/dynamic'
 
@@ -37,6 +38,7 @@ export const ChatRoom: React.FC<ChatRoomProps> = ({
 }) => {
     const openLinksInNewTab = chatbotConfig?.chatLinksInNewTab?.status ?? false
     const { showFeedbackContentDialog, setShowFeedbackContentDialog, feedbackId, submitFeedbackContent } = useAnswers()
+    const { openDialog: openSubscriptionDialog } = useSubscriptionDialog()
 
     return (
         <Box
@@ -71,11 +73,16 @@ export const ChatRoom: React.FC<ChatRoomProps> = ({
 
                 {error ? (
                     <>
-                        <MessageCard id='error' role='status' content={`${error.message} `} error={error} />
-                        <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+                        <MessageCard id='error' role='status' content={`${typeof error === 'string' ? error : error.message} `} error={error} />
+                        <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', gap: 1 }}>
                             <Button onClick={regenerateAnswer} variant='contained' color='primary' sx={{ margin: 'auto' }}>
                                 Retry
                             </Button>
+                            {typeof error === 'string' && error.toLowerCase().includes('usage limit') && (
+                                <Button onClick={openSubscriptionDialog} variant='contained' color='secondary' sx={{ margin: 'auto' }}>
+                                    Upgrade Plan
+                                </Button>
+                            )}
                         </Box>
                     </>
                 ) : null}

--- a/packages-answers/ui/src/SubscriptionDialogContext.tsx
+++ b/packages-answers/ui/src/SubscriptionDialogContext.tsx
@@ -1,0 +1,50 @@
+'use client'
+import React, { createContext, useContext, useState } from 'react'
+import dynamic from 'next/dynamic'
+
+const PurchaseSubscription = dynamic(() => import('./billing/PurchaseSubscription'), { ssr: false })
+const Dialog = dynamic(() => import('@mui/material/Dialog'), { ssr: false })
+const DialogContent = dynamic(() => import('@mui/material/DialogContent'), { ssr: false })
+const DialogTitle = dynamic(() => import('@mui/material/DialogTitle'), { ssr: false })
+
+interface SubscriptionDialogContextType {
+    open: boolean
+    openDialog: () => void
+    closeDialog: () => void
+}
+
+const SubscriptionDialogContext = createContext<SubscriptionDialogContextType>({
+    open: false,
+    openDialog: () => {},
+    closeDialog: () => {}
+})
+
+export const useSubscriptionDialog = () => useContext(SubscriptionDialogContext)
+
+export const SubscriptionDialogProvider = ({ children }: { children: React.ReactNode }) => {
+    const [open, setOpen] = useState(false)
+
+    const openDialog = () => setOpen(true)
+    const closeDialog = () => setOpen(false)
+
+    return (
+        <SubscriptionDialogContext.Provider value={{ open, openDialog, closeDialog }}>
+            {children}
+            <Dialog
+                open={open}
+                onClose={closeDialog}
+                fullWidth
+                maxWidth='md'
+                aria-labelledby='subscription-dialog-title'
+            >
+                <DialogTitle sx={{ fontSize: '1rem' }} id='subscription-dialog-title'>
+                    Upgrade your plan
+                </DialogTitle>
+                <DialogContent>
+                    <PurchaseSubscription />
+                </DialogContent>
+            </Dialog>
+        </SubscriptionDialogContext.Provider>
+    )
+}
+

--- a/packages-answers/ui/src/billing/BillingDashboard.tsx
+++ b/packages-answers/ui/src/billing/BillingDashboard.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import React from 'react'
-import { Box, Stack, Typography, CircularProgress } from '@mui/material'
+import { Box, Stack, Typography, CircularProgress, Button } from '@mui/material'
 import TotalCreditsProgress from './TotalCreditsProgress'
 import { useBillingData } from './hooks/useBillingData'
 import BillingOverview from './BillingOverview'
+import { useSubscriptionDialog } from '../SubscriptionDialogContext'
 
 const BillingDashboard: React.FC = () => {
     const { billingData, isLoading, isError } = useBillingData()
+    const { openDialog } = useSubscriptionDialog()
 
     // Calculate usage percentage
     const calculateUsagePercentage = () => {
@@ -50,6 +52,9 @@ const BillingDashboard: React.FC = () => {
                     <Typography sx={{ color: 'rgba(255, 255, 255, 0.5)', fontSize: '0.875rem' }}>
                         Manage your subscription and monitor your usage
                     </Typography>
+                    <Button onClick={openDialog} variant='contained' sx={{ mt: 2 }}>
+                        Upgrade Plan
+                    </Button>
                 </Box>
 
                 <TotalCreditsProgress usageSummary={billingData} isLoading={isLoading} isError={isError} />

--- a/packages-answers/ui/src/billing/BillingDashboard.tsx
+++ b/packages-answers/ui/src/billing/BillingDashboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Box, Stack, Typography, CircularProgress, Button } from '@mui/material'
+import { Box, Stack, Typography, CircularProgress } from '@mui/material'
 import TotalCreditsProgress from './TotalCreditsProgress'
 import { useBillingData } from './hooks/useBillingData'
 import BillingOverview from './BillingOverview'
@@ -52,9 +52,6 @@ const BillingDashboard: React.FC = () => {
                     <Typography sx={{ color: 'rgba(255, 255, 255, 0.5)', fontSize: '0.875rem' }}>
                         Manage your subscription and monitor your usage
                     </Typography>
-                    <Button onClick={openDialog} variant='contained' sx={{ mt: 2 }}>
-                        Upgrade Plan
-                    </Button>
                 </Box>
 
                 <TotalCreditsProgress usageSummary={billingData} isLoading={isLoading} isError={isError} />

--- a/packages-answers/ui/src/billing/BillingOverview.tsx
+++ b/packages-answers/ui/src/billing/BillingOverview.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import React, { useState } from 'react'
+import React from 'react'
 import { Box, Card, Typography, Button, Chip, Grid, Stack, Divider, useTheme, Alert, AlertTitle } from '@mui/material'
 import WarningIcon from '@mui/icons-material/Warning'
-import billingApi from '@/api/billing'
+import { useSubscriptionDialog } from '../SubscriptionDialogContext'
 
 // Define BillingPlan interface here since we can't find the module
 type PricingTierName = 'Free' | 'Plus' | 'Pro' | 'Plus+Overage'
@@ -39,7 +39,7 @@ const BillingOverview: React.FC<BillingOverviewProps> = ({
     usagePercentage = 0
 }) => {
     const theme = useTheme()
-    const [loading, setLoading] = useState(false)
+    const { openDialog } = useSubscriptionDialog()
 
     // Determine if we should show a warning (for free accounts at 80% or more usage)
     const showWarning = usagePercentage >= 80 && (!currentPlan || currentPlan?.name === 'Free')
@@ -54,22 +54,9 @@ const BillingOverview: React.FC<BillingOverviewProps> = ({
         }
     }
 
-    // Handle direct checkout instead of opening dialog
-    const handleUpgrade = async () => {
-        setLoading(true)
-        try {
-            const response = await billingApi.createSubscription({
-                priceId: 'price_1QdEegFeRAHyP6by6yTOvbwj' // Plus tier price ID
-            })
-
-            if (response.data?.url) {
-                window.location.assign(response.data.url)
-            }
-        } catch (error) {
-            console.error('Failed to initiate subscription:', error)
-        } finally {
-            setLoading(false)
-        }
+    // Open subscription dialog instead of redirecting directly
+    const handleUpgrade = () => {
+        openDialog()
     }
 
     return (
@@ -99,7 +86,6 @@ const BillingOverview: React.FC<BillingOverviewProps> = ({
                     <Button
                         variant='contained'
                         onClick={handleUpgrade}
-                        disabled={loading}
                         sx={{
                             bgcolor: theme.palette.warning.main,
                             '&:hover': {
@@ -128,7 +114,6 @@ const BillingOverview: React.FC<BillingOverviewProps> = ({
                     </Typography>
                     {/* <Button
                         onClick={handleUpgrade}
-                        disabled={loading}
                         variant='outlined'
                         sx={{
                             borderColor: 'rgba(255, 255, 255, 0.1)',


### PR DESCRIPTION
## Summary
- implement `SubscriptionDialogContext` for centralized purchase modal
- use provider in app layout
- open the modal from chat usage errors
- add upgrade button in billing dashboard
- use the modal for upgrade actions
- show persistent upgrade button in the app drawer

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*