### PR TITLE
Fix Default State for Chat Feedback Visibility Based on Config

### DIFF
--- a/packages/ui/src/ui-component/extended/ChatFeedback.jsx
+++ b/packages/ui/src/ui-component/extended/ChatFeedback.jsx
@@ -25,7 +25,7 @@ const ChatFeedback = ({ dialogProps }) => {
     const enqueueSnackbar = (...args) => dispatch(enqueueSnackbarAction(...args))
     const closeSnackbar = (...args) => dispatch(closeSnackbarAction(...args))
 
-    const [chatFeedbackStatus, setChatFeedbackStatus] = useState(false)
+    const [chatFeedbackStatus, setChatFeedbackStatus] = useState(true)
     const [chatbotConfig, setChatbotConfig] = useState({})
 
     const handleChange = (value) => {
@@ -88,9 +88,10 @@ const ChatFeedback = ({ dialogProps }) => {
         if (dialogProps.chatflow && dialogProps.chatflow.chatbotConfig) {
             let chatbotConfig = JSON.parse(dialogProps.chatflow.chatbotConfig)
             setChatbotConfig(chatbotConfig || {})
-            if (chatbotConfig.chatFeedback) {
+            if (chatbotConfig.chatFeedback && chatbotConfig.chatFeedback.status !== undefined) {
                 setChatFeedbackStatus(chatbotConfig.chatFeedback.status)
             }
+            // If chatFeedback is not defined or status is not set, keep the default (true)
         }
 
         return () => {}

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -203,7 +203,7 @@ export const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, preview
     const [fullFileUpload, setFullFileUpload] = useState(false)
 
     // feedback
-    const [chatFeedbackStatus, setChatFeedbackStatus] = useState(false)
+    const [chatFeedbackStatus, setChatFeedbackStatus] = useState(true)
     const [feedbackId, setFeedbackId] = useState('')
     const [showFeedbackContentDialog, setShowFeedbackContentDialog] = useState(false)
 
@@ -1096,9 +1096,10 @@ export const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, preview
                     })
                     setStarterPrompts(inputFields.filter((field) => field.prompt !== ''))
                 }
-                if (config.chatFeedback) {
+                if (config.chatFeedback && config.chatFeedback.status !== undefined) {
                     setChatFeedbackStatus(config.chatFeedback.status)
                 }
+                // If chatFeedback is not defined or status is not set, keep the default (true)
 
                 if (config.leads) {
                     setLeadsConfig(config.leads)


### PR DESCRIPTION
## PR Title

Fix Default State for Chat Feedback Visibility Based on Config

## Summary

This PR addresses an inconsistency in the default state of the **chat feedback** feature when its configuration is either missing or incomplete. Previously, `chatFeedbackStatus` was defaulting to `false`, which could unintentionally disable feedback UI elements.

## Changes

### ✅ Logic Adjustments
- Sets `chatFeedbackStatus` default to `true` in both:
  - `ChatFeedback.jsx`
  - `ChatMessage.jsx`
- Adds explicit `status !== undefined` check when parsing `chatbotConfig.chatFeedback`:
  - Prevents false negatives if `chatFeedback` exists but does not define `status`
  - Preserves the default `true` fallback if `status` is absent

### 🧠 Behavioral Impact
- Ensures **feedback components are enabled by default** unless explicitly disabled in config
- Supports future extensibility if additional flags are added to `chatFeedback`

## Testing

- [ ] Verify that feedback UI appears for chats without `chatFeedback` config
- [ ] Confirm disabling feedback via `chatbotConfig.chatFeedback.status: false` hides it
- [ ] Check no crashes occur if `chatbotConfig.chatFeedback` is `null` or malformed
- [ ] Confirm feedback dialog works in both `ChatFeedback` and `ChatMessage` views

