### PR TITLE
Add AnalyzerApp scaffolding

### DIFF
--- a/packages-answers/db/prisma/schema.prisma
+++ b/packages-answers/db/prisma/schema.prisma
@@ -6,6 +6,8 @@ generator client {
   output               = "../generated/prisma-client"
   referentialIntegrity = "prisma"
 }
+
+
 generator json {
   provider = "prisma-json-types-generator"
   // namespace = "PrismaJson"
@@ -521,4 +523,17 @@ model AppCsvParseRows {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
   csvParseRun AppCsvParseRuns @relation(fields: [csvParseRunId], references: [id])
+}
+model ResearchView {
+  id                 String   @id @default(uuid())
+  orgId              String   @map("org_id")
+  userId             String?  @map("user_id")
+  name               String
+  description        String?
+  answeraiChatflowId String?  @map("answerai_chatflow_id")
+  answeraiStoreId    String?  @map("answerai_store_id")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@map("research_views")
 }

--- a/packages-answers/server/package.json
+++ b/packages-answers/server/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "server-answers",
+    "version": "0.0.0",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "express": "^4.18.2"
+    },
+    "devDependencies": {
+        "tsconfig": "workspace:*",
+        "typescript": "^5.4.5"
+    }
+}

--- a/packages-answers/server/src/controllers/analyzerController.ts
+++ b/packages-answers/server/src/controllers/analyzerController.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express'
+import analyzerService from '../services/analyzerService'
+
+export const getResearchViews = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const views = await analyzerService.getResearchViews()
+        res.json({ data: views })
+    } catch (error) {
+        next(error)
+    }
+}
+
+export default {
+    getResearchViews
+}

--- a/packages-answers/server/src/index.ts
+++ b/packages-answers/server/src/index.ts
@@ -1,0 +1,3 @@
+export { default as analyzerController } from './controllers/analyzerController'
+export { default as analyzerService } from './services/analyzerService'
+export { default as analyzerRoutes } from './routes/analyzerRoutes'

--- a/packages-answers/server/src/routes/analyzerRoutes.ts
+++ b/packages-answers/server/src/routes/analyzerRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express'
+import analyzerController from '../controllers/analyzerController'
+
+const router = express.Router()
+
+router.get('/research-views', analyzerController.getResearchViews)
+
+export default router

--- a/packages-answers/server/src/services/analyzerService.ts
+++ b/packages-answers/server/src/services/analyzerService.ts
@@ -1,0 +1,8 @@
+export const getResearchViews = async () => {
+    // TODO: connect to database
+    return []
+}
+
+export default {
+    getResearchViews
+}

--- a/packages-answers/server/tsconfig.json
+++ b/packages-answers/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "lib": ["es2021"],
+        "outDir": "./dist",
+        "isolatedModules": false,
+        "paths": {
+            "@utils/*": ["../utils/src/*"],
+            "@db/*": ["../db/src/*"],
+            "@types/*": ["../types/src/*"]
+        }
+    },
+    "include": ["src"],
+    "extends": "../tsconfig/node.json",
+    "types": ["node"]
+}

--- a/packages-answers/types/src/index.ts
+++ b/packages-answers/types/src/index.ts
@@ -7,6 +7,8 @@ export interface Document extends DB.Document {
     pageContent: string
     metadata: any
 }
+
+export interface ResearchView extends DB.ResearchView {}
 export interface Sidekick extends DB.Sidekick {
     constraints: {
         isSpeechToTextEnabled: boolean

--- a/packages-answers/ui/src/AnalyzerApp/AnalyzerApp.Client.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/AnalyzerApp.Client.tsx
@@ -1,0 +1,24 @@
+'use client'
+import ResearchViewList from './components/ResearchViewList'
+import ResearchViewDetail from './components/ResearchViewDetail'
+import { User } from 'types'
+
+export interface AnalyzerAppProps {
+    user: User
+    accessToken?: string
+    viewId?: string
+}
+
+const AnalyzerApp = ({ user, accessToken, viewId }: AnalyzerAppProps) => {
+    return (
+        <div>
+            {viewId ? (
+                <ResearchViewDetail user={user} accessToken={accessToken} viewId={viewId} />
+            ) : (
+                <ResearchViewList user={user} accessToken={accessToken} />
+            )}
+        </div>
+    )
+}
+
+export default AnalyzerApp

--- a/packages-answers/ui/src/AnalyzerApp/AnalyzerApp.Server.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/AnalyzerApp.Server.tsx
@@ -1,0 +1,8 @@
+import getCachedSession from '../getCachedSession'
+import AnalyzerAppClient from './AnalyzerApp.Client'
+
+export default async function AnalyzerApp() {
+    const session = await getCachedSession()
+    if (!session?.user?.email) return null
+    return <AnalyzerAppClient user={session.user} accessToken={session.accessToken} />
+}

--- a/packages-answers/ui/src/AnalyzerApp/components/DeleteConfirmDialog.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/DeleteConfirmDialog.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { Dialog, DialogTitle, DialogActions, Button } from '@mui/material'
+
+interface Props {
+    open: boolean
+    onClose: (confirm: boolean) => void
+}
+
+const DeleteConfirmDialog = ({ open, onClose }: Props) => (
+    <Dialog open={open} onClose={() => onClose(false)}>
+        <DialogTitle>Are you sure?</DialogTitle>
+        <DialogActions>
+            <Button onClick={() => onClose(false)}>Cancel</Button>
+            <Button onClick={() => onClose(true)} color='error'>
+                Delete
+            </Button>
+        </DialogActions>
+    </Dialog>
+)
+
+export default DeleteConfirmDialog

--- a/packages-answers/ui/src/AnalyzerApp/components/ResearchViewCard.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/ResearchViewCard.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { Card, CardContent, Typography } from '@mui/material'
+
+interface Props {
+    name: string
+    description?: string
+}
+
+const ResearchViewCard = ({ name, description }: Props) => {
+    return (
+        <Card variant='outlined'>
+            <CardContent>
+                <Typography variant='h6'>{name}</Typography>
+                <Typography variant='body2'>{description}</Typography>
+            </CardContent>
+        </Card>
+    )
+}
+
+export default ResearchViewCard

--- a/packages-answers/ui/src/AnalyzerApp/components/ResearchViewDetail.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/ResearchViewDetail.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { Typography } from '@mui/material'
+import { User } from 'types'
+
+export interface ResearchViewDetailProps {
+    user: User
+    accessToken?: string
+    viewId: string
+}
+
+const ResearchViewDetail = ({ viewId }: ResearchViewDetailProps) => {
+    return <Typography>Research View Detail for {viewId}</Typography>
+}
+
+export default ResearchViewDetail

--- a/packages-answers/ui/src/AnalyzerApp/components/ResearchViewDialog.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/ResearchViewDialog.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { Dialog, DialogTitle } from '@mui/material'
+
+interface Props {
+    open: boolean
+    onClose: () => void
+}
+
+const ResearchViewDialog = ({ open, onClose }: Props) => {
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle>Research View</DialogTitle>
+        </Dialog>
+    )
+}
+
+export default ResearchViewDialog

--- a/packages-answers/ui/src/AnalyzerApp/components/ResearchViewList.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/ResearchViewList.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { Typography } from '@mui/material'
+import { User } from 'types'
+
+export interface ResearchViewListProps {
+    user: User
+    accessToken?: string
+}
+
+const ResearchViewList = ({ user }: ResearchViewListProps) => {
+    return <Typography>Research View List placeholder</Typography>
+}
+
+export default ResearchViewList

--- a/packages-answers/ui/src/AnalyzerApp/components/panels/AnalysisPanel.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/panels/AnalysisPanel.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { Typography } from '@mui/material'
+import { User } from 'types'
+
+interface Props {
+    researchViewId: string
+    user: User
+    accessToken?: string
+}
+
+const AnalysisPanel = ({ researchViewId }: Props) => {
+    return <Typography>Analysis for {researchViewId}</Typography>
+}
+
+export default AnalysisPanel

--- a/packages-answers/ui/src/AnalyzerApp/components/panels/DataSourcesPanel.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/panels/DataSourcesPanel.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { Typography } from '@mui/material'
+import { User } from 'types'
+
+interface Props {
+    researchViewId: string
+    user: User
+    accessToken?: string
+}
+
+const DataSourcesPanel = ({ researchViewId }: Props) => {
+    return <Typography>Data Sources for {researchViewId}</Typography>
+}
+
+export default DataSourcesPanel

--- a/packages-answers/ui/src/AnalyzerApp/components/panels/FilesTabPanel.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/panels/FilesTabPanel.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { Typography } from '@mui/material'
+import { User } from 'types'
+
+interface Props {
+    researchViewId: string
+    user: User
+    accessToken?: string
+}
+
+const FilesTabPanel = ({ researchViewId }: Props) => {
+    return <Typography>Files for {researchViewId}</Typography>
+}
+
+export default FilesTabPanel

--- a/packages-answers/ui/src/AnalyzerApp/components/panels/ReportsPanel.tsx
+++ b/packages-answers/ui/src/AnalyzerApp/components/panels/ReportsPanel.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { Typography } from '@mui/material'
+import { User } from 'types'
+
+interface Props {
+    researchViewId: string
+    user: User
+    accessToken?: string
+}
+
+const ReportsPanel = ({ researchViewId }: Props) => {
+    return <Typography>Reports for {researchViewId}</Typography>
+}
+
+export default ReportsPanel

--- a/packages-answers/ui/src/AnalyzerApp/index.ts
+++ b/packages-answers/ui/src/AnalyzerApp/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AnalyzerApp.Server'

--- a/packages-answers/ui/src/AnalyzerApp/types.ts
+++ b/packages-answers/ui/src/AnalyzerApp/types.ts
@@ -1,0 +1,9 @@
+import { ResearchView } from 'types'
+
+export interface AnalyzerAppProps {
+    user: any
+    accessToken?: string
+    viewId?: string
+}
+
+export type { ResearchView }


### PR DESCRIPTION
## Summary
- scaffold AnalyzerApp UI with placeholder components
- add basic server package and analyzer controller/service/routes
- define ResearchView model in Prisma schema
- expose ResearchView type in shared types

## Testing
- `pnpm lint` *(fails: 51 errors and 2195 warnings)*