### PR TITLE
Fixes AAI-413: Clone Sidekick from Chats Page Redirects Incorrectly Due to Click Event Conflict

### DIFF
--- a/packages-answers/ui/src/SidekickSelect/SidekickCard.tsx
+++ b/packages-answers/ui/src/SidekickSelect/SidekickCard.tsx
@@ -45,8 +45,8 @@ const SidekickCard = ({
     const theme = useTheme()
     const handleClone = useCallback(
         (sidekick: Sidekick, e: React.MouseEvent) => {
+            e.preventDefault()
             e.stopPropagation()
-
             if (!sidekick) return
 
             const isAgentCanvas = (sidekick.flowData?.nodes || []).some(
@@ -209,13 +209,28 @@ const SidekickCard = ({
                         ) : null}
                         {sidekick.isExecutable ? (
                             <Tooltip title='Clone this sidekick'>
-                                <WhiteIconButton size='small' onClick={(e) => handleClone(sidekick, e)}>
+                                <WhiteIconButton 
+                                    size='small' 
+                                    onClick={(e) => {
+                                        e.preventDefault()
+                                        e.stopPropagation()
+                                        handleClone(sidekick, e)
+                                    }}
+                                >
                                     <IconCopy />
                                 </WhiteIconButton>
                             </Tooltip>
                         ) : (
                             <Tooltip title='Clone this sidekick'>
-                                <WhiteButton variant='outlined' endIcon={<IconCopy />} onClick={(e) => handleClone(sidekick, e)}>
+                                <WhiteButton 
+                                    variant='outlined' 
+                                    endIcon={<IconCopy />} 
+                                    onClick={(e) => {
+                                        e.preventDefault()
+                                        e.stopPropagation()
+                                        handleClone(sidekick, e)
+                                    }}
+                                >
                                     Clone
                                 </WhiteButton>
                             </Tooltip>


### PR DESCRIPTION
## Description
Fixes AAI-413: Clone Sidekick from Chats Page Redirects Incorrectly Due to Click Event Conflict

## Changes Made
- Added explicit event prevention in clone button click handlers
- Ensured proper event propagation stopping for both icon and regular button variants
- Maintained existing event prevention in handleClone function as a safeguard

## Root Cause
The issue was caused by event propagation conflicts between the clone button click event and the card's click event. The clone button's click event was bubbling up to the card, causing both events to fire and resulting in incorrect navigation.

## Testing
1. Navigate to the Chats page
2. Locate a sidekick to clone
3. Click the clone button
4. Verify that it redirects directly to the canvas page without any intermediate redirects

## Related Issues
- Fixes AAI-413
