### PR TITLE
fix: AAI-352 Fix document store loader deletion by using correct file…

### DIFF
--- a/packages/ui/src/views/docstore/DocumentStoreDetail.jsx
+++ b/packages/ui/src/views/docstore/DocumentStoreDetail.jsx
@@ -236,7 +236,7 @@ const DocumentStoreDetails = () => {
             }
         } else if (type === 'LOADER') {
             try {
-                const deleteResp = await documentsApi.deleteLoaderFromStore(storeId, loaderId)
+                const deleteResp = await documentsApi.deleteLoaderFromStore(storeId, file.id)
                 setBackdropLoading(false)
                 if (deleteResp.data) {
                     enqueueSnackbar({


### PR DESCRIPTION
## Description
Fixed an issue where document store loader deletion was failing due to incorrect parameter usage. The code was using `loaderId` instead of `file.id` in the delete operation.

## Changes
- Updated `deleteLoaderFromStore` call to use `file.id` instead of `loaderId`

## Related Links
- Jira Ticket: [AAI-352](https://lastrev.atlassian.net/jira/software/c/projects/AAI/list?filter=assignee%20%3D%20%22712020%3A99355c3b-d30d-46fe-816c-2aa5bd816c9b%22&selectedIssue=AAI-352)
- Demo Video: [Loom Video](https://www.loom.com/share/a400caea51ff4ff7b7230150f6161e18?sid=40e44242-6ae4-4158-a3d7-ab228f2e1c62)

## Testing
- Verified document store loader deletion works correctly
- Tested both single and multiple loader deletion scenarios

[AAI-352]: https://lastrev.atlassian.net/browse/AAI-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ