### PR TITLE
aai-362: remove AnswerAI and Marketplace visibility options

### DIFF
--- a/packages/ui/src/ui-component/extended/VisibilitySettings.jsx
+++ b/packages/ui/src/ui-component/extended/VisibilitySettings.jsx
@@ -21,8 +21,6 @@ import { TooltipWithParser } from '../tooltip/TooltipWithParser'
 const visibilityOptions = [
     { name: 'Private', description: 'Only visible to you' },
     { name: 'Organization', description: 'Visible to all members of your organization' },
-    // { name: 'AnswerAI', description: 'Visible to AnswerAI users' },
-    // { name: 'Marketplace', description: 'Available in the public marketplace' },
     { name: 'Browser Extension', description: 'Accessible via browser extension' }
 ]
 

--- a/packages/ui/src/ui-component/extended/VisibilitySettings.jsx
+++ b/packages/ui/src/ui-component/extended/VisibilitySettings.jsx
@@ -21,8 +21,8 @@ import { TooltipWithParser } from '../tooltip/TooltipWithParser'
 const visibilityOptions = [
     { name: 'Private', description: 'Only visible to you' },
     { name: 'Organization', description: 'Visible to all members of your organization' },
-    { name: 'AnswerAI', description: 'Visible to AnswerAI users' },
-    { name: 'Marketplace', description: 'Available in the public marketplace' },
+    // { name: 'AnswerAI', description: 'Visible to AnswerAI users' },
+    // { name: 'Marketplace', description: 'Available in the public marketplace' },
     { name: 'Browser Extension', description: 'Accessible via browser extension' }
 ]
 


### PR DESCRIPTION
# Remove Answer AI and Marketplace from visibility options (AAI-362)

## Changes
- Remove Answer AI and Marketplace from visibility options 

## Screenshots
![image](https://github.com/user-attachments/assets/5ea97d1f-cac5-48f3-afe1-81b74c10ddbd)


## Related
[- Closes AAI-362](https://lastrev.atlassian.net/browse/AAI-362?atlOrigin=eyJpIjoiOWJmNzc5ZjY3MGJlNGYwOGFmNjAyMmYzMTYzMWU2N2EiLCJwIjoiaiJ9)
















