### PR TITLE
Improve sidekick API error handling

### DIFF
--- a/apps/web/app/api/sidekicks/[id]/route.ts
+++ b/apps/web/app/api/sidekicks/[id]/route.ts
@@ -30,6 +30,9 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
         return NextResponse.json(sidekickWithCloneInfo)
     } catch (error) {
         console.error('Error fetching sidekick details:', error)
-        return respond401()
+        if (error instanceof Error && error.message === 'Unauthorized') {
+            return respond401()
+        }
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
     }
 }

--- a/apps/web/app/api/sidekicks/route.ts
+++ b/apps/web/app/api/sidekicks/route.ts
@@ -27,6 +27,10 @@ export async function GET(req: Request) {
         // console.log({ sidekicks: sidekicksWithCloneInfo })
         return NextResponse.json({ ...data, sidekicks: sidekicksWithCloneInfo })
     } catch (error) {
-        return respond401()
+        if (error instanceof Error && error.message === 'Unauthorized') {
+            return respond401()
+        }
+        console.error('Error fetching sidekicks:', error)
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
     }
 }

--- a/packages-answers/ui/src/SidekickSelect/hooks/useSidekickSelectionHandlers.ts
+++ b/packages-answers/ui/src/SidekickSelect/hooks/useSidekickSelectionHandlers.ts
@@ -2,10 +2,13 @@
 import { useState, useCallback } from 'react'
 import { Sidekick } from '../SidekickSelect.types'
 import { useAnswers } from '../../AnswersContext'
+import { Chat, SidekickListItem } from 'types'
+
+type NavigateFn = (url: string | number, options?: { state?: any; replace?: boolean }) => void
 
 interface UseSidekickSelectionHandlersProps {
-    chat?: any
-    navigate: any
+    chat?: Chat
+    navigate: NavigateFn
 }
 
 interface UseSidekickSelectionHandlersResult {
@@ -38,11 +41,11 @@ const useSidekickSelectionHandlers = ({ chat, navigate }: UseSidekickSelectionHa
                 window.history.pushState({ sidekick, isClientNavigation: true }, '', newUrl)
 
                 // Directly initialize the chat with the sidekick data
-                setSelectedSidekick(sidekick as any)
-                setSidekick(sidekick as any)
+                setSelectedSidekick(sidekick as unknown as SidekickListItem)
+                setSidekick(sidekick as unknown as SidekickListItem)
             } else {
-                setSelectedSidekick(sidekick as any)
-                setSidekick(sidekick as any)
+                setSelectedSidekick(sidekick as unknown as SidekickListItem)
+                setSidekick(sidekick as unknown as SidekickListItem)
                 const sidekickHistory = JSON.parse(localStorage.getItem('sidekickHistory') || '{}')
                 sidekickHistory.lastUsed = sidekick
                 localStorage.setItem('sidekickHistory', JSON.stringify(sidekickHistory))

--- a/packages-answers/utils/src/findSidekicksForChat.ts
+++ b/packages-answers/utils/src/findSidekicksForChat.ts
@@ -204,6 +204,7 @@ export async function findSidekicksForChat(user: User, options: FindSidekicksOpt
         }
     } catch (err) {
         console.error('Error fetching chatflows:', err)
+        throw err
     }
 }
 


### PR DESCRIPTION
## Summary
- refine error handling for `api/sidekicks` routes
- throw errors from `findSidekicksForChat`
- restore typed navigation in `useSidekickSelectionHandlers`

## Testing
- `npx prettier --write apps/web/app/api/sidekicks/[id]/route.ts apps/web/app/api/sidekicks/route.ts packages-answers/utils/src/findSidekicksForChat.ts packages-answers/ui/src/SidekickSelect/hooks/useSidekickSelectionHandlers.ts`

------
https://chatgpt.com/codex/tasks/task_b_685e0a811b3c8331ab1333eaa2ee199c