### PR TITLE
fix: restrict browser extension chatflows to user's own chatflows

### DIFF
--- a/packages/server/src/services/browser-extension/index.ts
+++ b/packages/server/src/services/browser-extension/index.ts
@@ -31,15 +31,7 @@ const getBrowserExtensionChatflows = async (user: IUser): Promise<ChatFlow[]> =>
         // 1. Belong to the user or their organization
         // 2. Have 'Browser Extension' in their visibility settings
         // 3. Are public (isPublic must be true)
-        const queryBuilder = chatFlowRepository.createQueryBuilder('chatflow').where('chatflow.isPublic = true')
-
-        // If user is an org admin, show all org chatflows with Browser Extension visibility
-        if (user.permissions?.includes('org:manage')) {
-            queryBuilder.andWhere('chatflow.organizationId = :organizationId', { organizationId: user.organizationId })
-        } else {
-            // Otherwise only show user's own chatflows
-            queryBuilder.andWhere('chatflow.userId = :userId', { userId: user.id })
-        }
+        const queryBuilder = chatFlowRepository.createQueryBuilder('chatflow').where('chatflow.userId = :userId', { userId: user.id })
 
         // Return the complete chatflow objects with all fields
         const dbResponse = await queryBuilder.getMany()

--- a/packages/server/src/services/browser-extension/index.ts
+++ b/packages/server/src/services/browser-extension/index.ts
@@ -29,8 +29,6 @@ const getBrowserExtensionChatflows = async (user: IUser): Promise<ChatFlow[]> =>
 
         // Query chatflows that:
         // 1. Belong to the user or their organization
-        // 2. Have 'Browser Extension' in their visibility settings
-        // 3. Are public (isPublic must be true)
         const queryBuilder = chatFlowRepository.createQueryBuilder('chatflow').where('chatflow.userId = :userId', { userId: user.id })
 
         // Return the complete chatflow objects with all fields


### PR DESCRIPTION
Browser Extension endpoint will only return chatflows owder by the user.    Will return non-public chatflows for that user as well