### PR TITLE
fix: update chatflows view to use next/navigation for search parameters

### DIFF
--- a/packages/ui/src/views/chatflows/index.jsx
+++ b/packages/ui/src/views/chatflows/index.jsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from '@/utils/navigation'
+import { useSearchParams } from 'next/navigation'
 
 // material-ui
 import { Box, Skeleton, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material'
@@ -35,11 +36,12 @@ import { IconPlus, IconLayoutGrid, IconList } from '@tabler/icons-react'
 const Chatflows = () => {
     const navigate = useNavigate()
     const theme = useTheme()
+    const searchParams = useSearchParams()
 
     const [isLoading, setLoading] = useState(true)
     const [error, setError] = useState(null)
     const [images, setImages] = useState({})
-    const [search, setSearch] = useState('')
+    const [search, setSearch] = useState(searchParams?.get('search') || '')
     const [loginDialogOpen, setLoginDialogOpen] = useState(false)
     const [loginDialogProps, setLoginDialogProps] = useState({})
 


### PR DESCRIPTION
# Add URL search parameter support to Chatflows component

## Summary
Updated the Chatflows component to read the "search" query parameter from the URL and pre-populate the search input field.

## Changes Made

### Updated Imports
- Changed `useNavigate` import from `react-router-dom` to `@/utils/navigation` to use Next.js App Router
- Added `useSearchParams` import from `next/navigation` for URL parameter access

### Modified Search State Initialization
- Updated search state initialization to read from URL query parameter: `useState(searchParams?.get('search') || '')`
- Fixed searchParams usage to work with Next.js App Router API

## Technical Details
- **Before**: Search state was always initialized as empty string
- **After**: Search state is initialized with the "search" query parameter value if present in URL
- **Fallback**: Empty string if no "search" parameter exists

## Usage
Users can now navigate to `/chatflows?search=mysearchterm` and the search input will be pre-populated with "mysearchterm", with results filtered accordingly.

## Files Changed
- `packages/ui/src/views/chatflows/index.jsx`

## Testing
- ✅ Component loads without errors
- ✅ Search parameter is read from URL on page load
- ✅ Search functionality continues to work for user input
- ✅ Fallback to empty string when no search parameter present