### PR TITLE
AAI-427 - chore(render): Update to use S3 storage and disable secret sync – 2025.07.07

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -86,11 +86,11 @@ services:
           - key: FLOWISE_SECRETKEY_OVERWRITE
             sync: false
           - key: SECRETKEY_PATH
-            value: '/var/data'
+            sync: false
           - key: APIKEY_STORAGE_TYPE
             value: 'db'
           - key: APIKEY_PATH
-            value: '/var/data'
+            sync: false
 
           # =========================================
           # CORS & Iframe Settings
@@ -113,9 +113,19 @@ services:
           # Storage Configuration
           # =========================================
           - key: STORAGE_TYPE
-            value: db
-          - key: BLOB_STORAGE_PATH
-            value: '/var/data'
+            value: s3
+          - key: S3_STORAGE_BUCKET_NAME
+            sync: false
+          - key: S3_STORAGE_ACCESS_KEY_ID
+            sync: false
+          - key: S3_STORAGE_SECRET_ACCESS_KEY
+            sync: false
+          - key: S3_STORAGE_REGION
+            sync: false
+          - key: S3_ENDPOINT_URL
+            sync: false
+          - key: S3_FORCE_PATH_STYLE
+            sync: false
 
           # =========================================
           # Langfuse Tracing
@@ -157,10 +167,6 @@ services:
       dockerfilePath: ./Dockerfile
       # domains:
       #     - prod.studio.theanswer.ai
-      disk:
-          name: disk
-          mountPath: /var/data
-          sizeGB: 5
     - type: web
       name: theanswer-web
       runtime: docker


### PR DESCRIPTION
## PR Title
chore(render): Update to use S3 storage and disable secret sync – 2025.07.07

## Description
This change updates the `render.yaml` config to align with the current working deployment setup.

**Date:** 2025.07.07

### ✅ Updates
- **Storage Backend**
  - Switched `STORAGE_TYPE` from `db` to `s3`
  - Removed `BLOB_STORAGE_PATH`
  - Removed disk mount configuration (`/var/data`), as local storage is no longer used

- **Environment Secret Management**
  - Set `sync: false` for the following env vars:
    - `SECRETKEY_PATH`
    - `APIKEY_PATH`
    - `FLOWISE_SECRETKEY_OVERWRITE`
    - All newly added S3-related keys:
      - `S3_STORAGE_BUCKET_NAME`
      - `S3_STORAGE_ACCESS_KEY_ID`
      - `S3_STORAGE_SECRET_ACCESS_KEY`
      - `S3_STORAGE_REGION`
      - `S3_ENDPOINT_URL`
      - `S3_FORCE_PATH_STYLE`

### 📎 Notes
- Reflects the already deployed state of the infrastructure.
- No functional app-level changes—configuration-only.
