### PR TITLE
Fix refresh API user data

### DIFF
--- a/packages/server/src/controllers/documentstore/index.ts
+++ b/packages/server/src/controllers/documentstore/index.ts
@@ -446,11 +446,7 @@ const upsertDocStoreMiddleware = async (req: Request, res: Response, next: NextF
         }
         const body = req.body
         const files = (req.files as Express.Multer.File[]) || []
-        const apiResponse = await documentStoreService.upsertDocStoreMiddleware(
-            req.params.id,
-            { ...body, userId: req.user?.id!, organizationId: req.user?.organizationId! },
-            files
-        )
+        const apiResponse = await documentStoreService.upsertDocStoreMiddleware(req.params.id, { ...body, user: req.user! }, files)
         getRunningExpressApp().metricsProvider?.incrementCounter(FLOWISE_METRIC_COUNTERS.VECTORSTORE_UPSERT, {
             status: FLOWISE_COUNTER_STATUS.SUCCESS
         })
@@ -474,8 +470,7 @@ const refreshDocStoreMiddleware = async (req: Request, res: Response, next: Next
         const body = req.body
         const apiResponse = await documentStoreService.refreshDocStoreMiddleware(req.params.id, {
             ...body,
-            userId: req.user?.id!,
-            organizationId: req.user?.organizationId!
+            user: req.user!
         })
         getRunningExpressApp().metricsProvider?.incrementCounter(FLOWISE_METRIC_COUNTERS.VECTORSTORE_UPSERT, {
             status: FLOWISE_COUNTER_STATUS.SUCCESS


### PR DESCRIPTION
## Summary
- ensure refresh and upsert routes send user object

## Testing
- `pnpm lint` *(fails: 1108 problems)*
- `pnpm test` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_b_686d2ed83ae8832fa0ff7ebc708ec862