### PR TITLE
bugfix: document store refresh fails due to undefined user object

### DIFF
--- a/packages/server/src/controllers/documentstore/index.ts
+++ b/packages/server/src/controllers/documentstore/index.ts
@@ -446,11 +446,7 @@ const upsertDocStoreMiddleware = async (req: Request, res: Response, next: NextF
         }
         const body = req.body
         const files = (req.files as Express.Multer.File[]) || []
-        const apiResponse = await documentStoreService.upsertDocStoreMiddleware(
-            req.params.id,
-            { ...body, userId: req.user?.id!, organizationId: req.user?.organizationId! },
-            files
-        )
+        const apiResponse = await documentStoreService.upsertDocStoreMiddleware(req.params.id, { ...body, user: req.user! }, files)
         getRunningExpressApp().metricsProvider?.incrementCounter(FLOWISE_METRIC_COUNTERS.VECTORSTORE_UPSERT, {
             status: FLOWISE_COUNTER_STATUS.SUCCESS
         })
@@ -474,8 +470,7 @@ const refreshDocStoreMiddleware = async (req: Request, res: Response, next: Next
         const body = req.body
         const apiResponse = await documentStoreService.refreshDocStoreMiddleware(req.params.id, {
             ...body,
-            userId: req.user?.id!,
-            organizationId: req.user?.organizationId!
+            user: req.user!
         })
         getRunningExpressApp().metricsProvider?.incrementCounter(FLOWISE_METRIC_COUNTERS.VECTORSTORE_UPSERT, {
             status: FLOWISE_COUNTER_STATUS.SUCCESS

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1998,7 +1998,8 @@ const refreshDocStoreMiddleware = async (storeId: string, data: IDocumentStoreRe
             const loaders = JSON.parse(entity.loaders)
             totalItems = loaders.map((ldr: IDocumentStoreLoader) => {
                 return {
-                    docId: ldr.id
+                    docId: ldr.id,
+                    user: data.user
                 }
             })
         } else {


### PR DESCRIPTION
- Fixed refreshDocStoreMiddleware controller to pass user object instead of userId/organizationId
- Fixed upsertDocStoreMiddleware controller to pass user object instead of userId/organizationId
- Fixed refreshDocStoreMiddleware service to include user object in totalItems array
- Resolves GitHub issue #357 - Cannot read properties of undefined (reading 'id') error