### PR TITLE
Patch: Fixes Github Issue 357: Ensure `user` object is consistently passed to DocumentStore service methods

### DIFF
--- a/packages/server/src/controllers/documentstore/index.ts
+++ b/packages/server/src/controllers/documentstore/index.ts
@@ -446,11 +446,7 @@ const upsertDocStoreMiddleware = async (req: Request, res: Response, next: NextF
         }
         const body = req.body
         const files = (req.files as Express.Multer.File[]) || []
-        const apiResponse = await documentStoreService.upsertDocStoreMiddleware(
-            req.params.id,
-            { ...body, userId: req.user?.id!, organizationId: req.user?.organizationId! },
-            files
-        )
+        const apiResponse = await documentStoreService.upsertDocStoreMiddleware(req.params.id, { ...body, user: req.user! }, files)
         getRunningExpressApp().metricsProvider?.incrementCounter(FLOWISE_METRIC_COUNTERS.VECTORSTORE_UPSERT, {
             status: FLOWISE_COUNTER_STATUS.SUCCESS
         })
@@ -474,8 +470,7 @@ const refreshDocStoreMiddleware = async (req: Request, res: Response, next: Next
         const body = req.body
         const apiResponse = await documentStoreService.refreshDocStoreMiddleware(req.params.id, {
             ...body,
-            userId: req.user?.id!,
-            organizationId: req.user?.organizationId!
+            user: req.user!
         })
         getRunningExpressApp().metricsProvider?.incrementCounter(FLOWISE_METRIC_COUNTERS.VECTORSTORE_UPSERT, {
             status: FLOWISE_COUNTER_STATUS.SUCCESS

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1998,7 +1998,8 @@ const refreshDocStoreMiddleware = async (storeId: string, data: IDocumentStoreRe
             const loaders = JSON.parse(entity.loaders)
             totalItems = loaders.map((ldr: IDocumentStoreLoader) => {
                 return {
-                    docId: ldr.id
+                    docId: ldr.id,
+                    user: data.user
                 }
             })
         } else {


### PR DESCRIPTION
## PR Title
Fix: Ensure `user` object is consistently passed to DocumentStore service methods

## Description
### 🐛 Bug Fix

This PR addresses an inconsistency in how user-related metadata was passed to the `DocumentStoreService` methods `upsertDocStoreMiddleware` and `refreshDocStoreMiddleware`. Previously, only `userId` and `organizationId` were passed individually, while other parts of the system expect the full `user` object.

### ✅ Changes
- Replaces individual `userId` and `organizationId` with the full `user` object (`req.user`) in both:
  - `upsertDocStoreMiddleware` controller method
  - `refreshDocStoreMiddleware` controller method
- Ensures the service layer (`documentstore/index.ts`) properly consumes and forwards the `user` object when building internal payloads (e.g. `docId` and `user` pairing for loaders).

### 🧯 Why This Fix Matters
Some downstream logic (e.g., audit logging, scoped permissions, or async processing of loader entries) depends on the full `user` object being available. This fix ensures consistency and prevents unexpected `undefined` access errors during doc store operations.

---

## 🚀 Release Notes
Fixed a bug where only partial user data was sent to the document store service, potentially breaking downstream logic relying on the full user context. Now the full `user` object is consistently passed during both document upsert and refresh operations.
