### PR TITLE
Add Voice Agent for AI Workshops and Update Calendly Page for CTAs

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -66,7 +66,16 @@ const config: Config = {
             '@docusaurus/plugin-google-gtag',
             {
                 trackingID: 'G-VD1X9LNG3N',
-                anonymizeIP: true
+                anonymizeIP: true,
+                id: 'gtag-analytics'
+            }
+        ],
+        [
+            '@docusaurus/plugin-google-gtag',
+            {
+                trackingID: 'AW-16804071963',
+                anonymizeIP: true,
+                id: 'gtag-ads'
             }
         ],
         [

--- a/packages/docs/src/pages/ai-workshops.tsx
+++ b/packages/docs/src/pages/ai-workshops.tsx
@@ -1,12 +1,20 @@
 import clsx from 'clsx'
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import Layout from '@theme/Layout'
 import UsingAnswerAISubmenu from '@site/src/components/UsingAnswerAISubmenu'
 import ThreeJsScene from '@site/src/components/Annimations/SphereScene'
+import { useEffect } from 'react'
 
 import styles from './index.module.css'
 
 function WorkshopsHero() {
+    const handleAIAgentClick = (e: React.MouseEvent) => {
+        e.preventDefault()
+        const widget = document.querySelector('elevenlabs-convai') as any
+        if (widget) {
+            widget.style.display = 'block'
+        }
+    }
+
     return (
         <header className={clsx('hero hero--primary', styles.heroSection)}>
             <div className={styles.heroBackground}>
@@ -15,19 +23,23 @@ function WorkshopsHero() {
             <div className={styles.heroContent}>
                 <h1 className={styles.heroTitle}>AI Workshops for Your Team</h1>
                 <p className={styles.heroSubtitle}>
-                    Transform your organization with hands-on AI training. Expert-led workshops that empower your team to harness the full potential of artificial intelligence.
+                    Transform your organization with hands-on AI training. Expert-led workshops that empower your team to harness the full
+                    potential of artificial intelligence.
                 </p>
                 <div className={styles.heroCTAs}>
-                    <a href='#pricing' className={clsx(styles.ctaButton, styles.ctaPrimary)}>
+                    <a
+                        href='https://calendly.com/lastrev-brad/ai-workshop-discovery-call'
+                        className={clsx(styles.ctaButton, styles.ctaPrimary)}
+                    >
                         Book Consultation
                     </a>
                     <div className={styles.secondaryLinks}>
                         <a href='#how-it-works' className={styles.secondaryLink}>
                             🎯 How It Works
                         </a>
-                        <a href='#locations' className={styles.secondaryLink}>
-                            📍 Available Locations
-                        </a>
+                        <button onClick={handleAIAgentClick} className={styles.secondaryLink}>
+                            🤖 Talk to an Agent Now
+                        </button>
                     </div>
                 </div>
             </div>
@@ -41,28 +53,34 @@ function BenefitsSection() {
             <div className='container'>
                 <div className='row'>
                     <div className='col col--12'>
-                        <h2 className='text--center' style={{ marginBottom: '3rem' }}>Why AI Training Matters for Your Team</h2>
+                        <h2 className='text--center' style={{ marginBottom: '3rem' }}>
+                            Why AI Training Matters for Your Team
+                        </h2>
                     </div>
                 </div>
+
+                {/* First row of 3 cards */}
                 <div className='row'>
                     <div className='col col--4'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
-                            <div className={styles.comingSoonIcon}>🚀</div>
-                            <div>
-                                <h3>Accelerate Productivity</h3>
+                            <div className={styles.comingSoonIcon}>⚡</div>
+                            <div className='text--center'>
+                                <h3>Seamless, All-Inclusive Experience</h3>
                                 <p>
-                                    Empower your team to work smarter, not harder. Learn practical AI tools that can automate routine tasks, enhance decision-making, and boost overall productivity across departments.
+                                    We handle every detail—venue, meals, and events—making it effortless for you to coordinate. Just pick
+                                    your date and location; we do the rest.
                                 </p>
                             </div>
                         </div>
                     </div>
                     <div className='col col--4'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
-                            <div className={styles.comingSoonIcon}>💡</div>
-                            <div>
-                                <h3>Future-Proof Your Business</h3>
+                            <div className={styles.comingSoonIcon}>🚀</div>
+                            <div className='text--center'>
+                                <h3>Boost Team Productivity and Save Time</h3>
                                 <p>
-                                    Stay ahead of the competition by building AI literacy across your organization. Prepare your team for the AI-driven future with hands-on experience and practical knowledge.
+                                    Automate routine work so your team can focus on impactful projects. See less busywork and more
+                                    results—immediately.
                                 </p>
                             </div>
                         </div>
@@ -70,11 +88,118 @@ function BenefitsSection() {
                     <div className='col col--4'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
                             <div className={styles.comingSoonIcon}>🎯</div>
-                            <div>
-                                <h3>Customized for Your Industry</h3>
+                            <div className='text--center'>
+                                <h3>Customized for Your Team&apos;s Needs</h3>
                                 <p>
-                                    Whether you're in marketing, sales, customer support, or engineering, our workshops are tailored to your specific needs and use cases for maximum impact.
+                                    Tailored training for sales, marketing, technical, or support teams. Ensure every participant gets
+                                    relevant, actionable skills.
                                 </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Second row of 3 cards */}
+                <div className='row' style={{ marginTop: '2rem' }}>
+                    <div className='col col--4'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>🌟</div>
+                            <div className='text--center'>
+                                <h3>Attract & Retain Top Talent</h3>
+                                <p>
+                                    Provide growth opportunities that help your company stand out. Upskill staff so your leaders—and your
+                                    organization—shine.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div className='col col--4'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>🏆</div>
+                            <div className='text--center'>
+                                <h3>Position Your Company as a Leader</h3>
+                                <p>
+                                    Make your execs and teams look forward-thinking with advanced AI capabilities that impress stakeholders
+                                    and peers.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div className='col col--4'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>💼</div>
+                            <div className='text--center'>
+                                <h3>Effortless Scheduling and Support</h3>
+                                <p>
+                                    Dedicated support from consultation to workshop day. Fast, responsive answers so you can confidently
+                                    handle all planning questions and logistics.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    )
+}
+
+function ProminentCTASection() {
+    const handleAIAgentClick = (e: React.MouseEvent) => {
+        e.preventDefault()
+        const widget = document.querySelector('elevenlabs-convai') as any
+        if (widget) {
+            widget.style.display = 'block'
+        }
+    }
+
+    return (
+        <section className={styles.missionSection}>
+            <div className='container'>
+                <div className='row'>
+                    <div className='col col--12'>
+                        <div className={styles.prominentCTAHeader}>
+                            <div className={styles.comingSoonIcon}>🎉</div>
+                            <h2 className='text--center'>Complete AI Workshop Experience</h2>
+                            <p className='text--center' style={{ fontSize: '1.2rem', opacity: 0.9, marginBottom: '2rem' }}>
+                                We handle everything: venue booking, catering for lunches and dinners, evening networking events, and team
+                                celebrations at local nightlife spots. Perfect for team offsites or conference add-ons.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div className='row'>
+                    <div className='col col--6'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>🤖</div>
+                            <div>
+                                <h3>Talk to an AI Agent</h3>
+                                <p>
+                                    Get instant answers about our workshops, pricing, and availability. Our AI agent is trained to help you
+                                    understand how we can transform your team&apos;s AI capabilities.
+                                </p>
+                                <button onClick={handleAIAgentClick} className={clsx(styles.ctaButton, styles.ctaPrimary)}>
+                                    🤖 Chat with AI Agent
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div className='col col--6'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>👥</div>
+                            <div>
+                                <h3>Schedule with a Human</h3>
+                                <p>
+                                    Talk directly with our team about your specific needs and get a customized proposal. Perfect for
+                                    discussing team size, location preferences, and creating a tailored experience.
+                                </p>
+                                <a
+                                    href='https://calendly.com/lastrev-brad/ai-workshop-discovery-call'
+                                    className={clsx(styles.ctaButton, styles.ctaPrimary)}
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                >
+                                    📅 Schedule with a Human
+                                </a>
                             </div>
                         </div>
                     </div>
@@ -92,15 +217,16 @@ function HowItWorksSection() {
                 <p className='text--center' style={{ marginBottom: '3rem', fontSize: '1.2rem', opacity: 0.9 }}>
                     A comprehensive 5-day learning experience combining online preparation with intensive in-person training
                 </p>
-                
+
                 <div className='row' style={{ marginBottom: '3rem' }}>
                     <div className='col col--6'>
                         <div className={clsx(styles.featureCard, styles.stepCard)}>
                             <div className={styles.stepNumber}>1</div>
                             <h3>Pre-Workshop Online Training</h3>
                             <p>
-                                <strong>3 Days of Online Preparation</strong><br/>
-                                Get access to the Answer Academy with videos, documents, resources, prompts, and open-source agents. 
+                                <strong>3 Days of Online Preparation</strong>
+                                <br />
+                                Get access to the Answer Academy with videos, documents, resources, prompts, and open-source agents.
                                 Participate in Zoom sessions to build foundational knowledge before the in-person workshop.
                             </p>
                             <div className={styles.appFeatures}>
@@ -115,27 +241,15 @@ function HowItWorksSection() {
                             <div className={styles.stepNumber}>2</div>
                             <h3>In-Person Workshop Experience</h3>
                             <p>
-                                <strong>2 Days of Intensive Training</strong><br/>
-                                Join CEO Bradley Taylor and our expert team for hands-on workshops covering AI implementation 
-                                across marketing, sales, customer support, and engineering leadership.
+                                <strong>2 Days of Intensive Training</strong>
+                                <br />
+                                Join CEO Bradley Taylor and our expert team for hands-on workshops covering AI implementation across
+                                marketing, sales, customer support, and engineering leadership.
                             </p>
                             <div className={styles.appFeatures}>
                                 <span>👨‍💼 CEO-Led Sessions</span>
                                 <span>🛠️ Hands-On Training</span>
                                 <span>🎯 Department-Specific Breakouts</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div className='row'>
-                    <div className='col col--12'>
-                        <div className={clsx(styles.commandment, styles.comingSoonCard)}>
-                            <div className={styles.comingSoonIcon}>🎉</div>
-                            <div className={styles.commandmentText}>
-                                <strong>Complete Experience Package</strong><br/>
-                                We handle everything: venue booking, catering for lunches and dinners, evening networking events, 
-                                and a team celebration at local nightlife spots. Perfect for team offsites or conference add-ons.
                             </div>
                         </div>
                     </div>
@@ -153,22 +267,23 @@ function WorkshopTopicsSection() {
                 <p className='text--center' style={{ marginBottom: '3rem', fontSize: '1.2rem', opacity: 0.9 }}>
                     Tailored training modules designed for different roles and departments
                 </p>
-                
+
                 <div className='row'>
                     <div className='col col--6'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
                             <div className={styles.comingSoonIcon}>📈</div>
                             <div>
-                                <h3>Marketing & Sales Teams</h3>
+                                <h3>Sales & Marketing Teams</h3>
                                 <p>
-                                    Learn to leverage AI for content creation, customer segmentation, lead generation, 
-                                    personalized outreach, and sales process optimization. Create compelling campaigns 
-                                    and close deals faster with AI assistance.
+                                    Learn to leverage AI for content creation, customer segmentation, lead generation, personalized
+                                    outreach, and sales process optimization. Create compelling campaigns and close deals faster with AI
+                                    assistance.
                                 </p>
                                 <div className={styles.appFeatures}>
-                                    <span>✍️ Content Generation</span>
-                                    <span>🎯 Lead Qualification</span>
-                                    <span>📊 Campaign Optimization</span>
+                                    <span>✍️ Quality Content Generation</span>
+                                    <span>🎯 Lead Qualification & Nurturing</span>
+                                    <span>📊 Campaign Optimization & Tracking</span>
+                                    <span>🔄 Sales Process Optimization</span>
                                 </div>
                             </div>
                         </div>
@@ -179,53 +294,53 @@ function WorkshopTopicsSection() {
                             <div>
                                 <h3>Engineering & Technical Teams</h3>
                                 <p>
-                                    Deep dive into different AI models, implementation strategies, and technical best practices. 
-                                    Learn the differences between models, when to use each, and how to integrate AI into 
-                                    your development workflow.
+                                    Deep dive into different AI models, implementation strategies, and technical best practices. Learn the
+                                    differences between models, when to use each, and how to integrate AI into your development workflow.
                                 </p>
                                 <div className={styles.appFeatures}>
-                                    <span>🤖 Model Comparison</span>
-                                    <span>⚙️ Implementation Strategies</span>
-                                    <span>🔧 Development Integration</span>
+                                    <span>🤖 Agent & RAG Implementation</span>
+                                    <span>⚙️ Model Comparison</span>
+                                    <span>🔧 Development Process Integration</span>
+                                    <span>🔧 Fine Tuning & Prompt Engineering</span>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                
+
                 <div className='row' style={{ marginTop: '2rem' }}>
                     <div className='col col--6'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
                             <div className={styles.comingSoonIcon}>💬</div>
                             <div>
-                                <h3>Customer Support Excellence</h3>
+                                <h3>Customer Support Teams</h3>
                                 <p>
-                                    Transform your customer support with AI-powered solutions. Learn to implement chatbots, 
-                                    automate responses, analyze sentiment, and provide personalized customer experiences 
-                                    that scale.
+                                    Transform your customer support with AI-powered solutions. Learn to implement chatbots, automate
+                                    responses, analyze sentiment, and provide personalized customer experiences that scale.
                                 </p>
                                 <div className={styles.appFeatures}>
-                                    <span>🤖 Chatbot Implementation</span>
-                                    <span>📝 Response Automation</span>
+                                    <span>🤖 Chatbot & Voice Agents</span>
+                                    <span>📝 Response Automation & Documentation</span>
                                     <span>😊 Sentiment Analysis</span>
+                                    <span>🔄 Workflow Automation & Process Optimization</span>
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div className='col col--6'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
-                            <div className={styles.comingSoonIcon}>👥</div>
+                            <div className={styles.comingSoonIcon}>👔</div>
                             <div>
-                                <h3>End-User Empowerment</h3>
+                                <h3>Executive Leadership</h3>
                                 <p>
-                                    Help every team member become AI-literate. Learn practical applications, prompt engineering, 
-                                    workflow automation, and how to integrate AI tools into daily tasks for maximum productivity 
-                                    gains.
+                                    Strategic guidance for deploying AI across your organization. Learn to identify opportunities, manage
+                                    implementation, and drive company-wide AI adoption for competitive advantage and operational excellence.
                                 </p>
                                 <div className={styles.appFeatures}>
-                                    <span>✨ Prompt Engineering</span>
-                                    <span>🔄 Workflow Automation</span>
-                                    <span>🎯 Practical Applications</span>
+                                    <span>🎯 Strategic Planning & Implementation</span>
+                                    <span>📊 ROI Assessment & Tracking</span>
+                                    <span>🚀 Change Management & Training</span>
+                                    <span>🔄 AI Adoption & Culture</span>
                                 </div>
                             </div>
                         </div>
@@ -242,16 +357,19 @@ function LocationsSection() {
             <div className='container'>
                 <h2 className='text--center'>Available Workshop Locations</h2>
                 <p className='text--center' style={{ marginBottom: '3rem', fontSize: '1.2rem', opacity: 0.9 }}>
-                    Choose from premium locations across major cities. Workshops scheduled Thursday-Friday for optimal weekend extension.
+                    Choose from premium locations across major cities. Other locations available upon request.
                 </p>
-                
+
                 <div className='row'>
                     <div className='col col--4'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
                             <div className={styles.comingSoonIcon}>🌴</div>
                             <div>
                                 <h3>Los Angeles</h3>
-                                <p>Innovation hub of the West Coast. Perfect for tech companies and creative agencies looking to integrate AI into their workflows.</p>
+                                <p>
+                                    Innovation hub of the West Coast. Perfect for tech companies and creative agencies looking to integrate
+                                    AI into their workflows.
+                                </p>
                             </div>
                         </div>
                     </div>
@@ -260,7 +378,10 @@ function LocationsSection() {
                             <div className={styles.comingSoonIcon}>🌉</div>
                             <div>
                                 <h3>San Francisco</h3>
-                                <p>Heart of Silicon Valley. Ideal for startups and established tech companies at the forefront of AI adoption.</p>
+                                <p>
+                                    Heart of Silicon Valley. Ideal for startups and established tech companies at the forefront of AI
+                                    adoption.
+                                </p>
                             </div>
                         </div>
                     </div>
@@ -269,19 +390,25 @@ function LocationsSection() {
                             <div className={styles.comingSoonIcon}>🏔️</div>
                             <div>
                                 <h3>Seattle</h3>
-                                <p>Tech powerhouse of the Pacific Northwest. Great for companies seeking innovative AI solutions in a dynamic environment.</p>
+                                <p>
+                                    Tech powerhouse of the Pacific Northwest. Great for companies seeking innovative AI solutions in a
+                                    dynamic environment.
+                                </p>
                             </div>
                         </div>
                     </div>
                 </div>
-                
+
                 <div className='row' style={{ marginTop: '2rem' }}>
                     <div className='col col--4'>
                         <div className={clsx(styles.featureCard, styles.commandment)}>
                             <div className={styles.comingSoonIcon}>⛰️</div>
                             <div>
                                 <h3>Denver</h3>
-                                <p>Mile High City with growing tech scene. Perfect for teams looking to elevate their AI capabilities in an inspiring setting.</p>
+                                <p>
+                                    Mile High City with growing tech scene. Perfect for teams looking to elevate their AI capabilities in an
+                                    inspiring setting.
+                                </p>
                             </div>
                         </div>
                     </div>
@@ -290,7 +417,10 @@ function LocationsSection() {
                             <div className={styles.comingSoonIcon}>🎸</div>
                             <div>
                                 <h3>Austin</h3>
-                                <p>Keep Austin AI-powered! Vibrant tech community and creative culture make it ideal for innovative team experiences.</p>
+                                <p>
+                                    Keep Austin AI-powered! Vibrant tech community and creative culture make it ideal for innovative team
+                                    experiences.
+                                </p>
                             </div>
                         </div>
                     </div>
@@ -299,21 +429,24 @@ function LocationsSection() {
                             <div className={styles.comingSoonIcon}>🎰</div>
                             <div>
                                 <h3>Las Vegas</h3>
-                                <p>Entertainment capital perfect for memorable team experiences. Combine learning with world-class networking opportunities.</p>
+                                <p>
+                                    Entertainment capital perfect for memorable team experiences. Combine learning with world-class
+                                    networking opportunities.
+                                </p>
                             </div>
                         </div>
                     </div>
                 </div>
-                
+
                 <div className='row' style={{ marginTop: '3rem' }}>
                     <div className='col col--12'>
                         <div className={clsx(styles.commandment, styles.comingSoonCard, styles.subscriptionBanner)}>
                             <div className={styles.subscriptionBannerContent}>
                                 <div className={clsx(styles.comingSoonIcon, styles.subscriptionBannerIcon)}>📅</div>
                                 <div className={clsx(styles.commandmentText, styles.subscriptionBannerText)}>
-                                    <strong>Available Through End of 2026</strong><br/>
-                                    Book your workshop for any of these locations. We recommend Thursday-Friday scheduling 
-                                    so your team can enjoy the weekend in these amazing cities.
+                                    <strong>Available Through End of 2026</strong>
+                                    <br />
+                                    Book your workshop for any of these locations. We recommend coupling with a conference or team offsite.
                                 </div>
                             </div>
                         </div>
@@ -325,6 +458,14 @@ function LocationsSection() {
 }
 
 function PricingCTASection() {
+    const handleAIAgentClick = (e: React.MouseEvent) => {
+        e.preventDefault()
+        const widget = document.querySelector('elevenlabs-convai') as any
+        if (widget) {
+            widget.style.display = 'block'
+        }
+    }
+
     return (
         <section className={styles.pricingSection} id='pricing'>
             <div className='container'>
@@ -334,19 +475,21 @@ function PricingCTASection() {
                         Fixed cost plus per-person pricing. Comprehensive training, full logistics, and memorable team experience included.
                     </p>
                 </div>
-                
+
                 <div className='row'>
                     <div className='col col--8 col--offset-2'>
                         <div className={clsx(styles.pricingCard, styles.commandment, styles.pricingCardHighlighted)}>
                             <div className={styles.pricingIcon}>🎯</div>
                             <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-                                <h3 style={{ color: '#00ffff', marginBottom: '1rem', textAlign: 'center' }}>Complete AI Workshop Experience</h3>
+                                <h3 style={{ color: '#00ffff', marginBottom: '1rem', textAlign: 'center' }}>
+                                    Complete AI Workshop Experience
+                                </h3>
                                 <div className={styles.pricingHighlight}>Fixed Cost + Per Person</div>
                                 <p style={{ marginBottom: '2rem', textAlign: 'center', fontSize: '1.1rem' }}>
-                                    Everything included: Answer Academy access, 3 days online training, 2 days in-person workshops, 
-                                    all meals, venue, and team events. Fully customizable to your team's needs.
+                                    Everything included: Answer Academy access, 3 days online training, 2 days in-person workshops, all
+                                    meals, venue, and team events. Fully customizable to your team&apos;s needs.
                                 </p>
-                                
+
                                 <div style={{ marginBottom: '2rem' }}>
                                     <div style={{ marginBottom: '0.5rem' }}>✓ Answer Academy access (videos, docs, resources, agents)</div>
                                     <div style={{ marginBottom: '0.5rem' }}>✓ 3 days pre-workshop online training</div>
@@ -356,44 +499,35 @@ function PricingCTASection() {
                                     <div style={{ marginBottom: '0.5rem' }}>✓ All venue, meals, and event planning</div>
                                     <div style={{ marginBottom: '0.5rem' }}>✓ Team networking and celebration events</div>
                                 </div>
-                                
+
                                 <div className='text--center' style={{ marginTop: 'auto' }}>
-                                    <div className={clsx(styles.commandment, styles.comingSoonCard)} style={{ marginBottom: '2rem', backgroundColor: 'rgba(255, 0, 0, 0.1)', border: '2px solid #ff4444' }}>
+                                    <div
+                                        className={clsx(styles.commandment, styles.comingSoonCard)}
+                                        style={{
+                                            marginBottom: '2rem',
+                                            backgroundColor: 'rgba(255, 0, 0, 0.1)',
+                                            border: '2px solid #ff4444'
+                                        }}
+                                    >
                                         <div className={styles.comingSoonIcon}>⚡</div>
                                         <div className={styles.commandmentText}>
-                                            <strong style={{ color: '#ff4444' }}>Only 10 Spots Left in 2025!</strong><br/>
+                                            <strong style={{ color: '#ff4444' }}>Only 10 Spots Left in 2025!</strong>
+                                            <br />
                                             Book your consultation now to secure your preferred dates and location.
                                         </div>
                                     </div>
-                                    
+
                                     <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
-                                        <a href='/developers' className={clsx(styles.ctaButton, styles.ctaPrimary)}>
-                                            Book Consultation
-                                        </a>
-                                        <a href='/developers' className={clsx(styles.ctaButton, styles.ctaSecondary)}>
-                                            Get Pricing & Availability
+                                        <button onClick={handleAIAgentClick} className={clsx(styles.ctaButton, styles.ctaPrimary)}>
+                                            Talk to an AI Agent Now
+                                        </button>
+                                        <a
+                                            href='https://calendly.com/lastrev-brad/ai-workshop-discovery-call'
+                                            className={clsx(styles.ctaButton, styles.ctaSecondary)}
+                                        >
+                                            Schedule a Consultation
                                         </a>
                                     </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div className='row' style={{ marginTop: '3rem' }}>
-                    <div className='col col--12'>
-                        <div className={clsx(styles.pricingCallout, styles.commandment)}>
-                            <div style={{ textAlign: 'center' }}>
-                                <h3 style={{ color: '#00ffff', marginBottom: '1rem' }}>🤝 Fully Customizable Experience</h3>
-                                <p style={{ fontSize: '1.1rem', marginBottom: '1rem' }}>
-                                    Whether you're a focused marketing team or a diverse startup, we tailor the workshop to your exact needs. 
-                                    Perfect for team offsites or as part of your company conference. Let's talk about creating the perfect 
-                                    AI transformation experience for your organization.
-                                </p>
-                                <div style={{ marginTop: '2rem' }}>
-                                    <a href='/developers' className={clsx(styles.ctaButton, styles.ctaPrimary)}>
-                                        Talk to Us Now
-                                    </a>
                                 </div>
                             </div>
                         </div>
@@ -405,7 +539,21 @@ function PricingCTASection() {
 }
 
 export default function AIWorkshops(): JSX.Element {
-    const { siteConfig } = useDocusaurusContext()
+    useEffect(() => {
+        // Load the ElevenLabs widget script
+        const script = document.createElement('script')
+        script.src = 'https://unpkg.com/@elevenlabs/convai-widget-embed'
+        script.async = true
+        script.type = 'text/javascript'
+        document.head.appendChild(script)
+
+        return () => {
+            // Clean up
+            if (script.parentNode) {
+                script.parentNode.removeChild(script)
+            }
+        }
+    }, [])
 
     return (
         <div data-theme='dark'>
@@ -418,11 +566,26 @@ export default function AIWorkshops(): JSX.Element {
                 <main>
                     <BenefitsSection />
                     <HowItWorksSection />
+                    <ProminentCTASection />
                     <WorkshopTopicsSection />
                     <LocationsSection />
                     <PricingCTASection />
                 </main>
+
+                {/* ElevenLabs Conversational AI Widget */}
+                <div
+                    dangerouslySetInnerHTML={{
+                        __html: `<elevenlabs-convai 
+                        agent-id="DPsEbqvGlYGP9gJQObqN"
+                        action-text="Need AI workshop help?"
+                        start-call-text="Start conversation"
+                        end-call-text="End conversation"
+                        listening-text="Listening..."
+                        speaking-text="AI assistant speaking"
+                    ></elevenlabs-convai>`
+                    }}
+                />
             </Layout>
         </div>
     )
-} 
+}

--- a/packages/docs/src/pages/ai-workshops/scheduled.tsx
+++ b/packages/docs/src/pages/ai-workshops/scheduled.tsx
@@ -1,0 +1,128 @@
+import clsx from 'clsx'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import Layout from '@theme/Layout'
+import UsingAnswerAISubmenu from '@site/src/components/UsingAnswerAISubmenu'
+import ThreeJsScene from '@site/src/components/Annimations/SphereScene'
+
+import styles from '../index.module.css'
+
+function ScheduledHero() {
+    return (
+        <header className={clsx('hero hero--primary', styles.heroSection)}>
+            <div className={styles.heroBackground}>
+                <ThreeJsScene className={styles.threeJsCanvas} />
+            </div>
+            <div className={styles.heroContent}>
+                <div className={styles.confirmationIcon}>✅</div>
+                <h1 className={styles.heroTitle}>Workshop Consultation Scheduled!</h1>
+                <p className={styles.heroSubtitle}>
+                    Thank you for scheduling your AI workshop consultation. We&apos;re excited to help transform your team with cutting-edge
+                    AI training.
+                </p>
+                <div className={styles.confirmationDetails}>
+                    <div className={styles.confirmationCard}>
+                        <h3>What Happens Next?</h3>
+                        <div className={styles.nextSteps}>
+                            <div className={styles.nextStep}>
+                                <span className={styles.stepNumber}>1</span>
+                                <div>
+                                    <strong>Confirmation Email</strong>
+                                    <p>You&apos;ll receive a confirmation email with meeting details and a calendar invite.</p>
+                                </div>
+                            </div>
+                            <div className={styles.nextStep}>
+                                <span className={styles.stepNumber}>2</span>
+                                <div>
+                                    <strong>Pre-Meeting Preparation</strong>
+                                    <p>We&apos;ll send you a brief questionnaire to understand your team&apos;s specific needs.</p>
+                                </div>
+                            </div>
+                            <div className={styles.nextStep}>
+                                <span className={styles.stepNumber}>3</span>
+                                <div>
+                                    <strong>Consultation Call</strong>
+                                    <p>We&apos;ll discuss your requirements and create a customized workshop proposal.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div className={styles.confirmationActions}>
+                    <a href='/ai-workshops' className={clsx(styles.ctaButton, styles.ctaSecondary)}>
+                        Back to Workshop Details
+                    </a>
+                    <a href='/developers' className={clsx(styles.ctaButton, styles.ctaPrimary)}>
+                        Talk to AI Agent Now
+                    </a>
+                </div>
+            </div>
+        </header>
+    )
+}
+
+function AdditionalResourcesSection() {
+    return (
+        <section className={styles.missionSection}>
+            <div className='container'>
+                <h2 className='text--center'>While You Wait, Explore Our Resources</h2>
+                <div className='row'>
+                    <div className='col col--4'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>📚</div>
+                            <div>
+                                <h3>Answer Academy</h3>
+                                <p>Get a preview of our training content with free access to select courses and resources.</p>
+                                <a href='/developers' className={styles.resourceLink}>
+                                    Explore Academy →
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div className='col col--4'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>🎯</div>
+                            <div>
+                                <h3>Use Cases</h3>
+                                <p>See how other teams are using AI to transform their workflows and boost productivity.</p>
+                                <a href='/docs/use-cases' className={styles.resourceLink}>
+                                    View Use Cases →
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div className='col col--4'>
+                        <div className={clsx(styles.featureCard, styles.commandment)}>
+                            <div className={styles.comingSoonIcon}>🤖</div>
+                            <div>
+                                <h3>AI Agents</h3>
+                                <p>Try our AI agents to get a taste of what your team will learn to build and deploy.</p>
+                                <a href='/developers' className={styles.resourceLink}>
+                                    Try AI Agents →
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    )
+}
+
+export default function AIWorkshopsScheduled(): JSX.Element {
+    const { siteConfig } = useDocusaurusContext()
+
+    return (
+        <div data-theme='dark'>
+            <Layout
+                title='Workshop Consultation Scheduled - AI Workshops'
+                description='Your AI workshop consultation has been scheduled. Learn what happens next and explore our resources while you wait.'
+            >
+                <ScheduledHero />
+                <UsingAnswerAISubmenu />
+                <main>
+                    <AdditionalResourcesSection />
+                </main>
+            </Layout>
+        </div>
+    )
+}


### PR DESCRIPTION
This PR introduces the following updates to the AI Workshops documentation site:

Added ElevenLabs Voice Agent

- Integrated the ElevenLabs conversational AI widget for instant agent support on the AI Workshops page.
- Added multiple "Talk to an AI Agent" CTA buttons that trigger the agent widget.

Updated Calendly Link in CTAs

- Changed "Book Consultation" and "Schedule…" CTA links to use the new Calendly page: https://calendly.com/lastrev-brad/ai-workshop-discovery-call
- Ensures consistent scheduling experience for users.

Enhanced Workshop Experience Presentation

- New prominent CTA section ("Complete AI Workshop Experience") with both human and AI scheduling/support options.
- Benefits, topics, and locations sections have been improved for clarity and engagement.
- Added a new confirmation page at /ai-workshops/scheduled with next steps and resources for users post-scheduling.