### PR TITLE
chore: remove outdated Docker entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,4 @@ WORKDIR /app/packages/server
 # Expose the port that the application listens on.
 EXPOSE 4000
 
-COPY update_ui_env.sh /docker-entrypoint.d/update_ui_env.sh
-RUN chmod +x /docker-entrypoint.d/update_ui_env.sh
-
-# Run the application.
-ENTRYPOINT ["/docker-entrypoint.d/update_ui_env.sh"]
 CMD ["pnpm", "start"]


### PR DESCRIPTION
- Removed the `update_ui_env.sh` script from the Dockerfile as it is no longer needed for application startup.
- Updated the ENTRYPOINT to use the default CMD for starting the application.