### PR TITLE
docs: add comprehensive Salesforce Personal OAuth documentation

### DIFF
--- a/packages/components/nodes/tools/MCP/SalesforceOauthMcp/SalesforceOauthMcp.ts
+++ b/packages/components/nodes/tools/MCP/SalesforceOauthMcp/SalesforceOauthMcp.ts
@@ -22,7 +22,7 @@
  */
 import { Tool } from '@langchain/core/tools'
 import { ICommonObject, INode, INodeData, INodeOptionsValue, INodeParams } from '../../../../src/Interface'
-import { getCredentialData, getCredentialParam } from '../../../../src/utils'
+import { getCredentialData, getCredentialParam, getNodeModulesPackagePath } from '../../../../src/utils'
 import { MCPToolkit } from '../core'
 
 class SalesforceOauth_MCP implements INode {
@@ -130,12 +130,11 @@ class SalesforceOauth_MCP implements INode {
             )
         }
 
-        // Path to local MCP server for development
-        const localMcpServerPath = '/Users/jaime.morales/dev/mcp-server-salesforce/dist/index.js'
+        const packagePath = getNodeModulesPackagePath('@answerai/salesforce-mcp/dist/index.js')
 
         const serverParams = {
             command: process.execPath,
-            args: [localMcpServerPath],
+            args: [packagePath],
             env: {
                 SALESFORCE_CONNECTION_TYPE: 'OAuth_2.0_Personal',
                 SALESFORCE_CLIENT_ID: salesforceClientId,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,6 +25,7 @@
         "@answerai/answeragent-mcp": "^1.0.1",
         "@answerai/confluence-mcp": "^1.0.0",
         "@answerai/jira-mcp": "^1.0.2",
+        "@answerai/salesforce-mcp": "^0.1.0",
         "@apidevtools/json-schema-ref-parser": "^12.0.2",
         "@arizeai/openinference-instrumentation-langchain": "^2.0.0",
         "@aws-sdk/client-bedrock-runtime": "3.422.0",

--- a/packages/docs/docs/developers/authorization/salesforce-oauth.md
+++ b/packages/docs/docs/developers/authorization/salesforce-oauth.md
@@ -1,0 +1,389 @@
+---
+description: Complete guide to setting up Salesforce Personal OAuth for AnswerAI integrations
+---
+
+# Salesforce Personal OAuth Setup
+
+## Overview
+
+Salesforce Personal OAuth 2.0 enables individual users to connect their personal Salesforce accounts with AnswerAI, allowing for user-specific data access and operations. This is distinct from system-wide Salesforce API credentials and provides a more secure, user-controlled authentication method.
+
+### Personal OAuth vs System-Wide Credentials
+
+| **Personal OAuth**           | **System-Wide API Credentials**  |
+| ---------------------------- | -------------------------------- |
+| User-specific authentication | Organization-wide authentication |
+| Individual refresh tokens    | Shared client credentials        |
+| User grants permissions      | Admin configures permissions     |
+| Secure, isolated access      | Broader system access            |
+| OAuth 2.0 flow               | Client credentials flow          |
+
+## Prerequisites
+
+-   A Salesforce account with admin access
+-   Access to Salesforce Setup menu
+-   AnswerAI instance (local or deployed)
+-   Basic understanding of OAuth 2.0 concepts
+
+## Step 1: Create Salesforce Connected App
+
+### Access Salesforce Setup
+
+1. **Log in to Salesforce**
+
+    - Sign in to your Salesforce org
+    - Navigate to **Setup** (gear icon in top right)
+
+2. **Navigate to App Manager**
+
+    - In Setup, search for "App Manager"
+    - Click on **App Manager** under Apps
+
+3. **Create New Connected App**
+    - Click **New Connected App**
+    - Fill in the basic information:
+        - **Connected App Name**: `AnswerAI Personal OAuth`
+        - **API Name**: `AnswerAI_Personal_OAuth`
+        - **Contact Email**: Your email address
+        - **Description**: OAuth integration for personal AnswerAI access
+
+### Configure OAuth Settings
+
+1. **Enable OAuth Settings**
+
+    - Check **Enable OAuth Settings**
+    - **Callback URL**: Add your AnswerAI callback URL
+        - For local development: `http://localhost:4000/api/v1/salesforce-auth/callback`
+        - For production: `https://yourdomain.com/api/v1/salesforce-auth/callback`
+
+2. **Select OAuth Scopes**
+   Add the following scopes for comprehensive AnswerAI integration:
+
+    ```
+    Access and manage your data (api)
+    Access your basic information (id, profile, email, address, phone)
+    Perform requests on your behalf at any time (refresh_token, offline_access)
+    ```
+
+3. **Additional Settings**
+
+    - **Require Secret for Web Server Flow**: Checked
+    - **Require Secret for Refresh Token Flow**: Checked
+    - **Enable PKCE Extension for Supported Authorization Flows**: Checked
+
+4. **Save the Connected App**
+    - Click **Save**
+    - Wait for the app to be created (may take 2-10 minutes)
+
+## Step 2: Configure Connected App Policies
+
+### Set OAuth Policies
+
+1. **Access Connected App**
+
+    - Navigate back to **App Manager**
+    - Find your `AnswerAI Personal OAuth` app
+    - Click the dropdown arrow and select **Edit**
+
+2. **Configure OAuth Policies**
+
+    - **Permitted Users**: Select "Admin approved users are pre-authorized"
+    - **IP Relaxation**: Select "Relax IP restrictions"
+    - **Refresh Token Policy**: Select "Refresh token is valid until revoked"
+
+3. **Save Changes**
+    - Click **Save**
+
+### Get Client Credentials
+
+1. **View Consumer Details**
+
+    - In the Connected App details, click **View**
+    - Click **Manage Consumer Details**
+    - You may need to verify your identity
+
+2. **Record Credentials**
+    - **Consumer Key (Client ID)**: Copy and store securely
+    - **Consumer Secret (Client Secret)**: Copy and store securely
+    - **Instance URL**: Note your org's instance URL (e.g., `https://your-domain.my.salesforce.com`)
+
+## Step 3: Configure Environment Variables
+
+Add the following environment variables to your AnswerAI instance:
+
+### For Local Development
+
+```bash
+# Salesforce Personal OAuth Configuration
+SALESFORCE_CLIENT_ID=your_consumer_key_here
+SALESFORCE_CLIENT_SECRET=your_consumer_secret_here
+SALESFORCE_INSTANCE_URL=https://your-domain.my.salesforce.com
+
+# API Base URL (for callback)
+API_BASE_URL=http://localhost:4000/api/v1
+```
+
+### For Production
+
+```bash
+# Salesforce Personal OAuth Configuration
+SALESFORCE_CLIENT_ID=your_consumer_key_here
+SALESFORCE_CLIENT_SECRET=your_consumer_secret_here
+SALESFORCE_INSTANCE_URL=https://your-domain.my.salesforce.com
+
+# API Base URL (for callback)
+API_BASE_URL=https://yourdomain.com/api/v1
+```
+
+## Step 4: Credential Configuration in AnswerAI
+
+### Creating Salesforce Personal OAuth Credential
+
+1. **Navigate to Credentials**
+
+    - In AnswerAI, go to the Credentials section
+    - Click **Add Credential**
+
+2. **Select Salesforce OAuth**
+
+    - Choose **Salesforce OAuth** from the credential types
+    - This is different from "Salesforce API" which uses client credentials
+
+3. **Configure Credential**
+
+    - **Credential Name**: Give it a descriptive name (e.g., "My Salesforce Account")
+    - **Client ID**: Enter your Salesforce Consumer Key
+    - **Client Secret**: Enter your Salesforce Consumer Secret
+    - **Instance URL**: Enter your Salesforce instance URL
+
+4. **Authorize Access**
+    - Click **Authorize with Salesforce**
+    - You'll be redirected to Salesforce login
+    - Sign in to your Salesforce account
+    - Review and approve the requested permissions
+    - You'll be redirected back to AnswerAI
+
+## End User OAuth Flow
+
+### For End Users Connecting Their Accounts
+
+Once administrators have set up the Salesforce Connected App, end users can connect their personal accounts:
+
+1. **Access Credentials Section**
+
+    - Navigate to the Credentials section in AnswerAI
+    - Click **Add Credential**
+
+2. **Select Salesforce OAuth**
+
+    - Choose **Salesforce OAuth** from available credential types
+    - Enter a descriptive name for the credential
+
+3. **Fill Required Fields**
+
+    - **Client ID**: Provided by admin or from Connected App
+    - **Client Secret**: Provided by admin or from Connected App
+    - **Instance URL**: Your organization's Salesforce URL
+
+4. **Authorization Process**
+
+    - Click **Authorize with Salesforce**
+    - You'll be redirected to Salesforce's authorization page
+    - Sign in with your Salesforce credentials
+
+5. **Grant Permissions**
+
+    - Review the requested permissions:
+        - Access and manage your data
+        - Access your basic information
+        - Perform requests on your behalf
+    - Click **Allow** to grant access
+
+6. **Confirmation**
+
+    - You'll be redirected back to AnswerAI
+    - Your personal Salesforce account is now connected
+    - The refresh token is securely stored
+
+7. **Using the Credential**
+    - Select your Salesforce OAuth credential when configuring:
+        - Salesforce Personal OAuth MCP Server
+        - Other Salesforce-integrated nodes
+
+## Security Best Practices
+
+### Environment Variables
+
+1. **Never Expose Secrets**
+
+    - Keep client secrets in environment variables only
+    - Never commit secrets to version control
+    - Use secure environment variable management
+
+2. **Callback URL Security**
+    - Use HTTPS in production
+    - Validate callback URLs match exactly
+    - Consider using state parameters for additional security
+
+### Token Management
+
+1. **Refresh Token Handling**
+
+    - AnswerAI automatically handles token refresh
+    - Refresh tokens are stored encrypted
+    - Tokens can be revoked by users at any time
+
+2. **Access Control**
+    - Users control their own OAuth permissions
+    - Tokens are scoped to individual users
+    - No shared credentials between users
+
+### Production Considerations
+
+1. **Domain Verification**
+
+    - Verify your domain in Salesforce for production use
+    - This removes "unverified app" warnings
+    - Provides better user experience
+
+2. **Monitoring**
+    - Monitor OAuth usage in Salesforce Setup
+    - Track token refresh patterns
+    - Set up alerts for unusual activity
+
+## Testing Your Setup
+
+### Verify Connected App Configuration
+
+1. **Check OAuth Settings**
+
+    - Verify callback URL matches your AnswerAI instance
+    - Confirm all required scopes are enabled
+    - Test the OAuth flow in a sandbox first
+
+2. **Test Token Flow**
+    - Create a test Salesforce OAuth credential
+    - Verify authorization redirects work correctly
+    - Confirm tokens are stored and refresh properly
+
+### Integration Testing
+
+1. **Create Test Credential**
+
+    - Follow the end user flow to create a credential
+    - Verify the OAuth popup works correctly
+    - Check that refresh tokens are stored
+
+2. **Test MCP Integration**
+    - Use the credential with Salesforce Personal OAuth MCP
+    - Verify data access works as expected
+    - Test token refresh functionality
+
+## Troubleshooting
+
+### Common Setup Issues
+
+1. **"Error 400: redirect_uri_mismatch"**
+
+    - **Cause**: Callback URL in Connected App doesn't match AnswerAI
+    - **Solution**: Verify `API_BASE_URL` environment variable and Connected App callback URL match exactly
+
+2. **"Error 400: invalid_client_id"**
+
+    - **Cause**: Incorrect Consumer Key or app not properly saved
+    - **Solution**: Double-check Consumer Key and wait for Connected App to propagate (up to 10 minutes)
+
+3. **"Access Denied" during authorization**
+    - **Cause**: User doesn't have permission or app not approved
+    - **Solution**: Check Connected App policies and user permissions
+
+### OAuth Flow Issues
+
+1. **Popup Blocked**
+
+    - **Cause**: Browser blocking OAuth popup
+    - **Solution**: Allow popups for AnswerAI domain
+
+2. **Token Not Saving**
+
+    - **Cause**: Callback not reaching AnswerAI properly
+    - **Solution**: Check network connectivity and callback URL configuration
+
+3. **Refresh Token Issues**
+    - **Cause**: Token revoked or expired
+    - **Solution**: Re-authorize the credential through the OAuth flow
+
+### Permission Issues
+
+1. **Insufficient Permissions**
+
+    - **Cause**: User doesn't have required Salesforce permissions
+    - **Solution**: Grant user appropriate permissions in Salesforce
+
+2. **Scope Limitations**
+    - **Cause**: Connected App scopes too restrictive
+    - **Solution**: Add required scopes to Connected App configuration
+
+## Advanced Configuration
+
+### Custom Scopes
+
+If you need additional Salesforce API access:
+
+1. **Add Scopes to Connected App**
+
+    - Edit the Connected App in Salesforce
+    - Add required OAuth scopes
+    - Save and wait for propagation
+
+2. **Update Documentation**
+    - Document any additional scopes for your users
+    - Provide clear explanations of why scopes are needed
+
+### Multi-Environment Setup
+
+For multiple environments (dev, staging, production):
+
+1. **Separate Connected Apps**
+
+    - Create separate Connected Apps for each environment
+    - Use different callback URLs for each environment
+    - Maintain separate client credentials
+
+2. **Environment-Specific Variables**
+    - Use different environment variables per environment
+    - Ensure callback URLs match the deployed environment
+
+### Enterprise Considerations
+
+1. **User Management**
+
+    - Consider user onboarding process
+    - Provide clear documentation for end users
+    - Set up support processes for OAuth issues
+
+2. **Compliance**
+    - Ensure OAuth setup meets organizational security requirements
+    - Consider audit logging for OAuth activities
+    - Document data access patterns for compliance
+
+## Getting Help
+
+### Salesforce Resources
+
+-   [Salesforce OAuth Documentation](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_web_server_flow.htm)
+-   [Connected App Setup Guide](https://help.salesforce.com/s/articleView?id=sf.connected_app_create.htm)
+-   [OAuth Troubleshooting](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_troubleshoot.htm)
+
+### AnswerAI Support
+
+-   Check AnswerAI application logs for OAuth errors
+-   Verify environment variables are correctly set
+-   Test in a development environment first
+
+---
+
+**Next Steps:** Once OAuth is configured, you can set up specific Salesforce integrations:
+
+-   [Salesforce Personal OAuth MCP Server](../../sidekick-studio/chatflows/tools-mcp/salesforce-personal-oauth-mcp.md)
+-   [Salesforce API Credentials](../../sidekick-studio/credentials/README.md)

--- a/packages/docs/docs/sidekick-studio/chatflows/tools-mcp/README.md
+++ b/packages/docs/docs/sidekick-studio/chatflows/tools-mcp/README.md
@@ -23,7 +23,8 @@ Answer Agent includes the following MCP integrations:
 
 -   [AnswerAgent MCP](./answeragent-mcp.md) - Manage chatflows, document stores, assistants, and tools (Zero configuration required)
 -   [Contentful](./contentful-mcp.md) - Manage content in Contentful CMS
--   [Salesforce](./salesforce-mcp.md) - Interact with Salesforce CRM and database
+-   [Salesforce](./salesforce-mcp.md) - Interact with Salesforce CRM and database using client credentials
+-   [Salesforce Personal OAuth](./salesforce-personal-oauth-mcp.md) - Interact with Salesforce using individual user OAuth credentials
 -   [Jira](./jira-mcp.md) - Work with Jira issues and projects
 -   [Slack](./slack-mcp.md) - Send messages and interact with Slack
 -   [Confluence](./confluence-mcp.md) - Query and update Confluence pages

--- a/packages/docs/docs/sidekick-studio/chatflows/tools-mcp/salesforce-personal-oauth-mcp.md
+++ b/packages/docs/docs/sidekick-studio/chatflows/tools-mcp/salesforce-personal-oauth-mcp.md
@@ -1,0 +1,705 @@
+---
+sidebar_position: 3
+title: Salesforce Personal OAuth MCP
+description: Use Salesforce Personal OAuth MCP to interact with Salesforce CRM using individual user credentials
+---
+
+# Salesforce Personal OAuth MCP Server Documentation
+
+## Introduction
+
+The Salesforce Personal OAuth MCP (Model Context Protocol) Server enables Answer Agent to interact with Salesforce data using individual user OAuth credentials. This integration provides secure, user-specific access to Salesforce objects and records through natural language, with each user maintaining control over their own authentication tokens.
+
+### Personal OAuth vs Client Credentials
+
+| **Personal OAuth MCP**         | **Client Credentials MCP**        |
+| ------------------------------ | --------------------------------- |
+| Individual user authentication | Organization-wide authentication  |
+| User-managed refresh tokens    | Shared client credentials         |
+| User grants permissions        | Admin configures permissions      |
+| Secure, isolated access        | Broader system access             |
+| OAuth 2.0 Personal flow        | OAuth 2.0 Client Credentials flow |
+
+## Prerequisites
+
+Before using the Salesforce Personal OAuth MCP, ensure you have:
+
+1. **Salesforce Connected App** configured for Personal OAuth
+2. **Environment variables** set up for OAuth configuration
+3. **Salesforce Personal OAuth credential** created in Answer Agent
+4. **Appropriate Salesforce permissions** for the operations you want to perform
+
+## Setting Up Salesforce Personal OAuth Credentials
+
+### Step 1: Configure OAuth Environment Variables
+
+Ensure your Answer Agent instance has the following environment variables configured:
+
+```bash
+# Salesforce Personal OAuth Configuration
+SALESFORCE_CLIENT_ID=your_consumer_key_here
+SALESFORCE_CLIENT_SECRET=your_consumer_secret_here
+SALESFORCE_INSTANCE_URL=https://your-domain.my.salesforce.com
+
+# API Base URL (for OAuth callbacks)
+API_BASE_URL=https://yourdomain.com/api/v1
+```
+
+### Step 2: Create Personal OAuth Credential
+
+1. **Navigate to Credentials**
+
+    - In Answer Agent, go to the Credentials section
+    - Click **Add Credential**
+
+2. **Select Salesforce OAuth**
+
+    - Choose **Salesforce OAuth** from the credential types
+    - This is the personal OAuth credential, not the "Salesforce API" credential
+
+3. **Configure and Authorize**
+    - **Credential Name**: Give it a descriptive name
+    - **Client ID**: Your Salesforce Consumer Key
+    - **Client Secret**: Your Salesforce Consumer Secret
+    - **Instance URL**: Your Salesforce instance URL
+    - Click **Authorize with Salesforce**
+    - Complete the OAuth flow to grant permissions
+
+For detailed setup instructions, see the [Salesforce Personal OAuth Setup Guide](../../../developers/authorization/salesforce-oauth.md).
+
+## Configuration in Answer Agent
+
+### Adding Salesforce Personal OAuth MCP to Your Flow
+
+1. **Add MCP Node**
+
+    - In your chatflow or agentflow, add a new node
+    - Navigate to **Tools** > **MCP Servers**
+    - Select **Salesforce Personal OAuth MCP**
+
+2. **Configure Credential**
+
+    - In the **Connect Credential** field, select your Salesforce OAuth credential
+    - The node will automatically connect to the published MCP server
+
+3. **Select Available Actions**
+    - The node will load available Salesforce operations
+    - Choose the actions you want to enable for your flow
+    - Available actions are dynamically loaded from the MCP server
+
+### MCP Server Configuration
+
+The Salesforce Personal OAuth MCP uses the published MCP server package with the following configuration:
+
+```json
+{
+    "SALESFORCE_CONNECTION_TYPE": "OAuth_2.0_Personal",
+    "SALESFORCE_CLIENT_ID": "from_environment_variable",
+    "SALESFORCE_CLIENT_SECRET": "from_environment_variable",
+    "SALESFORCE_INSTANCE_URL": "from_environment_variable",
+    "SALESFORCE_REFRESH_TOKEN": "from_user_credential"
+}
+```
+
+## Available Tools
+
+The Salesforce Personal OAuth MCP provides the same comprehensive set of tools as the standard Salesforce MCP, but with user-specific authentication:
+
+### 1. salesforce_search_objects
+
+**Description**: Search for Salesforce standard and custom objects by name pattern.
+
+**Schema**:
+
+```json
+{
+    "searchPattern": "string" // Search pattern to find objects
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Find API names of objects to use in code
+-   **Publishers**: Discover available objects for content creation
+
+### 2. salesforce_describe_object
+
+**Description**: Get detailed schema metadata including all fields, relationships, and field properties of any Salesforce object.
+
+**Schema**:
+
+```json
+{
+    "objectName": "string" // API name of the object (e.g., 'Account', 'Contact', 'Custom_Object__c')
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Understand field types and relationships for integration development
+-   **Publishers**: Research data structures for documentation creation
+
+### 3. salesforce_query_records
+
+**Description**: Query records from any Salesforce object using SOQL, including relationship queries.
+
+**Schema**:
+
+```json
+{
+  "objectName": "string", // API name of the object to query
+  "fields": ["string"], // List of fields to retrieve, including relationship fields
+  "whereClause": "string", // Optional WHERE clause
+  "orderBy": "string", // Optional ORDER BY clause
+  "limit": number // Optional maximum number of records to return
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Test queries and validate data access patterns
+-   **Publishers**: Extract real data examples for documentation
+
+### 4. salesforce_dml_records
+
+**Description**: Perform data manipulation operations on Salesforce records (insert, update, delete, upsert).
+
+**Schema**:
+
+```json
+{
+    "operation": "string", // "insert", "update", "delete", or "upsert"
+    "objectName": "string", // API name of the object
+    "records": [{}], // Array of records to process
+    "externalIdField": "string" // Optional external ID field name for upsert operations
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Test data manipulation operations and validate business logic
+-   **Publishers**: Create sample data for demos or documentation
+
+### 5. salesforce_manage_object
+
+**Description**: Create new custom objects or modify existing ones in Salesforce.
+
+**Schema**:
+
+```json
+{
+    "operation": "string", // "create" or "update"
+    "objectName": "string", // API name for the object (without __c suffix)
+    "label": "string", // Label for the object
+    "pluralLabel": "string", // Plural label for the object
+    "description": "string", // Optional description
+    "nameFieldLabel": "string", // Optional label for the name field
+    "nameFieldType": "string", // Optional type of the name field ("Text" or "AutoNumber")
+    "nameFieldFormat": "string", // Optional display format for AutoNumber field
+    "sharingModel": "string" // Optional sharing model ("ReadWrite", "Read", "Private", "ControlledByParent")
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Create custom objects for application development
+-   **Publishers**: Set up demonstration environments for tutorials
+
+### 6. salesforce_manage_field
+
+**Description**: Create new custom fields or modify existing fields on any Salesforce object.
+
+**Schema**:
+
+```json
+{
+  "operation": "string", // "create" or "update"
+  "objectName": "string", // API name of the object to add/modify the field
+  "fieldName": "string", // API name for the field (without __c suffix)
+  "label": "string", // Optional label for the field
+  "type": "string", // Field type (required for create)
+  "required": boolean, // Optional whether the field is required
+  "unique": boolean, // Optional whether the field value must be unique
+  "externalId": boolean, // Optional whether the field is an external ID
+  "length": number, // Optional length for text fields
+  "precision": number, // Optional precision for numeric fields
+  "scale": number, // Optional scale for numeric fields
+  "referenceTo": "string", // Optional API name of the object to reference
+  "relationshipLabel": "string", // Optional label for the relationship
+  "relationshipName": "string", // Optional API name for the relationship
+  "deleteConstraint": "string", // Optional delete constraint for Lookup fields
+  "picklistValues": [{ "label": "string", "isDefault": boolean }], // Optional values for Picklist fields
+  "description": "string" // Optional description of the field
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Add custom fields to objects for application functionality
+-   **Publishers**: Create demo fields for tutorial environments
+
+### 7. salesforce_search_all
+
+**Description**: Search across multiple Salesforce objects using SOSL (Salesforce Object Search Language).
+
+**Schema**:
+
+```json
+{
+  "searchTerm": "string", // Text to search for (supports wildcards * and ?)
+  "searchIn": "string", // Optional which fields to search in
+  "objects": [{
+    "name": "string", // API name of the object
+    "fields": ["string"], // Fields to return for this object
+    "where": "string", // Optional WHERE clause for this object
+    "orderBy": "string", // Optional ORDER BY clause for this object
+    "limit": number // Optional maximum number of records to return
+  }],
+  "withClauses": [{
+    "type": "string", // WITH clause type
+    "value": "string", // Optional value for the WITH clause
+    "fields": ["string"] // Optional fields for SNIPPET clause
+  }],
+  "updateable": boolean, // Optional return only updateable records
+  "viewable": boolean // Optional return only viewable records
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Find records across multiple objects for integration testing
+-   **Publishers**: Gather comprehensive data examples across the platform
+
+### 8. salesforce_read_apex
+
+**Description**: Read Apex classes from Salesforce.
+
+**Schema**:
+
+```json
+{
+  "className": "string", // Optional name of a specific Apex class to read
+  "namePattern": "string", // Optional pattern to match Apex class names
+  "includeMetadata": boolean // Optional whether to include metadata about the Apex classes
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Review existing code for debugging or enhancement
+-   **Publishers**: Extract code examples for documentation
+
+### 9. salesforce_write_apex
+
+**Description**: Create or update Apex classes in Salesforce.
+
+**Schema**:
+
+```json
+{
+    "operation": "string", // "create" or "update"
+    "className": "string", // Name of the Apex class to create or update
+    "apiVersion": "string", // Optional API version for the Apex class
+    "body": "string" // Full body of the Apex class
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Deploy code changes or create new classes
+-   **Publishers**: Create example implementations for tutorials
+
+### 10. salesforce_read_apex_trigger
+
+**Description**: Read Apex triggers from Salesforce.
+
+**Schema**:
+
+```json
+{
+  "triggerName": "string", // Optional name of a specific Apex trigger to read
+  "namePattern": "string", // Optional pattern to match Apex trigger names
+  "includeMetadata": boolean // Optional whether to include metadata about the Apex triggers
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Analyze existing triggers for debugging or enhancement
+-   **Publishers**: Extract trigger examples for documentation
+
+### 11. salesforce_write_apex_trigger
+
+**Description**: Create or update Apex triggers in Salesforce.
+
+**Schema**:
+
+```json
+{
+    "operation": "string", // "create" or "update"
+    "triggerName": "string", // Name of the Apex trigger to create or update
+    "objectName": "string", // Optional name of the Salesforce object the trigger is for
+    "apiVersion": "string", // Optional API version for the Apex trigger
+    "body": "string" // Full body of the Apex trigger
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Deploy trigger changes or create new triggers
+-   **Publishers**: Create example trigger implementations for tutorials
+
+### 12. salesforce_execute_anonymous
+
+**Description**: Execute anonymous Apex code in Salesforce.
+
+**Schema**:
+
+```json
+{
+    "apexCode": "string", // Apex code to execute anonymously
+    "logLevel": "string" // Optional log level for debug logs
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Test code snippets without deploying
+-   **Publishers**: Demonstrate code functionality in real-time
+
+### 13. salesforce_manage_debug_logs
+
+**Description**: Manage debug logs for Salesforce users.
+
+**Schema**:
+
+```json
+{
+  "operation": "string", // "enable", "disable", or "retrieve"
+  "username": "string", // Username of the Salesforce user
+  "logLevel": "string", // Optional log level for debug logs
+  "expirationTime": number, // Optional minutes until expiration
+  "limit": number, // Optional maximum number of logs to retrieve
+  "logId": "string", // Optional ID of a specific log to retrieve
+  "includeBody": boolean // Optional whether to include the full log content
+}
+```
+
+**Use Cases**:
+
+-   **Developers**: Set up and monitor debugging sessions
+-   **Publishers**: Capture detailed system behavior for documentation
+
+## Common Use Case Examples
+
+### For Developers Using Personal OAuth
+
+1. **Personal Data Exploration**:
+
+    ```
+    "Show me all my personal contacts with their email addresses"
+    ```
+
+2. **User-Specific Querying**:
+
+    ```
+    "Find all opportunities I own that are closing this month"
+    ```
+
+3. **Personal Workspace Setup**:
+
+    ```
+    "Create a custom object for my personal project tracking"
+    ```
+
+4. **Individual Testing**:
+
+    ```
+    "Execute anonymous code to test my new validation logic"
+    ```
+
+5. **Personal Debugging**:
+    ```
+    "Enable debug logs for my user account and show recent API calls"
+    ```
+
+### For Publishers Using Personal OAuth
+
+1. **Content Research with Personal Access**:
+
+    ```
+    "Find all custom objects I have access to and describe their fields"
+    ```
+
+2. **Real User Examples**:
+
+    ```
+    "Show me examples of how Accounts relate to my accessible Contacts"
+    ```
+
+3. **Personal Demo Environment**:
+
+    ```
+    "Create a demo Project__c object in my personal developer org"
+    ```
+
+4. **User-Specific Documentation**:
+
+    ```
+    "What picklist values do I have access to for Lead Status?"
+    ```
+
+5. **Personal Workflow Examples**:
+    ```
+    "Create example Apex code that works with my current user permissions"
+    ```
+
+## Personal OAuth Advantages
+
+### Security Benefits
+
+1. **Individual Access Control**
+
+    - Each user controls their own authentication
+    - No shared credentials between users
+    - Users can revoke access at any time
+
+2. **Granular Permissions**
+
+    - Access limited to user's Salesforce permissions
+    - No over-privileged system access
+    - Audit trails tied to individual users
+
+3. **Token Security**
+    - Refresh tokens stored encrypted per user
+    - Automatic token refresh handling
+    - Secure token revocation process
+
+### User Experience Benefits
+
+1. **Personalized Access**
+
+    - Users see only their accessible data
+    - Operations respect user permissions
+    - Natural user-specific workflows
+
+2. **Easy Onboarding**
+
+    - Standard OAuth flow familiar to users
+    - No admin intervention required for user setup
+    - Self-service credential management
+
+3. **Flexible Usage**
+    - Users can connect multiple Salesforce orgs
+    - Different users can have different access levels
+    - Individual customization of integrations
+
+## Best Practices for Personal OAuth
+
+### For Administrators
+
+1. **Connected App Configuration**
+
+    - Set appropriate OAuth scopes for your use case
+    - Configure IP restrictions if needed
+    - Monitor OAuth usage and patterns
+
+2. **User Education**
+
+    - Provide clear documentation for end users
+    - Explain what permissions are being requested
+    - Set up support processes for OAuth issues
+
+3. **Security Monitoring**
+    - Monitor OAuth token usage
+    - Set up alerts for unusual activity
+    - Regularly review Connected App settings
+
+### For End Users
+
+1. **Permission Awareness**
+
+    - Understand what permissions you're granting
+    - Regularly review connected applications
+    - Revoke access when no longer needed
+
+2. **Credential Management**
+
+    - Use descriptive names for your credentials
+    - Keep track of which orgs are connected
+    - Re-authorize if you encounter issues
+
+3. **Data Security**
+    - Be cautious with data modification operations
+    - Test in sandbox environments when possible
+    - Monitor your Salesforce audit logs
+
+### For Developers
+
+1. **Error Handling**
+
+    - Handle OAuth token expiration gracefully
+    - Provide clear error messages to users
+    - Implement retry logic for token refresh
+
+2. **Testing**
+
+    - Test with different user permission levels
+    - Verify OAuth flow works correctly
+    - Test token refresh scenarios
+
+3. **Documentation**
+    - Document required Salesforce permissions
+    - Provide troubleshooting guides
+    - Keep OAuth setup instructions current
+
+## Troubleshooting Personal OAuth Issues
+
+### Common User Issues
+
+1. **Authorization Failures**
+
+    - **Symptom**: OAuth popup fails or shows errors
+    - **Solutions**:
+        - Check browser popup blockers
+        - Verify Connected App configuration
+        - Ensure environment variables are correct
+
+2. **Permission Denied Errors**
+
+    - **Symptom**: MCP operations fail with permission errors
+    - **Solutions**:
+        - Verify user has required Salesforce permissions
+        - Check Connected App OAuth scopes
+        - Ensure user is in correct Salesforce org
+
+3. **Token Refresh Problems**
+    - **Symptom**: Authentication works initially but fails later
+    - **Solutions**:
+        - Re-authorize the credential
+        - Check refresh token policy in Connected App
+        - Verify token hasn't been revoked
+
+### Technical Troubleshooting
+
+1. **Environment Variable Issues**
+
+    - **Symptom**: OAuth flow fails to start
+    - **Solutions**:
+        - Verify all required environment variables are set
+        - Check API_BASE_URL matches your deployment
+        - Ensure SALESFORCE_INSTANCE_URL is correct
+
+2. **Callback URL Problems**
+
+    - **Symptom**: OAuth flow completes but doesn't return to Answer Agent
+    - **Solutions**:
+        - Verify callback URL in Connected App
+        - Check network connectivity
+        - Ensure API_BASE_URL is accessible
+
+3. **MCP Server Connection Issues**
+    - **Symptom**: MCP actions don't load or fail to execute
+    - **Solutions**:
+        - Check MCP server logs
+        - Verify Salesforce connectivity
+        - Test with basic MCP operations first
+
+## Advanced Configuration
+
+### Multi-Org Support
+
+Users can connect to multiple Salesforce organizations:
+
+1. **Create Separate Credentials**
+
+    - Create different OAuth credentials for each org
+    - Use descriptive names (e.g., "Production Org", "Sandbox Org")
+    - Configure appropriate Connected Apps in each org
+
+2. **Org-Specific Workflows**
+    - Create separate flows for different orgs
+    - Use org-specific credentials in each flow
+    - Document which org each flow connects to
+
+### Custom Scopes and Permissions
+
+For specialized use cases:
+
+1. **Additional OAuth Scopes**
+
+    - Add custom scopes to Connected App
+    - Update user documentation
+    - Test with new permissions
+
+2. **Permission Set Management**
+    - Create specific permission sets for Answer Agent users
+    - Assign appropriate object and field permissions
+    - Document required permissions for different use cases
+
+### Integration with Other Systems
+
+1. **Workflow Automation**
+
+    - Combine with other MCP servers
+    - Create multi-system workflows
+    - Maintain user authentication across systems
+
+2. **Data Synchronization**
+    - Use personal OAuth for user-specific data sync
+    - Respect user permissions in sync operations
+    - Maintain audit trails for data changes
+
+## Migration from Client Credentials
+
+If migrating from the standard Salesforce MCP to Personal OAuth:
+
+### For Administrators
+
+1. **Gradual Migration**
+
+    - Set up Personal OAuth alongside existing system
+    - Test with select users first
+    - Gradually migrate workflows
+
+2. **User Training**
+    - Provide migration documentation
+    - Offer training sessions
+    - Set up support channels
+
+### For Users
+
+1. **Credential Replacement**
+
+    - Create new Personal OAuth credentials
+    - Update existing workflows to use new credentials
+    - Test thoroughly before removing old credentials
+
+2. **Permission Verification**
+    - Verify you have necessary Salesforce permissions
+    - Test all required operations
+    - Document any permission changes needed
+
+## Getting Help
+
+### Documentation Resources
+
+-   [Salesforce Personal OAuth Setup Guide](../../../developers/authorization/salesforce-oauth.md)
+-   [Salesforce OAuth Documentation](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_web_server_flow.htm)
+-   [Answer Agent Credentials Guide](../../credentials/README.md)
+
+### Support Channels
+
+-   Check Answer Agent application logs for OAuth errors
+-   Review Salesforce Setup Audit Trail for OAuth activities
+-   Test OAuth flow in Salesforce sandbox environment
+
+### Community Resources
+
+-   [Salesforce Developer Community](https://developer.salesforce.com/forums)
+-   [OAuth Best Practices](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_best_practices.htm)
+-   [MCP Server Documentation](https://github.com/tsmztech/mcp-server-salesforce)
+
+---
+
+The Salesforce Personal OAuth MCP Server provides a secure, user-controlled way to integrate Salesforce data with Answer Agent. By using individual OAuth credentials, users maintain control over their data access while benefiting from the full power of Salesforce integration through natural language interactions.

--- a/packages/docs/docs/sidekick-studio/credentials/api-credentials.md
+++ b/packages/docs/docs/sidekick-studio/credentials/api-credentials.md
@@ -552,13 +552,25 @@ Authentication for Notion.
 
 ### Salesforce API
 
-Authentication for Salesforce.
+Authentication for Salesforce using client credentials (system-wide access).
 
 -   **How to obtain**: Refer to [official guide](https://developer.salesforce.com/docs/atlas.en-us.api_analytics.meta/api_analytics/sforce_analytics_rest_api_get_started.htm) on how to get your Salesforce API key.
 -   **Inputs**:
     -   Salesforce Client ID (password)
     -   Salesforce Client Secret (password)
     -   Salesforce Instance (e.g., https://na1.salesforce.com)
+
+### Salesforce Personal OAuth
+
+Authentication for Salesforce using individual user OAuth credentials (personal access).
+
+-   **How to obtain**: Follow the [Salesforce Personal OAuth Setup Guide](../../developers/authorization/salesforce-oauth.md) to create a Connected App and configure OAuth flow.
+-   **Inputs**:
+    -   Refresh Token (password) - Automatically populated after OAuth authorization
+-   **Setup Requirements**:
+    -   Salesforce Connected App configured for OAuth 2.0
+    -   Environment variables: `SALESFORCE_CLIENT_ID`, `SALESFORCE_CLIENT_SECRET`, `SALESFORCE_INSTANCE_URL`
+    -   OAuth authorization flow completed by end user
 
 ### Slack API
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,6 +839,9 @@ importers:
             '@answerai/jira-mcp':
                 specifier: ^1.0.2
                 version: 1.0.2
+            '@answerai/salesforce-mcp':
+                specifier: ^0.1.0
+                version: 0.1.0
             '@apidevtools/json-schema-ref-parser':
                 specifier: ^12.0.2
                 version: 12.0.2
@@ -2353,6 +2356,10 @@ packages:
     '@answerai/jira-mcp@1.0.2':
         resolution: { integrity: sha512-nLdQY6Kfcj/X0u/l+ehG+0bUIyOrPLDIJT2F7eg3ceusgOZpmdUEG02G5KjVDpC4q6SiNxFLxIGuGqupC4QNMw== }
         engines: { node: '>=18.0.0' }
+        hasBin: true
+
+    '@answerai/salesforce-mcp@0.1.0':
+        resolution: { integrity: sha512-aTxjb7DvQfCk3fXOaLclwA2jBD8qQR9kAY+Gsqhg1uSEUPunElAeFmyAbgpVx3zEJIRTH2XtNDZosVyCU2Eibw== }
         hasBin: true
 
     '@anthropic-ai/sdk@0.21.1':
@@ -24113,6 +24120,12 @@ snapshots:
             typescript: 5.8.3
         transitivePeerDependencies:
             - supports-color
+
+    '@answerai/salesforce-mcp@0.1.0':
+        dependencies:
+            '@modelcontextprotocol/sdk': 0.5.0
+            dotenv: 16.5.0
+            jsforce: 1.11.1
 
     '@anthropic-ai/sdk@0.21.1(encoding@0.1.13)':
         dependencies:


### PR DESCRIPTION
- Add complete Salesforce Personal OAuth setup guide for developers
- Create detailed MCP server documentation with usage examples
- Update API credentials reference with OAuth credential info
- Add Salesforce Personal OAuth MCP to tools index
- Include security best practices and troubleshooting guides
- Distinguish personal OAuth from system-wide client credentials
- Cover published MCP server package configuration