### PR TITLE
Address code review feedback for QuickSetup

### DIFF
--- a/packages-answers/types/src/index.ts
+++ b/packages-answers/types/src/index.ts
@@ -714,3 +714,14 @@ export interface TextInputConfig {
     placeholder: string
     sendButtonColor: string
 }
+
+export interface CredentialInfo {
+    nodeId: string
+    nodeName: string
+    credentialType: string
+    parameterName: string
+    label: string
+    isOptional: boolean
+    isAssigned: boolean
+    assignedCredentialId: string | null
+}

--- a/packages-answers/utils/src/extractAllCredentials.ts
+++ b/packages-answers/utils/src/extractAllCredentials.ts
@@ -1,11 +1,12 @@
 import { INodeParams } from '@flowise/components'
+import { CredentialInfo } from 'types'
 
 /**
  * Extract all credentials (assigned and unassigned) from flow data
  * @param {string|object} flowData - Flow data as JSON string or object
- * @returns {any[]} Array of all credentials with assignment status
+ * @returns {CredentialInfo[]} Array of all credentials with assignment status
  */
-export const extractAllCredentials = (flowData: string | any) => {
+export const extractAllCredentials = (flowData: string | any): CredentialInfo[] => {
     try {
         // Parse flow data if it's a string
         const flow = typeof flowData === 'string' ? JSON.parse(flowData) : flowData
@@ -14,7 +15,7 @@ export const extractAllCredentials = (flowData: string | any) => {
             return []
         }
 
-        const allCredentials: any[] = []
+        const allCredentials: CredentialInfo[] = []
         const credentialTypes = new Set<string>()
 
         // Define commonly needed optional credentials that should be offered

--- a/packages/ui/src/hooks/useSidekickWithCredentials.js
+++ b/packages/ui/src/hooks/useSidekickWithCredentials.js
@@ -39,7 +39,9 @@ export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) 
         [sidekickId, mutate]
     )
 
-    console.log('[useSidekickWithCredentials] sidekick', { sidekickId, sidekick, forceQuickSetup, error })
+    if (process.env.NODE_ENV !== 'production') {
+        console.log('[useSidekickWithCredentials] sidekick', { sidekickId, sidekick, forceQuickSetup, error })
+    }
     return {
         sidekick,
         isLoading,

--- a/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
+++ b/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
@@ -396,6 +396,11 @@ const UnifiedCredentialsModal = ({ show, missingCredentials, onAssign, onSkip, o
             </DialogTitle>
 
             <DialogContent sx={{ padding: 3, minHeight: '400px' }}>
+                {isQuickSetupMode && (
+                    <Typography variant='caption' color='text.secondary' sx={{ mb: 2 }}>
+                        Quick Setup mode enabled - all credentials are shown
+                    </Typography>
+                )}
                 {loading ? (
                     <Box display='flex' justifyContent='center' alignItems='center' minHeight='200px'>
                         <CircularProgress />


### PR DESCRIPTION
## Summary
- create `CredentialInfo` interface
- use `CredentialInfo` in credential extraction helper
- hide credential hook debug logs in production
- show quick setup indicator in credentials modal

## Testing
- `pnpm lint` *(fails: 1334 problems)*
- `pnpm test` *(fails to execute pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_6882dad1582483318d3af10e00ff25dc