### PR TITLE
Fix/enhance sidekick setup functionality

### DIFF
--- a/apps/web/app/api/sidekicks/[id]/route.ts
+++ b/apps/web/app/api/sidekicks/[id]/route.ts
@@ -20,11 +20,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     if (!session?.user?.email) return respond401()
 
     try {
-        // Parse URL to get query parameters
-        const url = new URL(req.url)
-        const isQuickSetup = url.searchParams.get('QuickSetup') === 'true'
-
-        const sidekick = await findSidekickById(user, params.id, isQuickSetup)
+        const sidekick = await findSidekickById(user, params.id)
 
         if (!sidekick) {
             return NextResponse.json({ error: 'Sidekick not found' }, { status: 404 })

--- a/apps/web/app/api/sidekicks/[id]/route.ts
+++ b/apps/web/app/api/sidekicks/[id]/route.ts
@@ -20,7 +20,11 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     if (!session?.user?.email) return respond401()
 
     try {
-        const sidekick = await findSidekickById(user, params.id)
+        // Parse URL to get query parameters
+        const url = new URL(req.url)
+        const isQuickSetup = url.searchParams.get('QuickSetup') === 'true'
+
+        const sidekick = await findSidekickById(user, params.id, isQuickSetup)
 
         if (!sidekick) {
             return NextResponse.json({ error: 'Sidekick not found' }, { status: 404 })

--- a/packages-answers/types/src/index.ts
+++ b/packages-answers/types/src/index.ts
@@ -714,3 +714,14 @@ export interface TextInputConfig {
     placeholder: string
     sendButtonColor: string
 }
+
+export interface CredentialInfo {
+    nodeId: string
+    nodeName: string
+    credentialType: string
+    parameterName: string
+    label: string
+    isOptional: boolean
+    isAssigned: boolean
+    assignedCredentialId: string | null
+}

--- a/packages-answers/ui/src/AssistantInfoCard.tsx
+++ b/packages-answers/ui/src/AssistantInfoCard.tsx
@@ -16,6 +16,7 @@ import { useTheme } from '@mui/material/styles'
 import { baseURL } from '@/store/constant'
 import { useNavigate, useNavigationState } from '@/utils/navigation'
 import { useUser } from '@auth0/nextjs-auth0/client'
+import { useRouter } from 'next/navigation'
 
 interface AssistantInfoCardProps {
     sidekick?: Sidekick
@@ -65,6 +66,7 @@ const AssistantInfoCard = ({
     const navigate = useNavigate()
     const [, setNavigationState] = useNavigationState()
     const { user } = useUser()
+    const router = useRouter()
 
     const [images, setImages] = useState<string[]>([])
     const [nodeTypes, setNodeTypes] = useState<string[]>([])
@@ -321,13 +323,10 @@ const AssistantInfoCard = ({
                                 <WhiteIconButton
                                     size='small'
                                     onClick={() => {
-                                        if (needsSetup) {
-                                            const currentUrl = new URL(window.location.href)
-                                            currentUrl.searchParams.set('QuickSetup', 'true')
-                                            window.history.pushState({}, '', currentUrl.toString())
-                                            // Trigger a re-render to show the modal
-                                            window.dispatchEvent(new Event('popstate'))
-                                        }
+                                        const searchParams = new URLSearchParams(window.location.search)
+                                        searchParams.set('QuickSetup', 'true')
+                                        const newUrl = `${window.location.pathname}?${searchParams.toString()}`
+                                        router.replace(newUrl)
                                     }}
                                     sx={{
                                         color: needsSetup ? theme.palette.warning.main : theme.palette.success.main,

--- a/packages-answers/ui/src/ChatDetail.tsx
+++ b/packages-answers/ui/src/ChatDetail.tsx
@@ -253,21 +253,7 @@ export const ChatDetail = ({
                                 <iframe src={embeddedUrl} style={{ flex: 1, border: 'none' }} title='Embedded Form' allowFullScreen />
                             </Box>
                         )}
-                        {selectedSidekick?.id && (
-                            <SidekickSetupModal
-                                sidekickId={selectedSidekick.id}
-                                onComplete={() => {
-                                    const searchParams = new URLSearchParams(window.location.search)
-                                    if (searchParams.get('QuickSetup') === 'true') {
-                                        searchParams.delete('QuickSetup')
-                                        const newUrl = chat?.id
-                                            ? `/chat/${chat.id}${searchParams.toString() ? '?' + searchParams.toString() : ''}`
-                                            : `${window.location.pathname}${searchParams.toString() ? '?' + searchParams.toString() : ''}`
-                                        router.replace(newUrl)
-                                    }
-                                }}
-                            />
-                        )}
+                        {selectedSidekick?.id && <SidekickSetupModal sidekickId={selectedSidekick.id} />}
                     </Box>
                 </Box>
 

--- a/packages-answers/utils/src/extractAllCredentials.ts
+++ b/packages-answers/utils/src/extractAllCredentials.ts
@@ -1,0 +1,79 @@
+import { INodeParams } from '@flowise/components'
+
+/**
+ * Extract all credentials (assigned and unassigned) from flow data
+ * @param {string|object} flowData - Flow data as JSON string or object
+ * @returns {any[]} Array of all credentials with assignment status
+ */
+export const extractAllCredentials = (flowData: string | any) => {
+    try {
+        // Parse flow data if it's a string
+        const flow = typeof flowData === 'string' ? JSON.parse(flowData) : flowData
+
+        if (!flow.nodes || !Array.isArray(flow.nodes)) {
+            return []
+        }
+
+        const allCredentials: any[] = []
+        const credentialTypes = new Set<string>()
+
+        // Define commonly needed optional credentials that should be offered
+        const importantOptionalCredentials = ['redisCacheApi', 'redisCacheUrlApi', 'upstashRedisApi', 'upstashRedisMemoryApi']
+
+        // Iterate through all nodes
+        flow.nodes.forEach((node: any) => {
+            if (node.data && node.data.inputParams) {
+                // Find credential input parameters (required OR important optional ones)
+                const credentialParams = node.data.inputParams.filter((param: INodeParams) => {
+                    if (param.type !== 'credential') return false
+
+                    // Include required credentials
+                    if (!param.optional) return true
+
+                    // Include important optional credentials
+                    if (
+                        param.credentialNames &&
+                        param.credentialNames.some((name: string) => importantOptionalCredentials.includes(name))
+                    ) {
+                        return true
+                    }
+
+                    return false
+                })
+
+                credentialParams.forEach((credentialParam: INodeParams) => {
+                    // Check if credential is assigned
+                    const hasCredential =
+                        node.data.credential ||
+                        (node.data.inputs && node.data.inputs[credentialParam.name]) ||
+                        (node.data.inputs && node.data.inputs['FLOWISE_CREDENTIAL_ID'])
+
+                    // Extract credential names
+                    const credentialNames = credentialParam.credentialNames || []
+
+                    credentialNames.forEach((credentialName: string) => {
+                        credentialTypes.add(credentialName)
+
+                        const credInfo = {
+                            nodeId: node.id,
+                            nodeName: node.data.name || 'Unknown Node',
+                            credentialType: credentialName,
+                            parameterName: credentialParam.name,
+                            label: credentialParam.label || credentialParam.name,
+                            isOptional: !!credentialParam.optional,
+                            isAssigned: !!hasCredential,
+                            assignedCredentialId: hasCredential || null
+                        }
+
+                        allCredentials.push(credInfo)
+                    })
+                })
+            }
+        })
+
+        return allCredentials
+    } catch (error) {
+        console.error('Error in extractAllCredentials:', error)
+        return []
+    }
+}

--- a/packages-answers/utils/src/extractAllCredentials.ts
+++ b/packages-answers/utils/src/extractAllCredentials.ts
@@ -1,11 +1,12 @@
 import { INodeParams } from '@flowise/components'
+import { CredentialInfo } from 'types'
 
 /**
  * Extract all credentials (assigned and unassigned) from flow data
  * @param {string|object} flowData - Flow data as JSON string or object
- * @returns {any[]} Array of all credentials with assignment status
+ * @returns {CredentialInfo[]} Array of all credentials with assignment status
  */
-export const extractAllCredentials = (flowData: string | any) => {
+export const extractAllCredentials = (flowData: string | any): CredentialInfo[] => {
     try {
         // Parse flow data if it's a string
         const flow = typeof flowData === 'string' ? JSON.parse(flowData) : flowData
@@ -14,7 +15,7 @@ export const extractAllCredentials = (flowData: string | any) => {
             return []
         }
 
-        const allCredentials: any[] = []
+        const allCredentials: CredentialInfo[] = []
         const credentialTypes = new Set<string>()
 
         // Define commonly needed optional credentials that should be offered

--- a/packages-answers/utils/src/findSidekickById.ts
+++ b/packages-answers/utils/src/findSidekickById.ts
@@ -3,8 +3,9 @@ import { User } from 'types'
 import auth0 from '@utils/auth/auth0'
 import { INodeParams } from '@flowise/components'
 import { extractMissingCredentials } from './extractMissingCredentials'
+import { extractAllCredentials } from './extractAllCredentials'
 
-export async function findSidekickById(user: User, id: string) {
+export async function findSidekickById(user: User, id: string, isQuickSetup: boolean = false) {
     let token
     try {
         const { accessToken } = await auth0.getAccessToken({
@@ -84,8 +85,11 @@ export async function findSidekickById(user: User, id: string) {
         .flat()
 
     const missingCredentials = extractMissingCredentials(chatflow.flowData)
+    const allCredentials = extractAllCredentials(chatflow.flowData)
 
-    const needsSetup = missingCredentials.length > 0
+    // In QuickSetup mode, show all credentials; otherwise show only missing ones
+    const credentialsToShow = isQuickSetup ? allCredentials : missingCredentials
+    const needsSetup = isQuickSetup ? allCredentials.length > 0 : missingCredentials.length > 0
 
     return {
         id: chatflow.id || '',
@@ -102,7 +106,8 @@ export async function findSidekickById(user: User, id: string) {
         isAvailable: chatflow.isPublic || chatflow.visibility.includes('Organization'),
         isFavorite: false,
         needsSetup,
-        credentialsToShow: missingCredentials,
+        credentialsToShow,
+        allCredentials,
         constraints: {
             isSpeechToTextEnabled,
             isImageUploadAllowed,

--- a/packages/ui/src/components/SidekickSetupModal.jsx
+++ b/packages/ui/src/components/SidekickSetupModal.jsx
@@ -121,8 +121,8 @@ const SidekickSetupModal = ({ sidekickId, onComplete }) => {
         return null
     }
 
-    // For non-QuickSetup mode, only show if there are credentials to show and setup is needed
-    if (!isQuickSetup && (!needsSetup || credentialsToShow.length === 0)) {
+    // For non-QuickSetup mode, only show if there are unassigned credentials
+    if (!isQuickSetup && !needsSetup) {
         return null
     }
 

--- a/packages/ui/src/hooks/useSidekickWithCredentials.js
+++ b/packages/ui/src/hooks/useSidekickWithCredentials.js
@@ -11,12 +11,14 @@ const fetcher = async (url) => {
 }
 
 export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) => {
+    const apiUrl = sidekickId ? `/api/sidekicks/${sidekickId}${forceQuickSetup ? '?QuickSetup=true' : ''}` : null
+
     const {
         data: sidekick,
         error,
         mutate,
         isLoading
-    } = useSWR(sidekickId ? `/api/sidekicks/${sidekickId}` : null, fetcher, {
+    } = useSWR(apiUrl, fetcher, {
         revalidateOnFocus: false,
         dedupingInterval: 10000
     })
@@ -44,6 +46,6 @@ export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) 
         error,
         updateSidekick,
         needsSetup: sidekick?.needsSetup,
-        credentialsToShow: sidekick?.credentialsToShow
+        credentialsToShow: sidekick?.credentialsToShow || []
     }
 }

--- a/packages/ui/src/hooks/useSidekickWithCredentials.js
+++ b/packages/ui/src/hooks/useSidekickWithCredentials.js
@@ -11,7 +11,7 @@ const fetcher = async (url) => {
 }
 
 export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) => {
-    const apiUrl = sidekickId ? `/api/sidekicks/${sidekickId}${forceQuickSetup ? '?QuickSetup=true' : ''}` : null
+    const apiUrl = sidekickId ? `/api/sidekicks/${sidekickId}` : null
 
     const {
         data: sidekick,
@@ -39,9 +39,6 @@ export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) 
         [sidekickId, mutate]
     )
 
-    if (process.env.NODE_ENV !== 'production') {
-        console.log('[useSidekickWithCredentials] sidekick', { sidekickId, sidekick, forceQuickSetup, error })
-    }
     return {
         sidekick,
         isLoading,

--- a/packages/ui/src/hooks/useSidekickWithCredentials.js
+++ b/packages/ui/src/hooks/useSidekickWithCredentials.js
@@ -39,7 +39,9 @@ export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) 
         [sidekickId, mutate]
     )
 
-    console.log('[useSidekickWithCredentials] sidekick', { sidekickId, sidekick, forceQuickSetup, error })
+    if (process.env.NODE_ENV !== 'production') {
+        console.log('[useSidekickWithCredentials] sidekick', { sidekickId, sidekick, forceQuickSetup, error })
+    }
     return {
         sidekick,
         isLoading,

--- a/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
+++ b/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
@@ -63,7 +63,7 @@ const UnifiedCredentialsModal = ({ show, missingCredentials, onAssign, onSkip, o
 
     // Load available credentials when modal opens
     useEffect(() => {
-        if (show && missingCredentials.length > 0) {
+        if (show && (missingCredentials.length > 0 || isQuickSetupMode)) {
             const loadCredentials = async () => {
                 setLoading(true)
                 const credentialsData = {}

--- a/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
+++ b/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
@@ -396,6 +396,11 @@ const UnifiedCredentialsModal = ({ show, missingCredentials, onAssign, onSkip, o
             </DialogTitle>
 
             <DialogContent sx={{ padding: 3, minHeight: '400px' }}>
+                {isQuickSetupMode && (
+                    <Typography variant='caption' color='text.secondary' sx={{ mb: 2 }}>
+                        Quick Setup mode enabled - all credentials are shown
+                    </Typography>
+                )}
                 {loading ? (
                     <Box display='flex' justifyContent='center' alignItems='center' minHeight='200px'>
                         <CircularProgress />

--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -484,12 +484,10 @@ const CanvasHeader = forwardRef(({ chatflow, isAgentCanvas, isAgentflowV2, handl
                                 }
                             }}
                             onClick={() => {
-                                if (needsSetup) {
-                                    const currentUrl = new URL(window.location.href)
-                                    currentUrl.searchParams.set('QuickSetup', 'true')
-                                    window.history.pushState({}, '', currentUrl.toString())
-                                    window.dispatchEvent(new Event('popstate'))
-                                }
+                                const currentUrl = new URL(window.location.href)
+                                currentUrl.searchParams.set('QuickSetup', 'true')
+                                window.history.pushState({}, '', currentUrl.toString())
+                                window.dispatchEvent(new Event('popstate'))
                             }}
                         >
                             {needsSetup ? <IconAlertCircle stroke={1.5} size='1.3rem' /> : <IconCircleCheck stroke={1.5} size='1.3rem' />}


### PR DESCRIPTION
# 🛠️ Enhance Sidekick QuickSetup Functionality
This PR significantly improves the Sidekick setup experience by adding and refining QuickSetup support for credential assignment and initialization.

## Key Changes


### QuickSetup Mode (triggered with ?QuickSetup=true in the URL):

UI and API will show all required and important optional credentials, not just missing ones.
Users can set up or review all relevant Sidekick credentials in a single modal flow.


### Backend/API Enhancements:

The Sidekick API recognizes the QuickSetup flag and adjusts credential filtering logic.
Updated findSidekickById to support full credential discovery when QuickSetup is active.


### Utilities & Types:

Added extractAllCredentials for comprehensive credential parsing.
Defined a new CredentialInfo type for unified credential metadata.


### UI/UX Improvements:

Modal and URL management: Adds/removes QuickSetup param to the URL as users interact with setup.
Improved modal invocation and teardown in SidekickSetupModal, AssistantInfoCard, CanvasHeader, and unified credential dialogs.
Visual indicator and explicit logic for QuickSetup in all relevant setup screens.
All credential assignment screens respect QuickSetup state for more consistent experience.




### Benefits


Much clearer and faster credential setup flow.
Easier onboarding and troubleshooting for new Sidekicks.
Improved user feedback and better state/URL management throughout the setup journey.


### Manual QA Checklist


[ ] Test QuickSetup with a new Sidekick (all credentials visible; modal/URL behaves correctly)
[ ] Test standard setup (only missing credentials shown)
[ ] Validate modal open/close and parameter cleanup in all flows
[ ] Test assignment of all credential types (required and optional)
[ ] Review displayed copy and indicators for clarity
