### PR TITLE
Security: Fix CVE in Salesforce MCP dependencies and update package manager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
                   submodules: recursive
             - uses: pnpm/action-setup@v4
               with:
-                  version: 9.7.0
+                  version: 9.14.4
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/package.json
+++ b/package.json
@@ -105,36 +105,36 @@
             "sqlite3"
         ],
         "overrides": {
+            "axios": "1.8.2",
             "body-parser": "2.0.2",
             "braces": "3.0.3",
+            "cookie": ">=0.7.0",
             "cross-spawn": "7.0.6",
             "ejs": "^3.1.10",
+            "esbuild": ">=0.25.0",
+            "express": ">=4.19.2",
             "form-data": "^4.0.4",
             "glob-parent": "6.0.2",
             "http-proxy-middleware": ">=3.0.5",
+            "jsforce": "^3.10.0",
             "json5": "2.2.3",
-            "nth-check": "2.1.1",
-
-            "prismjs": ">=1.30.0",
-            "semver": "7.7.1",
-            "set-value": "4.1.0",
-            "unset-value": "2.0.1",
-            "webpack-dev-middleware": "7.4.2",
-            "ws": "8.17.1",
-            "axios": "1.8.2",
-            "qs": "6.7.3",
-            "tar-fs": "3.0.9",
-            "express": ">=4.19.2",
-            "tough-cookie": ">=4.1.3",
             "micromatch": ">=4.0.8",
-            "webpack-dev-server": ">=5.2.1",
-            "esbuild": ">=0.25.0",
+            "nth-check": "2.1.1",
+            "postcss": ">=8.4.31",
+            "prismjs": ">=1.30.0",
+            "qs": "6.7.3",
+            "semver": "7.7.1",
             "send": ">=0.19.0",
             "serve-static": ">=1.16.0",
-            "cookie": ">=0.7.0",
-            "postcss": ">=8.4.31",
+            "set-value": "4.1.0",
+            "tar-fs": "3.0.9",
+            "tmp": "^0.2.4",
+            "tough-cookie": ">=4.1.3",
             "tsup": ">=8.3.5",
-            "jsforce": "^3.10.0"
+            "unset-value": "2.0.1",
+            "webpack-dev-middleware": "7.4.2",
+            "webpack-dev-server": ">=5.2.1",
+            "ws": "8.17.1"
         }
     },
     "engines": {
@@ -177,5 +177,5 @@
             ]
         ]
     },
-    "packageManager": "pnpm@9.7.0"
+    "packageManager": "pnpm@9.14.4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ overrides:
   postcss: '>=8.4.31'
   tsup: '>=8.3.5'
   jsforce: ^3.10.0
+  tmp: ^0.2.4
 
 importers:
 
@@ -16752,10 +16753,6 @@ packages:
     resolution: {integrity: sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==}
     engines: {node: '>=0.10.0'}
 
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
 
@@ -20132,12 +20129,8 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
-
-  tmp@0.2.3:
-    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+  tmp@0.2.4:
+    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -34594,7 +34587,7 @@ snapshots:
       request-progress: 3.0.0
       semver: 7.7.1
       supports-color: 8.1.1
-      tmp: 0.2.3
+      tmp: 0.2.4
       tree-kill: 1.2.2
       untildify: 4.0.0
       yauzl: 2.10.0
@@ -36491,7 +36484,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.4
 
   extract-files@9.0.0: {}
 
@@ -42223,8 +42216,6 @@ snapshots:
     dependencies:
       lcid: 1.0.0
 
-  os-tmpdir@1.0.2: {}
-
   ospath@1.2.2: {}
 
   ow@0.28.2:
@@ -46294,11 +46285,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
-
-  tmp@0.2.3: {}
+  tmp@0.2.4: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
# Security: Fix CVE in Salesforce MCP dependencies and update package manager

## Description
This PR addresses a low severity security vulnerability in the `tmp` package used by Salesforce MCP dependencies and updates the package manager to the latest stable version with full CI/CD consistency.

## Changes Made

### Security Fixes
- **Added tmp@^0.2.4 override** to fix CVE in `@answerai/salesforce-mcp` and `@tsmztech/mcp-server-salesforce`
- **Resolves vulnerability**: tmp allows arbitrary file/directory write via symbolic link
- **Maintains alphabetical order** in pnpm overrides section for consistency

### Package Manager Updates
- **Updated packageManager** to `pnpm@9.14.4` (latest stable 9.x release) from `pnpm@9.7.0`
- **Updated GitHub workflow** to use `pnpm@9.14.4` for CI/CD consistency
- **Ensures version alignment** across development and production environments

## Impact
- ✅ **Security audit now shows zero vulnerabilities**
- ✅ **Eliminates low severity CVE** in tmp package
- ✅ **Latest stable tooling** for improved reliability and security
- ✅ **Consistent pnpm version** across local development and CI/CD
- ✅ **Non-breaking changes** - maintains existing functionality

## Follow-up Actions
- [x] **Update embed submodule** after clipboard enhancement PR is merged
- [x] **Verify builds** work correctly with updated package manager in CI/CD
- [x] **Confirm security audit** remains clean across all environments

## Technical Details
- Modified `package.json` pnpm overrides section and packageManager field
- Updated `.github/workflows/main.yml` pnpm version for CI/CD consistency
- No functional code changes - dependency resolution and tooling updates only
- All existing functionality preserved

## Commits
- `5556be46d`: fix: resolve tmp package vulnerability in Salesforce MCP dependencies
- `144c88ad3`: chore: update GitHub workflow to use pnpm@9.14.4 for consistency