### PR TITLE
refactor export import utilities

### DIFF
--- a/packages-answers/ui/src/flowise.d.ts
+++ b/packages-answers/ui/src/flowise.d.ts
@@ -1,0 +1,26 @@
+declare module '@/utils/exportImport' {
+    export function stringify(object: any): string
+    export function exportData(data: any): any
+}
+
+declare module '@/api/exportimport' {
+    const exportImportApi: {
+        exportData: (body: Record<string, boolean>) => Promise<any>
+        importData: (body: any) => Promise<any>
+    }
+    export default exportImportApi
+}
+
+declare module '@/hooks/useApi' {
+    interface ApiState<TData = any, TError = any> {
+        data?: TData
+        error?: TError
+        loading: boolean
+        request: (body?: any) => Promise<void>
+    }
+    export default function useApi<TData = any>(fn: (...args: any[]) => Promise<TData>): ApiState<TData>
+}
+
+declare module '@/utils/errorHandler' {
+    export function getErrorMessage(error: unknown): string
+}

--- a/packages/server/src/controllers/export-import/index.ts
+++ b/packages/server/src/controllers/export-import/index.ts
@@ -1,21 +1,11 @@
 import { NextFunction, Request, Response } from 'express'
+import { StatusCodes } from 'http-status-codes'
 import exportImportService from '../../services/export-import'
 
 const exportData = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        console.log('📤 Export request received:', {
-            body: req.body,
-            userId: req.user?.id,
-            userEmail: req.user?.email
-        })
-        
-        const apiResponse = await exportImportService.exportData(exportImportService.convertExportInput(req.body), req.user!)
-        
-        console.log('✅ Export completed successfully:', {
-            responseKeys: Object.keys(apiResponse),
-            fileDefaultName: apiResponse.FileDefaultName
-        })
-        
+        if (!req.user) return res.status(StatusCodes.UNAUTHORIZED).json({ message: 'Unauthorized' })
+        const apiResponse = await exportImportService.exportData(exportImportService.convertExportInput(req.body), req.user)
         return res.json(apiResponse)
     } catch (error) {
         console.error('❌ Export error:', error)
@@ -25,68 +15,12 @@ const exportData = async (req: Request, res: Response, next: NextFunction) => {
 
 const importData = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        console.log('📥 Import request received:', {
-            userId: req.user?.id,
-            userEmail: req.user?.email,
-            bodySize: JSON.stringify(req.body).length,
-            headers: req.headers['content-type'],
-            method: req.method,
-            url: req.url
-        })
-        
+        if (!req.user) return res.status(StatusCodes.UNAUTHORIZED).json({ message: 'Unauthorized' })
         const importData = req.body
-        
-        // Log the structure of imported data
-        console.log('📊 Import data structure:', {
-            AgentFlow: importData.AgentFlow?.length || 0,
-            AgentFlowV2: importData.AgentFlowV2?.length || 0,
-            AssistantCustom: importData.AssistantCustom?.length || 0,
-            AssistantOpenAI: importData.AssistantOpenAI?.length || 0,
-            AssistantAzure: importData.AssistantAzure?.length || 0,
-            ChatFlow: importData.ChatFlow?.length || 0,
-            ChatMessage: importData.ChatMessage?.length || 0,
-            ChatMessageFeedback: importData.ChatMessageFeedback?.length || 0,
-            CustomTemplate: importData.CustomTemplate?.length || 0,
-            DocumentStore: importData.DocumentStore?.length || 0,
-            DocumentStoreFileChunk: importData.DocumentStoreFileChunk?.length || 0,
-            Execution: importData.Execution?.length || 0,
-            Tool: importData.Tool?.length || 0,
-            Variable: importData.Variable?.length || 0
-        })
-        
-        // Log sample data for debugging
-        console.log('🔍 Sample data check:')
-        if (importData.AgentFlow?.length > 0) {
-            console.log('  - AgentFlow sample:', importData.AgentFlow[0])
-        }
-        if (importData.ChatFlow?.length > 0) {
-            console.log('  - ChatFlow sample:', importData.ChatFlow[0])
-        }
-        if (importData.Tool?.length > 0) {
-            console.log('  - Tool sample:', importData.Tool[0])
-        }
-        if (importData.Variable?.length > 0) {
-            console.log('  - Variable sample:', importData.Variable[0])
-        }
-        
-        console.log('🚀 Starting import process...')
-        console.log('👤 User info for import:', {
-            id: req.user?.id,
-            email: req.user?.email,
-            organizationId: req.user?.organizationId
-        })
-        
-        await exportImportService.importData(req.user!, importData)
-        
-        console.log('✅ Import completed successfully')
+        await exportImportService.importData(req.user, importData)
         return res.json({ message: 'success' })
     } catch (error) {
         console.error('❌ Import error:', error)
-        console.error('❌ Import error details:', {
-            message: error instanceof Error ? error.message : String(error),
-            stack: error instanceof Error ? error.stack : 'No stack trace',
-            name: error instanceof Error ? error.name : 'Unknown error'
-        })
         next(error)
     }
 }

--- a/packages/ui/src/utils/exportImport.js
+++ b/packages/ui/src/utils/exportImport.js
@@ -22,9 +22,7 @@ const sanitizeTool = (Tool) => {
 const sanitizeChatflow = (ChatFlow) => {
     try {
         return ChatFlow.map((chatFlow) => {
-            console.log('🔄 chatFlow:', chatFlow)
             const sanitizeFlowData = generateExportFlowData(chatFlow)
-            console.log('🔄 sanitizeFlowData:', sanitizeFlowData)
             return {
                 id: chatFlow.id,
                 name: chatFlow.name,


### PR DESCRIPTION
## Summary
- remove `@ts-ignore` directives and use Next.js router for imports/export component
- add module declarations and replace hard redirect with router navigation
- drop verbose logging from export/import utilities and controller
- avoid logging full file contents on JSON parse failures
- destructure API hooks and add explicit effect dependencies to satisfy lint rules
- enforce ownership checks for all export/import operations

## Testing
- `pnpm exec eslint packages-answers/ui/src/components/ExportImportComponent.tsx packages-answers/ui/src/flowise.d.ts packages/ui/src/utils/exportImport.js packages/server/src/controllers/export-import/index.ts packages/server/src/services/export-import/index.ts && echo 'lint passed'`
- `pnpm test` *(fails: exec: "pnpm": cannot run executable found relative to current directory)*

------
https://chatgpt.com/codex/tasks/task_b_6899fd716b1c833196baa5f1054e9104