### PR TITLE
bug: Update build script in docs package to include sitemap fix (#496)

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -40,7 +40,7 @@
     "name": "docs",
     "private": true,
     "scripts": {
-        "build": "pnpm api-docs && docusaurus build",
+        "build": "pnpm api-docs && docusaurus build && node scripts/fix-sitemap.js",
         "clear": "docusaurus clear",
         "deploy": "docusaurus deploy",
         "docs": "docusaurus start --port 4242",

--- a/packages/docs/scripts/fix-sitemap.js
+++ b/packages/docs/scripts/fix-sitemap.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Script to fix sitemap.xml encoding issues that may occur during deployment
+ * Removes any extraneous characters and ensures proper XML formatting
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const SITEMAP_PATH = path.join(__dirname, '..', 'build', 'sitemap.xml')
+
+function fixSitemap() {
+    console.log('🔧 Fixing sitemap.xml encoding issues...')
+
+    try {
+        // Check if sitemap exists
+        if (!fs.existsSync(SITEMAP_PATH)) {
+            console.log('⚠️  sitemap.xml not found at:', SITEMAP_PATH)
+            return
+        }
+
+        // Read the sitemap content
+        let content = fs.readFileSync(SITEMAP_PATH, 'utf8')
+
+        // Remove any trailing non-XML characters (like %)
+        // Ensure the file ends properly with </urlset>
+        const urlsetCloseTag = '</urlset>'
+        const urlsetIndex = content.lastIndexOf(urlsetCloseTag)
+
+        if (urlsetIndex !== -1) {
+            // Keep everything up to and including the closing </urlset> tag
+            const cleanContent = content.substring(0, urlsetIndex + urlsetCloseTag.length)
+
+            // Only write if content changed
+            if (cleanContent !== content) {
+                fs.writeFileSync(SITEMAP_PATH, cleanContent, 'utf8')
+                console.log('✅ Fixed sitemap.xml - removed extraneous characters')
+                console.log(`📊 Original size: ${content.length} bytes`)
+                console.log(`📊 Cleaned size: ${cleanContent.length} bytes`)
+            } else {
+                console.log('✅ sitemap.xml is already properly formatted')
+            }
+        } else {
+            console.error('❌ Could not find closing </urlset> tag in sitemap.xml')
+            process.exit(1)
+        }
+    } catch (error) {
+        console.error('❌ Error fixing sitemap.xml:', error.message)
+        process.exit(1)
+    }
+}
+
+// Run the fix
+fixSitemap()

--- a/packages/docs/vercel.json
+++ b/packages/docs/vercel.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "buildCommand": "pnpm build",
+    "outputDirectory": "build",
+    "trailingSlash": false,
+    "headers": [
+        {
+            "source": "/sitemap.xml",
+            "headers": [
+                {
+                    "key": "Content-Type",
+                    "value": "application/xml; charset=utf-8"
+                },
+                {
+                    "key": "Cache-Control",
+                    "value": "public, max-age=86400, s-maxage=86400"
+                }
+            ]
+        },
+        {
+            "source": "/(.*\\.xml)",
+            "headers": [
+                {
+                    "key": "Content-Type",
+                    "value": "application/xml; charset=utf-8"
+                }
+            ]
+        }
+    ],
+    "rewrites": [
+        {
+            "source": "/sitemap.xml",
+            "destination": "/sitemap.xml"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Enhances the build process for the documentation package by adding a script to fix the sitemap after building.

## Changes
- Updated the `build` script in `packages/docs/package.json` to include `&& node scripts/fix-sitemap.js` after the Docusaurus build command.

This change ensures that the sitemap is properly fixed as part of the build process, improving the documentation deployment workflow.