### PR TITLE
fix: Improve the reliability of the cache file - AAI-619

### DIFF
--- a/scripts/bws-secure/secureRun.js
+++ b/scripts/bws-secure/secureRun.js
@@ -97,7 +97,7 @@ function getMachineAccountsUrl() {
 async function readConfigFileWithFallback() {
   const hasToken = process.env.BWS_ACCESS_TOKEN;
   const noOverride = process.env.BWS_NO_OVERRIDE === 'true';
-  const cacheFile = path.join(process.cwd(), '.bwsconfig.cache');
+  const cacheFile = path.join(dirname, '.bwsconfig.cache');
   const cacheTimeout = 5 * 60 * 1000; // 5 minutes cache
 
   // Skip BWS override if BWS_NO_OVERRIDE is set


### PR DESCRIPTION
## Summary
This commit modifies the path for the cache file in the `readConfigFileWithFallback` function to utilize `dirname` instead of `process.cwd()`, ensuring that the cache file is correctly located relative to the current module's directory.

## Changes
- Updated the cache file path from `path.join(process.cwd(), '.bwsconfig.cache')` to `path.join(dirname, '.bwsconfig.cache')`.

This change improves the reliability of the cache file's location, particularly in environments where the working directory may differ from the module's directory.