### PR TITLE
fix: Update GitHub Actions workflow for staging reset - AAI-619

### DIFF
--- a/.github/workflows/smart-staging-reset.yml
+++ b/.github/workflows/smart-staging-reset.yml
@@ -22,8 +22,8 @@ jobs:
               id: generate-token
               uses: tibdex/github-app-token@v1
               with:
-                  app-id: ${{ secrets.STAGING_RESET_APP_ID }}
-                  private-key: ${{ secrets.STAGING_RESET_APP_PRIVATE_KEY }}
+                  app_id: ${{ secrets.STAGING_RESET_APP_ID }}
+                  private_key: ${{ secrets.STAGING_RESET_APP_PRIVATE_KEY }}
 
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow for the smart staging reset by changing the parameter names from `app-id` and `private-key` to `app_id` and `private_key`, respectively. This adjustment aligns with the expected parameter naming conventions for the GitHub App Token action, ensuring proper functionality of the staging reset process.