### PR TITLE
fix: disable export button until messages are fully loaded

### DIFF
--- a/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
@@ -23,7 +23,8 @@ import {
     CardContent,
     FormControlLabel,
     Checkbox,
-    DialogActions
+    DialogActions,
+    CircularProgress
 } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import DatePicker from 'react-datepicker'
@@ -311,6 +312,11 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
     }
 
     const exportMessages = async () => {
+        // Prevent export if messages are still loading
+        if (getChatmessageApi.loading || getChatmessageFromPKApi.loading || !allChatlogs.length) {
+            return
+        }
+
         if (!storagePath && getStoragePathFromServer.data) {
             storagePath = getStoragePathFromServer.data.storagePath
         }
@@ -823,8 +829,30 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
                 <div style={{ display: 'flex', flexDirection: 'row' }}>
                     {dialogProps.title}
                     <div style={{ flex: 1 }} />
-                    <Button variant='outlined' onClick={() => exportMessages()} startIcon={<IconFileExport />}>
-                        Export
+                    <Button
+                        variant='outlined'
+                        onClick={() => exportMessages()}
+                        startIcon={
+                            getChatmessageApi.loading || getChatmessageFromPKApi.loading ? (
+                                <CircularProgress size={16} color='inherit' />
+                            ) : (
+                                <IconFileExport />
+                            )
+                        }
+                        disabled={getChatmessageApi.loading || getChatmessageFromPKApi.loading || !allChatlogs.length}
+                        title={
+                            getChatmessageApi.loading || getChatmessageFromPKApi.loading
+                                ? 'Loading messages...'
+                                : allChatlogs.length
+                                ? 'Export messages'
+                                : 'No messages to export'
+                        }
+                        sx={{
+                            opacity: !allChatlogs.length ? 0.6 : 1,
+                            cursor: !allChatlogs.length ? 'not-allowed' : 'pointer'
+                        }}
+                    >
+                        {getChatmessageApi.loading || getChatmessageFromPKApi.loading ? 'Loading...' : 'Export'}
                     </Button>
                 </div>
             </DialogTitle>


### PR DESCRIPTION
# Fix: Disable export button until messages are fully loaded

## �� Problem
Fixes [AAI-225](https://lastrev.atlassian.net/browse/AAI-225)

When a user presses the export button before all chatflow messages are fully loaded, the system exports an empty JSON file. If the user waits for messages to fully load, the export works as expected and contains all messages.

**Issue**: Export button was always enabled, allowing users to export incomplete data resulting in empty JSON files.

## ✅ Solution
Disable the export button until all chat messages are completely loaded. This ensures that exports only occur when the message data is fully available, preventing empty JSON downloads and improving the user experience.

### Changes Made

#### 1. **Export Button State Management**
- Button is now disabled during message loading states
- Disabled when `getChatmessageApi.loading` is true (initial message loading)
- Disabled when `getChatmessageFromPKApi.loading` is true (detailed message loading)
- Disabled when `allChatlogs.length` is 0 (no messages available)

#### 2. **Visual Feedback & User Experience**
- **Loading State**: Shows spinner icon and "Loading..." text during data fetch
- **Ready State**: Shows export icon and "Export" text when ready
- **Dynamic Tooltips**: Context-aware help text based on current state
- **Visual Styling**: Button opacity and cursor changes when disabled

#### 3. **Safety Mechanisms**
- **Function-Level Validation**: Added early return in `exportMessages()` function
- **Multiple Validation Layers**: Button state + function validation for robustness
- **Prevents Race Conditions**: Multiple API calls are properly handled

### Technical Implementation

```jsx
// Enhanced export button with loading states
<Button 
    variant='outlined' 
    onClick={() => exportMessages()} 
    startIcon={
        getChatmessageApi.loading || getChatmessageFromPKApi.loading ? 
        <CircularProgress size={16} color="inherit" /> : 
        <IconFileExport />
    }
    disabled={getChatmessageApi.loading || getChatmessageFromPKApi.loading || !allChatlogs.length}
    title={getChatmessageApi.loading || getChatmessageFromPKApi.loading ? 'Loading messages...' : allChatlogs.length ? 'Export messages' : 'No messages to export'}
>
    {getChatmessageApi.loading || getChatmessageFromPKApi.loading ? 'Loading...' : 'Export'}
</Button>
```

```jsx
// Safety check in export function
const exportMessages = async () => {
    // Prevent export if messages are still loading
    if (getChatmessageApi.loading || getChatmessageFromPKApi.loading || !allChatlogs.length) {
        return
    }
    // ... rest of export logic
}

[AAI-225]: https://lastrev.atlassian.net/browse/AAI-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ