### PR TITLE
feat(AAI-610): prevent deletion of Chief Sidekick default chatflow

### DIFF
--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -99,6 +99,23 @@ const CanvasHeader = forwardRef(({ chatflow, isAgentCanvas, isAgentflowV2, handl
         setSettingsOpen(false)
 
         if (setting === 'deleteChatflow') {
+            // Safety check - prevent deletion of user's default chatflow (Chief Sidekick)
+            if (chatflow?.isUserDefault) {
+                enqueueSnackbar({
+                    message: 'Cannot delete your Chief Sidekick',
+                    options: {
+                        key: new Date().getTime() + Math.random(),
+                        variant: 'error',
+                        persist: true,
+                        action: (key) => (
+                            <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
+                                <IconX />
+                            </Button>
+                        )
+                    }
+                })
+                return
+            }
             handleDeleteFlow()
         } else if (setting === 'viewMessages') {
             setViewMessagesDialogProps({

--- a/packages/ui/src/views/settings/index.jsx
+++ b/packages/ui/src/views/settings/index.jsx
@@ -54,7 +54,12 @@ const Settings = ({ chatflow, isSettingsOpen, isCustomAssistant, anchorEl, isAge
                 setSettingsMenu(menus.children)
             } else {
                 const menus = isAgentCanvas ? agentsettings : settings
-                setSettingsMenu(menus.children)
+                // Filter out delete option if this is the user's default chatflow (Chief Sidekick)
+                let filteredMenus = menus.children
+                if (chatflow.isUserDefault) {
+                    filteredMenus = menus.children.filter((menu) => menu.id !== 'deleteChatflow')
+                }
+                setSettingsMenu(filteredMenus)
             }
         }
     }, [chatflow, isAgentCanvas, isCustomAssistant])


### PR DESCRIPTION
## 📋 Summary
Implements protection to prevent users from deleting their default **"Chief Sidekick"** chatflow, ensuring every user maintains access to their primary AI assistant.

---

## 🎯 Problem
Users could previously delete their **Chief Sidekick** through the delete button on the canvas page, removing their default AI assistant and impacting core functionality.

---

## 💡 Solution
Added **defense-in-depth protection** with multiple layers:

### 🔒 Backend Security Layer
- **Service Validation**: Added check in `deleteChatflow()` service to block deletion when `chatflow.id === user.defaultChatflowId`.
- **Error Response**: Returns HTTP **403** with message `"Cannot delete your Chief Sidekick"`.
- **Context Enhancement**: Enhanced `getChatflowById()` to include `isUserDefault` flag.

### 🎨 Frontend UX Layer
- **Settings Menu**: Automatically hides delete option when viewing default chatflow.
- **Safety Check**: Added notification in `CanvasHeader` as final safeguard.
- **User Feedback**: Clear `"Cannot delete your Chief Sidekick"` message using existing snackbar system.

---

## 🔧 Technical Details

### 📂 Files Changed
- `packages/server/src/services/chatflows/index.ts` – Backend protection logic
- `packages/ui/src/views/settings/index.jsx` – Hide delete menu option
- `packages/ui/src/views/canvas/CanvasHeader.jsx` – Safety notification

### 📝 Key Implementation

```ts
// Backend protection
if (chatflow.id === user.defaultChatflowId) {
    throw new InternalFlowiseError(StatusCodes.FORBIDDEN, 'Cannot delete your Chief Sidekick')
}

// Frontend UX
if (chatflow.isUserDefault) {
    filteredMenus = menus.children.filter((menu) => menu.id !== 'deleteChatflow')
}
```

## 🔗 References
- **Jira Ticket**: [AAI-610](https://lastrev.atlassian.net/browse/AAI-610)  
- **Requirements**: Disable delete option and show `"Cannot delete your Chief Sidekick"` message  

---

## 🚀 Deployment Notes
- No database migrations required  
- Uses existing `User.defaultChatflowId` field  
- Backward compatible – no breaking changes  
- Ready for immediate deployment  


[AAI-610]: https://lastrev.atlassian.net/browse/AAI-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ