### PR TITLE
fix: align Langfuse configuration — standardize env var to LANGFUSE_HOST and update client options

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -94,7 +94,6 @@ LANGFUSE_RELEASE=
 LANGFUSE_SECRET_KEY=your_langfuse_secret_key
 LANGFUSE_PUBLIC_KEY=your_langfuse_public_key
 LANGFUSE_HOST=https://cloud.langfuse.com
-LANGFUSE_BASEURL=https://cloud.langfuse.com
 
 # Feature Flags & Monitoring
 FLAGSMITH_ENVIRONMENT_ID=your_flagsmith_env_id

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -496,7 +496,7 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                 release: process.env.LANGFUSE_RELEASE ?? process.env.GIT_COMMIT_HASH,
                 secretKey: process.env.LANGFUSE_SECRET_KEY,
                 publicKey: process.env.LANGFUSE_PUBLIC_KEY,
-                baseUrl: process.env.LANGFUSE_HOST ?? 'https://cloud.langfuse.com',
+                endpoint: process.env.LANGFUSE_HOST ?? 'https://cloud.langfuse.com',
                 sdkIntegration: 'Flowise'
             }
         }

--- a/packages/components/src/speechToText.ts
+++ b/packages/components/src/speechToText.ts
@@ -32,7 +32,7 @@ export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfi
     const langfuse = new Langfuse({
         publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
         secretKey: process.env.LANGFUSE_SECRET_KEY!,
-        baseUrl: process.env.LANGFUSE_BASE_URL || 'https://cloud.langfuse.com'
+        baseUrl: process.env.LANGFUSE_HOST || 'https://cloud.langfuse.com'
     })
 
     const credentialId = speechToTextConfig.credentialId as string

--- a/packages/server/src/aai-utils/billing/langfuse/config.ts
+++ b/packages/server/src/aai-utils/billing/langfuse/config.ts
@@ -5,7 +5,7 @@ import type { LangfuseClient } from './types'
 export const langfuse = new Langfuse({
     publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
     secretKey: process.env.LANGFUSE_SECRET_KEY!,
-    baseUrl: process.env.LANGFUSE_BASE_URL || 'https://cloud.langfuse.com'
+    baseUrl: process.env.LANGFUSE_HOST || 'https://cloud.langfuse.com'
 }) as unknown as LangfuseClient
 
 // Logger setup

--- a/render.yaml
+++ b/render.yaml
@@ -302,7 +302,7 @@ services:
           # Flowise Langfuse Tracing
           # =========================================
           - key: LANGFUSE_HOST
-            value: 'https://cloud.langfuse.com'
+            sync: false
           - key: LANGFUSE_PUBLIC_KEY
             sync: false
           - key: LANGFUSE_SECRET_KEY


### PR DESCRIPTION
## Title
fix: align Langfuse configuration — standardize env var to `LANGFUSE_HOST` and update client options

## Description
### Motivation
Standardize Langfuse host configuration across the codebase and align option names passed to the Langfuse client. This removes inconsistent env var names and ensures a single source of truth for the Langfuse host.

### What Changed
- **.env.template**
  - Removed `LANGFUSE_BASEURL` entry. (`.env.template`)
- **packages/components/src/handler.ts**
  - In `additionalCallbacks`, replaced `baseUrl` with **`endpoint`** and continued to read from `process.env.LANGFUSE_HOST ?? 'https://cloud.langfuse.com'`. (`handler.ts`)
- **packages/components/src/speechToText.ts**
  - Langfuse client now reads host from **`process.env.LANGFUSE_HOST`** instead of `LANGFUSE_BASE_URL` while still using the `baseUrl` option. (`speechToText.ts`)
- **packages/server/src/aai-utils/billing/langfuse/config.ts**
  - Langfuse client `baseUrl` now sourced from **`process.env.LANGFUSE_HOST`** instead of `LANGFUSE_BASE_URL`. (`config.ts`)
- **render.yaml**
  - `LANGFUSE_HOST` changed from a hardcoded value to `sync: false` (no default value provisioned via Render). (`render.yaml`)

### Expected Impact
- **Config consistency:** All runtime code now expects **`LANGFUSE_HOST`** for overriding the Langfuse host. Default continues to fall back to `https://cloud.langfuse.com` when the env var is unset.
- **Option alignment:** Components handler now uses the **`endpoint`** option, while other modules still use **`baseUrl`**. This may reflect differing client construction paths; functionally, behavior should remain unchanged if both keys are supported by the Langfuse client in their respective contexts.

### Breaking/Operational Notes
- **Env var rename:** Deployments that previously set `LANGFUSE_BASE_URL` or `LANGFUSE_BASEURL` must migrate to **`LANGFUSE_HOST`** to customize the host.
- **Render deployment:** `LANGFUSE_HOST` is no longer hardcoded in `render.yaml`. For non-default hosts, set `LANGFUSE_HOST` in the environment. Defaults still resolve to `https://cloud.langfuse.com`.

### Tests
- **No test updates apparent from the diff.**
- Suggested validation during review:
  - Verify traces/metrics are emitted when `LANGFUSE_HOST` is unset (default host path).
  - Verify behavior with a custom `LANGFUSE_HOST`.
  - Sanity-check that both the `endpoint` (components handler) and `baseUrl` (speech/server) options successfully initialize the Langfuse client.

### Files/Functions Touched
- `.env.template`: removed `LANGFUSE_BASEURL` line.
- `packages/components/src/handler.ts`: `additionalCallbacks` config object — `baseUrl` → `endpoint`.
- `packages/components/src/speechToText.ts`: Langfuse client init — `process.env.LANGFUSE_BASE_URL` → `process.env.LANGFUSE_HOST`.
- `packages/server/src/aai-utils/billing/langfuse/config.ts`: Langfuse client init — `process.env.LANGFUSE_BASE_URL` → `process.env.LANGFUSE_HOST`.
- `render.yaml`: `LANGFUSE_HOST` now `sync: false`.
