### PR TITLE
docs: update links & AWS Secrets Manager notes; next: env passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,29 +339,68 @@ For detailed testing documentation, see:
 
 ## 📖 Documentation
 
-[TheAnswer Docs](https://docs.theanswer.ai/)
+[AnswerAgent Docs](https://answeragent.ai/docs)
 
 ## 🌐 Self Host
 
-Deploy TheAnswer self-hosted in your existing infrastructure. We support various [deployments](https://docs.theanswer.ai/configuration/deployment)
+Deploy AnswerAgent self-hosted in your existing infrastructure. We support various [deployments](https://answeragent.ai/docs/developers/deployment)
 
--   [AWS](https://docs.theanswer.ai/configuration/deployment/aws)
--   [Azure](https://docs.theanswer.ai/configuration/deployment/azure)
--   [Digital Ocean](https://docs.theanswer.ai/configuration/deployment/digital-ocean)
--   [GCP](https://docs.theanswer.ai/configuration/deployment/gcp)
--   [Alibaba Cloud](https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=Flowise社区版)
+-   [AWS](https://answeragent.ai/docs/developers/deployment/aws)
+-   [Azure](https://answeragent.ai/docs/developers/deployment/azure)
+-   [GCP](https://answeragent.ai/docs/developers/deployment/gcp)
+-   [Render](https://answeragent.ai/docs/developers/deployment/render)
+
+## 🔐 AWS Secrets Manager Integration
+
+For AWS deployments, AnswerAgent supports using AWS Secrets Manager to securely store the Flowise encryption key instead of environment variables.
+
+### Quick Setup
+
+1. **Create the encryption key secret:**
+
+    ```bash
+    aws secretsmanager create-secret \
+      --name FlowiseEncryptionKey \
+      --secret-string 'your-secure-encryption-key-here'
+    ```
+
+2. **Update an existing secret:**
+
+    ```bash
+    aws secretsmanager put-secret-value \
+      --secret-id FlowiseEncryptionKey \
+      --secret-string 'your-new-encryption-key-here'
+    ```
+
+3. **Add to your environment variables:**
+    ```bash
+    # Flowise Encryption Key Override - AWS Secrets Manager
+    SECRETKEY_STORAGE_TYPE="aws"
+    SECRETKEY_AWS_REGION="us-east-1"
+    SECRETKEY_AWS_NAME="FlowiseEncryptionKey"
+    ```
+
+### Benefits
+
+-   **Enhanced Security**: Keys are encrypted at rest and in transit
+-   **Key Rotation**: Easy rotation without application restarts
+-   **Audit Trail**: Full access logging and monitoring
+-   **IAM Integration**: Fine-grained access control
+
+For detailed AWS deployment instructions, see [AWS Deployment Guide](https://answeragent.ai/docs/developers/deployment/aws).
+
 -   <details>
       <summary>Others</summary>
 
-    -   [Railway](https://docs.theanswer.ai/configuration/deployment/railway)
+    -   [Railway](https://answeragent.ai/docs/developers/deployment/railway)
 
         [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/pn4G8S?referralCode=WVNPD9)
 
-    -   [Render](https://docs.theanswer.ai/configuration/deployment/render)
+    -   [Render](https://answeragent.ai/docs/developers/deployment/render)
 
-        [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://docs.theanswer.ai/configuration/deployment/render)
+        [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://answeragent.ai/docs/developers/deployment/render)
 
-    -   [HuggingFace Spaces](https://docs.theanswer.ai/deployment/hugging-face)
+    -   [HuggingFace Spaces](https://answeragent.ai/docs/deployment/hugging-face)
 
         <a href="https://huggingface.co/spaces/TheAnswer/TheAnswer"><img src="https://huggingface.co/datasets/huggingface/badges/raw/main/open-in-hf-spaces-sm.svg" alt="HuggingFace Spaces"></a>
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -92,7 +92,7 @@ let nextConfig = withBundleAnalyzer({
         AUTH0_BASE_URL:
             process.env.AUTH0_BASE_URL ?? (process.env.VERCEL_BRANCH_URL ? `https://${process.env.VERCEL_BRANCH_URL}` : undefined),
         FLAGSMITH_ENVIRONMENT_ID: process.env.FLAGSMITH_ENVIRONMENT_ID,
-        AUTH0_SECRET: process.env.AUTH0_SECRET ?? process.env.WEB_AUTH0_SECRET,
+        AUTH0_SECRET: process.env.AUTH0_SECRET,
         CHATFLOW_DOMAIN_OVERRIDE: process.env.CHATFLOW_DOMAIN_OVERRIDE
     },
     webpack: (config, { isServer }) => {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -87,6 +87,14 @@ let nextConfig = withBundleAnalyzer({
             }
         ]
     },
+    env: {
+        // Use explicit AUTH0_BASE_URL from environment, fallback to VERCEL_BRANCH_URL if on Vercel
+        AUTH0_BASE_URL:
+            process.env.AUTH0_BASE_URL ?? (process.env.VERCEL_BRANCH_URL ? `https://${process.env.VERCEL_BRANCH_URL}` : undefined),
+        FLAGSMITH_ENVIRONMENT_ID: process.env.FLAGSMITH_ENVIRONMENT_ID,
+        AUTH0_SECRET: process.env.AUTH0_SECRET ?? process.env.WEB_AUTH0_SECRET,
+        CHATFLOW_DOMAIN_OVERRIDE: process.env.CHATFLOW_DOMAIN_OVERRIDE
+    },
     webpack: (config, { isServer }) => {
         config.externals = [...config.externals, 'db', 'puppeteer', 'handlebars']
         config.plugins = [

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -62,32 +62,3 @@ copilot app init --domain client.theanswer.ai
 ```bash
 pnpm copilot deploy
 ```
-
-## AWS Secrets Manager Integration
-
-For enhanced security, configure AWS Secrets Manager to store the Flowise encryption key:
-
-### Setup Commands
-
-```bash
-# Create the encryption key secret (if it doesn't exist)
-aws secretsmanager create-secret \
-  --name FlowiseEncryptionKey \
-  --secret-string 'your-secure-encryption-key-here'
-
-# Update an existing secret
-aws secretsmanager put-secret-value \
-  --secret-id FlowiseEncryptionKey \
-  --secret-string 'your-new-encryption-key-here'
-```
-
-### Environment Configuration
-
-Add to your `copilot.appName.env` file:
-
-```bash
-# Flowise Encryption Key Override - AWS Secrets Manager
-SECRETKEY_STORAGE_TYPE="aws"
-SECRETKEY_AWS_REGION="us-east-1"
-SECRETKEY_AWS_NAME="FlowiseEncryptionKey"
-```

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -62,3 +62,32 @@ copilot app init --domain client.theanswer.ai
 ```bash
 pnpm copilot deploy
 ```
+
+## AWS Secrets Manager Integration
+
+For enhanced security, configure AWS Secrets Manager to store the Flowise encryption key:
+
+### Setup Commands
+
+```bash
+# Create the encryption key secret (if it doesn't exist)
+aws secretsmanager create-secret \
+  --name FlowiseEncryptionKey \
+  --secret-string 'your-secure-encryption-key-here'
+
+# Update an existing secret
+aws secretsmanager put-secret-value \
+  --secret-id FlowiseEncryptionKey \
+  --secret-string 'your-new-encryption-key-here'
+```
+
+### Environment Configuration
+
+Add to your `copilot.appName.env` file:
+
+```bash
+# Flowise Encryption Key Override - AWS Secrets Manager
+SECRETKEY_STORAGE_TYPE="aws"
+SECRETKEY_AWS_REGION="us-east-1"
+SECRETKEY_AWS_NAME="FlowiseEncryptionKey"
+```

--- a/packages/docs/docs/developers/deployment/README.md
+++ b/packages/docs/docs/developers/deployment/README.md
@@ -17,6 +17,17 @@ The following cloud providers offer robust platforms for deploying AnswerAgentAI
 
 Each of these platforms provides unique features and capabilities. Choose the one that best aligns with your organization's requirements, existing infrastructure, and technical expertise.
 
+## Security Enhancements
+
+### AWS Secrets Manager Integration
+
+For AWS deployments, we recommend using AWS Secrets Manager to securely store sensitive configuration data like encryption keys:
+
+-   **Enhanced Security**: Keys are encrypted at rest and in transit
+-   **Key Rotation**: Easy rotation without application restarts
+-   **Audit Trail**: Full access logging and monitoring
+-   **IAM Integration**: Fine-grained access control
+
 For detailed deployment instructions for each platform, please refer to the respective links above.
 
 ## Local Machine

--- a/packages/docs/docs/developers/environment-variables.md
+++ b/packages/docs/docs/developers/environment-variables.md
@@ -81,6 +81,9 @@ There are three different .env files you can set environment variables for Answe
 | S3_ENDPOINT_URL               | Custom S3 endpoint URL (commented out)                   | Server                      |
 | APIKEY_STORAGE_TYPE           | API key storage type (json or db) (commented out)        | Server                      |
 | SHOW_COMMUNITY_NODES          | Show community nodes when set to true (commented out)    | Server                      |
+| SECRETKEY_STORAGE_TYPE        | Secret key storage type (file, aws)                      | Root, Server                |
+| SECRETKEY_AWS_REGION          | AWS region for Secrets Manager (when using aws storage)  | Root, Server                |
+| SECRETKEY_AWS_NAME            | AWS Secrets Manager secret name (when using aws storage) | Root, Server                |
 
 This table provides a comprehensive overview of all the environment variables used across the different files in your project. The "File Location" column indicates which file(s) each variable is found in (Root, Server, UI, or AnswerAgentAI).
 
@@ -162,6 +165,22 @@ AAI-branded nodes use environment variables with the `AAI_DEFAULT_` prefix to pr
 2. **Access Control**: Ensure that only authorized services and users have access to these environment variables.
 
 3. **Default Credentials**: These are intended for development and testing. In production, consider using more secure credential management systems.
+
+4. **AWS Secrets Manager Integration**: For enhanced security in AWS deployments, use AWS Secrets Manager to store the Flowise encryption key:
+
+    ```bash
+    # Configure AWS Secrets Manager for encryption key storage
+    SECRETKEY_STORAGE_TYPE="aws"
+    SECRETKEY_AWS_REGION="us-east-1"
+    SECRETKEY_AWS_NAME="FlowiseEncryptionKey"
+    ```
+
+    **Benefits:**
+
+    - Keys are encrypted at rest and in transit
+    - Automatic key rotation capabilities
+    - Full audit trail and access logging
+    - IAM-based access control
 
 ### Usage Examples
 

--- a/scripts/seed-credentials/seed-credentials.env.template
+++ b/scripts/seed-credentials/seed-credentials.env.template
@@ -74,6 +74,12 @@ AAI_DEFAULT_POSTGRES_API_PASSWORD=""
 # --- Postgres URL Credential ---
 AAI_DEFAULT_POSTGRES_URL=""
 
+# --- AWS Secrets Manager Configuration (Optional) ---
+# Uncomment and configure these if you want to use AWS Secrets Manager for Flowise encryption key
+#SECRETKEY_STORAGE_TYPE="aws"
+#SECRETKEY_AWS_REGION="us-east-1"
+#SECRETKEY_AWS_NAME="FlowiseEncryptionKey"
+
 # --- Auto-detectable credentials (examples, uncomment and fill as needed) ---
 # For any credential in /credentials, you can add a variable like:
 #   AAI_DEFAULT_{CREDTYPE}_API_KEY="..."


### PR DESCRIPTION
## Title
docs: update links & AWS Secrets Manager notes; next: env passthrough

## Description
### Summary
- Rebrand links in **README** and docs to `answeragent.ai`; prune/refresh provider URLs.
- Add concise **AWS Secrets Manager** guidance (create/update secret + env overrides).
- Improve AWS guide (STS check, domain example fix to `myapp.theanswer.ai`, troubleshooting).
- Extend env reference + seed template with optional `SECRETKEY_*` variables.
- **Next.js**: expose minimal env vars via `apps/web/next.config.js`:
  - `AUTH0_BASE_URL` (fallback to `https://${VERCEL_BRANCH_URL}` when unset),
  - `FLAGSMITH_ENVIRONMENT_ID`,
  - `AUTH0_SECRET`,
  - `CHATFLOW_DOMAIN_OVERRIDE`.

### Impact
- Docs clarity + security posture improved; easier self-hosting.
- Web app reads values from environment; behavior unchanged unless relying on new `AUTH0_BASE_URL` fallback.

### Breaking/Config
- None apparent. New env passthroughs only.

### Testing
- Verify docs links render correctly.
- Set/unset `AUTH0_BASE_URL` with `VERCEL_BRANCH_URL` present to confirm fallback.
- Smoke login with `AUTH0_SECRET` set.
