### PR TITLE
feat: Flowise Secrets Manager access policy (#531)

### DIFF
--- a/copilot/flowise/addons/flowise-secrets-manager-access-policy.yml
+++ b/copilot/flowise/addons/flowise-secrets-manager-access-policy.yml
@@ -1,0 +1,39 @@
+Parameters:
+    App:
+        Type: String
+        Description: Your application's name.
+    Env:
+        Type: String
+        Description: The environment name your service, job, or workflow is being deployed to.
+    Name:
+        Type: String
+        Description: Your workload's name.
+
+Resources:
+    FlowiseSecretsManagerAccessPolicy:
+        Type: AWS::IAM::ManagedPolicy
+        Metadata:
+            'aws:copilot:description': 'Allow Flowise task role to read FlowiseEncryptionKey from Secrets Manager'
+        Properties:
+            Description: 'Read-only access for Flowise to retrieve the FlowiseEncryptionKey secret'
+            PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                    - Sid: ReadFlowiseEncryptionKey
+                      Effect: Allow
+                      Action:
+                          - secretsmanager:GetSecretValue
+                          - secretsmanager:CreateSecret
+                          - secretsmanager:DescribeSecret
+                      Resource:
+                          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:FlowiseEncryptionKey-*'
+                    # If you use a customer-managed KMS key for the secret, also allow kms:Decrypt:
+                    # - Sid: DecryptWithCMK
+                    #   Effect: Allow
+                    #   Action: kms:Decrypt
+                    #   Resource: arn:aws:kms:<region>:<account>:key/<your-key-id>
+
+Outputs:
+    FlowiseSecretsManagerAccessPolicyArn:
+        Description: 'Managed policy to attach to the task role for Secrets Manager access'
+        Value: !Ref FlowiseSecretsManagerAccessPolicy


### PR DESCRIPTION
This commit introduces a new YAML configuration file for the Flowise Secrets Manager access policy. The policy grants read-only access to the FlowiseEncryptionKey secret, allowing the Flowise task role to retrieve sensitive information securely. The configuration includes parameters for application name, environment, and workload name, along with the necessary IAM policy document.

No breaking changes are introduced with this addition.