### PR TITLE
feat: update Flowise encryption key handling to use AWS Secrets Manager

### DIFF
--- a/copilot/copilot.appName.env.template
+++ b/copilot/copilot.appName.env.template
@@ -3,7 +3,6 @@
 # ==================================================
 # These are Flowise-specific settings not handled by manifest
 APIKEY_PATH=/var/efs/
-SECRETKEY_PATH=/var/efs/
 LOG_PATH=/var/efs/logs
 DISABLE_FLOWISE_TELEMETRY=true
 IFRAME_ORIGINS=*
@@ -15,8 +14,13 @@ APIKEY_STORAGE_TYPE=db
 # Enable Flagsmith 
 FLAGSMITH_ENVIRONMENT_ID=
 
-# Encryption Key Override: Overrides the encryption key from SECRETKEY_PATH
-# WARNING: Changing this invalidates all existing encrypted credentials
+# Encryption Key Configuration (Auto-configured via CloudFormation):
+# - SECRETKEY_STORAGE_TYPE=aws (automatically set to use AWS Secrets Manager)  
+# - SECRETKEY_AWS_REGION (automatically set to deployment region)
+# - SECRETKEY_AWS_NAME (automatically set to ${App}-${Env}-FlowiseEncryptionKey)
+# - Each app/environment gets its own unique encryption key for security isolation
+# - FLOWISE_SECRETKEY_OVERWRITE can still be used to override if needed (advanced use cases only)
+# WARNING: Changing encryption keys invalidates all existing encrypted credentials
 # FLOWISE_SECRETKEY_OVERWRITE=
 
 # Session Secret: Cryptographically secure secret for Express session cookies

--- a/copilot/environments/addons/flowise-encryption-key.yml
+++ b/copilot/environments/addons/flowise-encryption-key.yml
@@ -1,0 +1,38 @@
+Parameters:
+    App:
+        Type: String
+        Description: Your application's name.
+    Env:
+        Type: String
+        Description: The name of the environment being deployed.
+
+Resources:
+    # Create the Flowise encryption key secret
+    FlowiseEncryptionKey:
+        Type: AWS::SecretsManager::Secret
+        Metadata:
+            'aws:copilot:description': 'Flowise encryption key for credential storage'
+        Properties:
+            Name: !Sub '${App}-${Env}-FlowiseEncryptionKey'
+            Description: !Sub 'Flowise encryption key for ${App}-${Env}'
+            GenerateSecretString:
+                PasswordLength: 32
+                IncludeSpace: false
+                # Generate plain string value (not JSON) that Flowise expects
+
+Outputs:
+    FlowiseEncryptionKeyName:
+        Description: 'The name of the Flowise encryption key secret'
+        Value: !Ref FlowiseEncryptionKey
+        Export:
+            Name: !Sub ${App}-${Env}-FlowiseEncryptionKeyName
+    FlowiseEncryptionKeyArn:
+        Description: 'The ARN of the Flowise encryption key secret'
+        Value: !Ref FlowiseEncryptionKey
+        Export:
+            Name: !Sub ${App}-${Env}-FlowiseEncryptionKeyArn
+    FlowiseEncryptionKeyRegion:
+        Description: 'The AWS region where the Flowise encryption key secret is deployed'
+        Value: !Ref AWS::Region
+        Export:
+            Name: !Sub ${App}-${Env}-FlowiseEncryptionKeyRegion

--- a/copilot/flowise/addons/flowise-secrets-manager-access-policy.yml
+++ b/copilot/flowise/addons/flowise-secrets-manager-access-policy.yml
@@ -10,23 +10,24 @@ Parameters:
         Description: Your workload's name.
 
 Resources:
+    # IAM policy to access the environment-level encryption key
     FlowiseSecretsManagerAccessPolicy:
         Type: AWS::IAM::ManagedPolicy
         Metadata:
-            'aws:copilot:description': 'Allow Flowise task role to read FlowiseEncryptionKey from Secrets Manager'
+            'aws:copilot:description': 'Allow Flowise task role to access FlowiseEncryptionKey from Secrets Manager'
         Properties:
-            Description: 'Read-only access for Flowise to retrieve the FlowiseEncryptionKey secret'
+            Description: 'Access for Flowise to retrieve and manage the FlowiseEncryptionKey secret'
             PolicyDocument:
                 Version: '2012-10-17'
                 Statement:
-                    - Sid: ReadFlowiseEncryptionKey
+                    - Sid: AccessFlowiseEncryptionKey
                       Effect: Allow
                       Action:
                           - secretsmanager:GetSecretValue
                           - secretsmanager:CreateSecret
                           - secretsmanager:DescribeSecret
                       Resource:
-                          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:FlowiseEncryptionKey-*'
+                          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${App}-${Env}-FlowiseEncryptionKey-*'
                     # If you use a customer-managed KMS key for the secret, also allow kms:Decrypt:
                     # - Sid: DecryptWithCMK
                     #   Effect: Allow

--- a/copilot/flowise/manifest.yml
+++ b/copilot/flowise/manifest.yml
@@ -81,6 +81,12 @@ variables: # Pass environment variables as key value pairs.
         from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-theansweraiserverstorageBucketRegion
     # Lacework configuration variables - will be loaded from env file (COMMENTED OUT FOR NOW)
     LaceworkVerbose: 'true'
+    # Flowise encryption key from CloudFormation-managed secret
+    SECRETKEY_STORAGE_TYPE: 'aws'
+    SECRETKEY_AWS_REGION:
+        from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FlowiseEncryptionKeyRegion
+    SECRETKEY_AWS_NAME:
+        from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FlowiseEncryptionKeyName
 
 env_file: copilot.${COPILOT_APPLICATION_NAME}.env
 
@@ -111,7 +117,7 @@ environments:
         # Upgrade path: 4096 → 8192 → 16384
         memory: 4096
         # Upgrade path: 8192 → 16384 → 32768
-        # count:
+        count: 2
         #     range: 1-12
         #     # Can handle significant load automatically
         #     cpu_percentage: 85


### PR DESCRIPTION
## Title
feat: update Flowise encryption key handling to use AWS Secrets Manager

## Description
### Motivation & Scope
Refactors Flowise’s encryption key configuration to use AWS Secrets Manager instead of a filesystem path. While conceptually small, this change improves security posture and standardizes secret management. Motivation inferred from diff: security and environment isolation.

### Major Changes
- **copilot/copilot.appName.env.template**
  - Removed `SECRETKEY_PATH=/var/efs/`.
  - Updated documentation comments to describe Secrets Manager–based configuration:
    - Variables: `SECRETKEY_STORAGE_TYPE=aws`, `SECRETKEY_AWS_REGION`, `SECRETKEY_AWS_NAME`.
    - Notes per-environment isolation and warns that key changes invalidate credentials.
  - Retained `FLOWISE_SECRETKEY_OVERWRITE` as an advanced override option.

- **copilot/environments/addons/flowise-encryption-key.yml** *(new)*
  - Adds CloudFormation resource to generate a secret in AWS Secrets Manager.
  - Outputs secret **Name**, **Arn**, and **Region** for consumption by the service.

- **copilot/flowise/addons/flowise-secrets-manager-access-policy.yml**
  - Clarified description and metadata.
  - Adjusted IAM policy to reference env-specific secret ARN `${App}-${Env}-FlowiseEncryptionKey-*`.
  - Allows actions `GetSecretValue`, `CreateSecret`, and `DescribeSecret`.

- **copilot/flowise/manifest.yml**
  - Injects new environment variables to reference the secret via CFN outputs.
  - Sets `count: 2` to scale Flowise service.

### Expected Impact
- More secure and isolated management of Flowise encryption keys.
- Simplified deployment: keys automatically provisioned and injected via env vars.
- Slight capacity increase from scaling to two tasks.

### Breaking Changes & Migrations
- **Encryption Key Migration:** Credentials encrypted with the old filesystem key will be invalid unless migrated. Existing encrypted values may need re-entry.
- No API or schema changes apparent.

### Env/Config Changes
- Introduces a new CloudFormation addon for secret provisioning.
- Requires updated manifest variables (`SECRETKEY_STORAGE_TYPE`, `SECRETKEY_AWS_REGION`, `SECRETKEY_AWS_NAME`).
- `FLOWISE_SECRETKEY_OVERWRITE` remains as an override option.

### Testing Notes
- Deploy to staging to confirm service can read secrets correctly.
- Verify encrypted credentials behavior post-migration.
- Check app startup with missing or rotated secrets.
- Validate scaling to `count: 2` functions as expected.

### Related Issues/Links
- None referenced in the diff.
