### PR TITLE
chore: update development scripts to prevent console clearing during watch mode

### DIFF
--- a/packages/api-documentation/package.json
+++ b/packages/api-documentation/package.json
@@ -4,7 +4,7 @@
     "description": "Flowise API documentation server",
     "scripts": {
         "build": "tsc",
-        "dev": "tsc-watch --onSuccess \"node dist/index.js\"",
+        "dev": "tsc-watch --noClear --onSuccess \"node dist/index.js\"",
         "start": "node dist/index.js",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
     },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -9,7 +9,7 @@
     ],
     "scripts": {
         "build": "tsc && gulp",
-        "dev": "tsc --watch",
+        "dev": "tsc-watch --noClear",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
         "clean": "rimraf dist",
         "nuke": "rimraf dist node_modules .turbo"


### PR DESCRIPTION
This commit modifies the `dev` script in both `packages/api-documentation/package.json` and `packages/components/package.json` to include the `--noClear` option for `tsc-watch`. This change enhances the development experience by preventing the console from clearing on each compilation, allowing developers to retain visibility of previous output during development.