### PR TITLE
chore: use nullish coalescing for AAI PostgreSQL env fallbacks

### DIFF
--- a/packages/server/src/commands/base.ts
+++ b/packages/server/src/commands/base.ts
@@ -178,25 +178,55 @@ export abstract class BaseCommand extends Command {
             process.env.DATABASE_TYPE = engine
         }
 
-        // AAI PostgreSQL fallbacks - Individual variable fallbacks using shorthand
+        // AAI PostgreSQL fallbacks - Individual variable fallbacks with explicit checks
         // Precedence order: Individual AAI secrets > Individual AAI variables > Shared DATABASE_SECRET
-        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_HOST ||= process.env.DATABASE_HOST
-        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PORT ||= process.env.DATABASE_PORT
-        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_DATABASE ||= process.env.DATABASE_NAME
-        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_USER ||= process.env.DATABASE_USER
-        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PASSWORD ||= process.env.DATABASE_PASSWORD
+        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_HOST && process.env.DATABASE_HOST) {
+            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_HOST = process.env.DATABASE_HOST
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PORT && process.env.DATABASE_PORT) {
+            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PORT = process.env.DATABASE_PORT
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_DATABASE && process.env.DATABASE_NAME) {
+            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_DATABASE = process.env.DATABASE_NAME
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_USER && process.env.DATABASE_USER) {
+            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_USER = process.env.DATABASE_USER
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PASSWORD && process.env.DATABASE_PASSWORD) {
+            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PASSWORD = process.env.DATABASE_PASSWORD
+        }
 
-        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_HOST ||= process.env.DATABASE_HOST
-        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PORT ||= process.env.DATABASE_PORT
-        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_DATABASE ||= process.env.DATABASE_NAME
-        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_USER ||= process.env.DATABASE_USER
-        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PASSWORD ||= process.env.DATABASE_PASSWORD
+        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_HOST && process.env.DATABASE_HOST) {
+            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_HOST = process.env.DATABASE_HOST
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PORT && process.env.DATABASE_PORT) {
+            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PORT = process.env.DATABASE_PORT
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_DATABASE && process.env.DATABASE_NAME) {
+            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_DATABASE = process.env.DATABASE_NAME
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_USER && process.env.DATABASE_USER) {
+            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_USER = process.env.DATABASE_USER
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PASSWORD && process.env.DATABASE_PASSWORD) {
+            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PASSWORD = process.env.DATABASE_PASSWORD
+        }
 
-        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_HOST ||= process.env.DATABASE_HOST
-        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PORT ||= process.env.DATABASE_PORT
-        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_DATABASE ||= process.env.DATABASE_NAME
-        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_USER ||= process.env.DATABASE_USER
-        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PASSWORD ||= process.env.DATABASE_PASSWORD
+        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_HOST && process.env.DATABASE_HOST) {
+            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_HOST = process.env.DATABASE_HOST
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PORT && process.env.DATABASE_PORT) {
+            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PORT = process.env.DATABASE_PORT
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_DATABASE && process.env.DATABASE_NAME) {
+            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_DATABASE = process.env.DATABASE_NAME
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_USER && process.env.DATABASE_USER) {
+            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_USER = process.env.DATABASE_USER
+        }
+        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PASSWORD && process.env.DATABASE_PASSWORD) {
+            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PASSWORD = process.env.DATABASE_PASSWORD
+        }
 
         // Parse individual AAI secrets if they exist (highest precedence)
         // This allows managing each AAI service with its own database/credentials

--- a/packages/server/src/commands/base.ts
+++ b/packages/server/src/commands/base.ts
@@ -178,55 +178,25 @@ export abstract class BaseCommand extends Command {
             process.env.DATABASE_TYPE = engine
         }
 
-        // AAI PostgreSQL fallbacks - Individual variable fallbacks with explicit checks
+        // AAI PostgreSQL fallbacks - Individual variable fallbacks using nullish coalescing
         // Precedence order: Individual AAI secrets > Individual AAI variables > Shared DATABASE_SECRET
-        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_HOST && process.env.DATABASE_HOST) {
-            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_HOST = process.env.DATABASE_HOST
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PORT && process.env.DATABASE_PORT) {
-            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PORT = process.env.DATABASE_PORT
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_DATABASE && process.env.DATABASE_NAME) {
-            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_DATABASE = process.env.DATABASE_NAME
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_USER && process.env.DATABASE_USER) {
-            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_USER = process.env.DATABASE_USER
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PASSWORD && process.env.DATABASE_PASSWORD) {
-            process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PASSWORD = process.env.DATABASE_PASSWORD
-        }
+        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_HOST ??= process.env.DATABASE_HOST
+        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PORT ??= process.env.DATABASE_PORT
+        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_DATABASE ??= process.env.DATABASE_NAME
+        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_USER ??= process.env.DATABASE_USER
+        process.env.AAI_DEFAULT_POSTGRES_RECORDMANAGER_PASSWORD ??= process.env.DATABASE_PASSWORD
 
-        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_HOST && process.env.DATABASE_HOST) {
-            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_HOST = process.env.DATABASE_HOST
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PORT && process.env.DATABASE_PORT) {
-            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PORT = process.env.DATABASE_PORT
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_DATABASE && process.env.DATABASE_NAME) {
-            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_DATABASE = process.env.DATABASE_NAME
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_USER && process.env.DATABASE_USER) {
-            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_USER = process.env.DATABASE_USER
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PASSWORD && process.env.DATABASE_PASSWORD) {
-            process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PASSWORD = process.env.DATABASE_PASSWORD
-        }
+        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_HOST ??= process.env.DATABASE_HOST
+        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PORT ??= process.env.DATABASE_PORT
+        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_DATABASE ??= process.env.DATABASE_NAME
+        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_USER ??= process.env.DATABASE_USER
+        process.env.AAI_DEFAULT_POSTGRES_AGENTMEMORY_PASSWORD ??= process.env.DATABASE_PASSWORD
 
-        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_HOST && process.env.DATABASE_HOST) {
-            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_HOST = process.env.DATABASE_HOST
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PORT && process.env.DATABASE_PORT) {
-            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PORT = process.env.DATABASE_PORT
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_DATABASE && process.env.DATABASE_NAME) {
-            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_DATABASE = process.env.DATABASE_NAME
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_USER && process.env.DATABASE_USER) {
-            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_USER = process.env.DATABASE_USER
-        }
-        if (!process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PASSWORD && process.env.DATABASE_PASSWORD) {
-            process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PASSWORD = process.env.DATABASE_PASSWORD
-        }
+        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_HOST ??= process.env.DATABASE_HOST
+        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PORT ??= process.env.DATABASE_PORT
+        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_DATABASE ??= process.env.DATABASE_NAME
+        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_USER ??= process.env.DATABASE_USER
+        process.env.AAI_DEFAULT_POSTGRES_VECTORSTORE_PASSWORD ??= process.env.DATABASE_PASSWORD
 
         // Parse individual AAI secrets if they exist (highest precedence)
         // This allows managing each AAI service with its own database/credentials


### PR DESCRIPTION
## Title
fix: use nullish coalescing for AAI PostgreSQL env fallbacks

## Description
This change updates the environment variable fallback logic in `packages/server/src/commands/base.ts` for AAI PostgreSQL configuration. It replaces logical OR assignment (`||=`) with nullish coalescing assignment (`??=`) across all AAI-related Postgres variables and updates the accompanying comment to reflect the new behavior.

### Motivation
Motivation inferred from the diff comments: ensure fallbacks only apply when variables are `null` or `undefined`, not when they are any falsy value. This avoids unintentionally overriding intentionally provided but falsy environment values. If broader motivation exists, it is not evident beyond the comment change.

### Modified Areas
**File:** `packages/server/src/commands/base.ts`
- Comment updated to: “AAI PostgreSQL fallbacks - Individual variable fallbacks using nullish coalescing.”
- For each scope (RecordManager, AgentMemory, VectorStore), the following variables now use `??=` instead of `||=`:
  - `AAI_DEFAULT_POSTGRES_RECORDMANAGER_HOST`
  - `AAI_DEFAULT_POSTGRES_RECORDMANAGER_PORT`
  - `AAI_DEFAULT_POSTGRES_RECORDMANAGER_DATABASE`
  - `AAI_DEFAULT_POSTGRES_RECORDMANAGER_USER`
  - `AAI_DEFAULT_POSTGRES_RECORDMANAGER_PASSWORD`
  - `AAI_DEFAULT_POSTGRES_AGENTMEMORY_HOST`
  - `AAI_DEFAULT_POSTGRES_AGENTMEMORY_PORT`
  - `AAI_DEFAULT_POSTGRES_AGENTMEMORY_DATABASE`
  - `AAI_DEFAULT_POSTGRES_AGENTMEMORY_USER`
  - `AAI_DEFAULT_POSTGRES_AGENTMEMORY_PASSWORD`
  - `AAI_DEFAULT_POSTGRES_VECTORSTORE_HOST`
  - `AAI_DEFAULT_POSTGRES_VECTORSTORE_PORT`
  - `AAI_DEFAULT_POSTGRES_VECTORSTORE_DATABASE`
  - `AAI_DEFAULT_POSTGRES_VECTORSTORE_USER`
  - `AAI_DEFAULT_POSTGRES_VECTORSTORE_PASSWORD`

### Behavior & Impact
- **Previous behavior (`||=`):** would assign a fallback when the left-hand env var was any falsy value (e.g., empty string `""`, `"0"`).
- **New behavior (`??=`):** assigns a fallback only when the left-hand env var is `null` or `undefined`.
- **Impact:** Reduces accidental overrides of defined-but-falsy environment variables and aligns fallback logic with intent expressed in the comment’s precedence rules.

### Config/Env/Deps
- **Env:** Uses existing `DATABASE_*` values as fallbacks with updated nullish semantics.
- **Dependencies:** None added/removed.
- **Migrations/Schema:** None apparent.
