### PR TITLE
Ct/SUPPORT-5021-dalle-api-url-issues-with-domain-var

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -84,6 +84,12 @@ let nextConfig = withBundleAnalyzer({
                 hostname: 'localhost',
                 port: '4000',
                 pathname: '/**'
+            },
+            {
+                protocol: 'https',
+                hostname: '**.theanswer.ai',
+                port: '',
+                pathname: '/**'
             }
         ]
     },

--- a/copilot/flowise/manifest.yml
+++ b/copilot/flowise/manifest.yml
@@ -64,6 +64,7 @@ variables: # Pass environment variables as key value pairs.
     CHATFLOW_DOMAIN: 'http://flowise:4000'
     DOMAIN: 'http://flowise:4000'
     FLOWISE_DOMAIN: 'http://flowise:4000'
+    API_HOST: 'https://api.${CLIENT_DOMAIN}'
     NODE_ENV: 'production'
     PORT: '4000'
     NUMBER_OF_PROXIES: '1'

--- a/packages/components/nodes/tools/CreateDalleImage/AAICreateDalleImage.ts
+++ b/packages/components/nodes/tools/CreateDalleImage/AAICreateDalleImage.ts
@@ -101,7 +101,8 @@ export class AAIDallePostTool extends Tool {
             }
 
             // Convert FILE-STORAGE:: reference to a full URL with domain
-            const domain = process.env.DOMAIN || process.env.FLOWISE_DOMAIN || this.baseURL || 'http://localhost:4000'
+            const domain =
+                process.env.API_HOST || process.env.DOMAIN || process.env.FLOWISE_DOMAIN || this.baseURL || 'http://localhost:4000'
             const imageFileName = imageStorageUrl.replace('FILE-STORAGE::', '')
             const fullImageUrl = `${domain}/api/v1/get-upload-file?chatflowId=dalle-images&chatId=${orgId}%2F${usrId}&fileName=${imageFileName}`
 
@@ -308,7 +309,7 @@ class AAIDallePost_Tool implements INode {
     constructor() {
         this.label = 'Answer DALL-E Post'
         this.name = 'aaiDallePost'
-        this.version = 1.0
+        this.version = 1.1
         this.type = 'AAIDallePost'
         this.icon = 'openai.svg'
         this.category = 'Tools'
@@ -459,8 +460,8 @@ class AAIDallePost_Tool implements INode {
         if (process.env.NODE_ENV === 'development') {
             baseURL = 'http://localhost:4000'
         } else {
-            // In production, use the current domain (Flowise server)
-            baseURL = process.env.DOMAIN || process.env.FLOWISE_DOMAIN || 'http://localhost:4000'
+            // In production, prefer external API host, then fall back to Flowise domain
+            baseURL = process.env.API_HOST || process.env.DOMAIN || process.env.FLOWISE_DOMAIN || 'http://localhost:4000'
         }
 
         const obj: RequestParameters = {}

--- a/packages/components/nodes/tools/CreateDalleImage/CreateDalleImage.ts
+++ b/packages/components/nodes/tools/CreateDalleImage/CreateDalleImage.ts
@@ -104,7 +104,8 @@ export class DallePostTool extends Tool {
             }
 
             // Convert FILE-STORAGE:: reference to a full URL with domain
-            const domain = process.env.DOMAIN || process.env.FLOWISE_DOMAIN || this.baseURL || 'http://localhost:4000'
+            const domain =
+                process.env.API_HOST || process.env.DOMAIN || process.env.FLOWISE_DOMAIN || this.baseURL || 'http://localhost:4000'
             const imageFileName = imageStorageUrl.replace('FILE-STORAGE::', '')
             const fullImageUrl = `${domain}/api/v1/get-upload-file?chatflowId=dalle-images&chatId=${orgId}%2F${usrId}&fileName=${imageFileName}`
 
@@ -314,7 +315,7 @@ class DallePost_Tool implements INode {
     constructor() {
         this.label = 'Dall-E Post'
         this.name = 'dallePost'
-        this.version = 1.0
+        this.version = 1.1
         this.type = 'DallePost'
         this.icon = 'openai.svg'
         this.category = 'Tools'
@@ -470,8 +471,8 @@ class DallePost_Tool implements INode {
         if (process.env.NODE_ENV === 'development') {
             baseURL = 'http://localhost:4000'
         } else {
-            // In production, use the current domain (Flowise server)
-            baseURL = process.env.DOMAIN || process.env.FLOWISE_DOMAIN || 'http://localhost:4000'
+            // In production, prefer external API host, then fall back to Flowise domain
+            baseURL = process.env.API_HOST || process.env.DOMAIN || process.env.FLOWISE_DOMAIN || 'http://localhost:4000'
         }
 
         const obj: RequestParameters = {}


### PR DESCRIPTION
This commit introduces several updates to the configuration and functionality of the DALL-E image generation tools.

### Changes:
- Added a new environment variable `API_HOST` to the manifest for better API endpoint management.
- Updated the `next.config.js` to support HTTPS for the specified hostname.
- Modified the DALL-E image tools to prioritize the new `API_HOST` variable for constructing URLs, ensuring that the tools can correctly reference the API in production environments.
- Incremented the version of the DALL-E tools from 1.0 to 1.1 to reflect these changes.

### Impact:
These updates enhance the flexibility of the API configuration and improve the reliability of image generation by ensuring the correct API endpoint is used based on the environment settings.