### PR TITLE
feat: analytics tracing, billing accuracy, and admin navigation fixes (+ streaming demo & Copilot docs)

### DIFF
--- a/copilot/.gitignore
+++ b/copilot/.gitignore
@@ -1,3 +1,4 @@
 .workspace
 scripts/*
 !scripts/copilot-switch-app.sh
+!scripts/copilot-auto-readme.md

--- a/copilot/scripts/copilot-auto-readme.md
+++ b/copilot/scripts/copilot-auto-readme.md
@@ -1,0 +1,17 @@
+# Copilot Auto-Deploy Scripts
+
+Automated deployment scripts for AWS Copilot environments.
+
+## Install
+
+```bash
+pnpm secure-run 'eval "$COPILOT_AUTO_INSTALL"'
+```
+
+## Usage
+
+```bash
+pnpm copilot:auto
+```
+
+Guides you through environment selection, domain configuration and service deployment and ensures you're using the correct AWS credentials.

--- a/packages-answers/ui/src/Admin/Chatflows/index.tsx
+++ b/packages-answers/ui/src/Admin/Chatflows/index.tsx
@@ -159,20 +159,8 @@ const AdminChatflows = () => {
         refreshChatflows()
     }
 
-    const getCanvasRoute = (chatflow: any) => {
-        // For react-router-dom Link component (relative paths - router handles base path)
-        if (chatflow.type === 'AGENTFLOW') {
-            return `/v2/agentcanvas/${chatflow.id}`
-        } else if (chatflow.type === 'MULTIAGENT') {
-            return `/agentcanvas/${chatflow.id}`
-        } else {
-            // Default to regular chatflow canvas
-            return `/canvas/${chatflow.id}`
-        }
-    }
-
     const getCanvasFullUrl = (chatflow: any) => {
-        // For window.open() (full absolute URLs with /sidekick-studio prefix)
+        // Generate full absolute URL with /sidekick-studio prefix for navigation
         if (chatflow.type === 'AGENTFLOW') {
             return `/sidekick-studio/v2/agentcanvas/${chatflow.id}`
         } else if (chatflow.type === 'MULTIAGENT') {

--- a/packages-answers/ui/src/Admin/Chatflows/index.tsx
+++ b/packages-answers/ui/src/Admin/Chatflows/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
 import {
     Box,
     Skeleton,
@@ -161,8 +160,19 @@ const AdminChatflows = () => {
     }
 
     const getCanvasRoute = (chatflow: any) => {
-        // Generate full URL path with /sidekick-studio prefix
-        // Works for both window.open() and react-router-dom Link components
+        // For react-router-dom Link component (relative paths - router handles base path)
+        if (chatflow.type === 'AGENTFLOW') {
+            return `/v2/agentcanvas/${chatflow.id}`
+        } else if (chatflow.type === 'MULTIAGENT') {
+            return `/agentcanvas/${chatflow.id}`
+        } else {
+            // Default to regular chatflow canvas
+            return `/canvas/${chatflow.id}`
+        }
+    }
+
+    const getCanvasFullUrl = (chatflow: any) => {
+        // For window.open() (full absolute URLs with /sidekick-studio prefix)
         if (chatflow.type === 'AGENTFLOW') {
             return `/sidekick-studio/v2/agentcanvas/${chatflow.id}`
         } else if (chatflow.type === 'MULTIAGENT') {
@@ -171,12 +181,6 @@ const AdminChatflows = () => {
             // Default to regular chatflow canvas
             return `/sidekick-studio/canvas/${chatflow.id}`
         }
-    }
-
-    const getCanvasFullUrl = (chatflow: any) => {
-        // Alias for getCanvasRoute for backward compatibility
-        // Both now return the same full URL with /sidekick-studio prefix
-        return getCanvasRoute(chatflow)
     }
 
     const sortData = (data: any[]) => {
@@ -354,7 +358,7 @@ const AdminChatflows = () => {
     return (
         <Box sx={{ p: { xs: 1, md: 4 } }}>
             <Box sx={{ mb: 2 }}>
-                <Button component={Link} to='/sidekick-studio/admin' size='small' variant='text'>
+                <Button onClick={() => (window.location.href = '/sidekick-studio/admin')} size='small' variant='text'>
                     ← Back to admin
                 </Button>
             </Box>
@@ -638,7 +642,7 @@ const AdminChatflows = () => {
                                                 <Tooltip title='View Template' placement='top'>
                                                     <IconButton
                                                         size='small'
-                                                        onClick={() => window.open(getCanvasRoute(fullDefaultTemplate), '_blank')}
+                                                        onClick={() => window.open(getCanvasFullUrl(fullDefaultTemplate), '_blank')}
                                                         sx={{
                                                             color: 'rgba(255, 193, 7, 0.8)',
                                                             bgcolor: 'rgba(255, 193, 7, 0.1)',
@@ -1206,19 +1210,22 @@ const AdminChatflows = () => {
                                                 <Box>
                                                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.25 }}>
                                                         <Typography
+                                                            component='a'
+                                                            href={getCanvasFullUrl(chatflow)}
+                                                            target='_blank'
+                                                            rel='noopener noreferrer'
                                                             sx={{
                                                                 color: 'rgba(255, 255, 255, 0.9)',
                                                                 cursor: 'pointer',
                                                                 fontSize: '0.875rem',
+                                                                textDecoration: 'none',
                                                                 '&:hover': {
                                                                     color: 'rgba(255, 255, 255, 1)',
                                                                     textDecoration: 'underline'
                                                                 }
                                                             }}
                                                         >
-                                                            <Link to={getCanvasRoute(chatflow)} target='_blank' rel='noopener noreferrer'>
-                                                                {chatflow.name}
-                                                            </Link>
+                                                            {chatflow.name}
                                                         </Typography>
                                                         {defaultTemplateData && chatflow.id === defaultTemplateData.id && (
                                                             <Chip

--- a/packages-answers/ui/src/Admin/Chatflows/index.tsx
+++ b/packages-answers/ui/src/Admin/Chatflows/index.tsx
@@ -161,21 +161,8 @@ const AdminChatflows = () => {
     }
 
     const getCanvasRoute = (chatflow: any) => {
-        // For react-router-dom Link component (relative paths)
-        console.log('🤖id', chatflow.id)
-        console.log('type', chatflow)
-        if (chatflow.type === 'AGENTFLOW') {
-            return `/v2/agentcanvas/${chatflow.id}`
-        } else if (chatflow.type === 'MULTIAGENT') {
-            return `/agentcanvas/${chatflow.id}`
-        } else {
-            // Default to regular chatflow canvas
-            return `/canvas/${chatflow.id}`
-        }
-    }
-
-    const getCanvasFullUrl = (chatflow: any) => {
-        // For window.open() (full URLs with base path)
+        // Generate full URL path with /sidekick-studio prefix
+        // Works for both window.open() and react-router-dom Link components
         if (chatflow.type === 'AGENTFLOW') {
             return `/sidekick-studio/v2/agentcanvas/${chatflow.id}`
         } else if (chatflow.type === 'MULTIAGENT') {
@@ -184,6 +171,12 @@ const AdminChatflows = () => {
             // Default to regular chatflow canvas
             return `/sidekick-studio/canvas/${chatflow.id}`
         }
+    }
+
+    const getCanvasFullUrl = (chatflow: any) => {
+        // Alias for getCanvasRoute for backward compatibility
+        // Both now return the same full URL with /sidekick-studio prefix
+        return getCanvasRoute(chatflow)
     }
 
     const sortData = (data: any[]) => {
@@ -330,8 +323,8 @@ const AdminChatflows = () => {
                 setRollbackConfirmOpen(false)
                 setSelectedVersionForRollback(null)
                 handleCloseVersions()
-                // Refresh data
-                window.location.reload()
+                // Refresh data without full page reload
+                refreshChatflows()
             } catch (error) {
                 console.error('Failed to rollback chatflow:', error)
             }
@@ -361,7 +354,7 @@ const AdminChatflows = () => {
     return (
         <Box sx={{ p: { xs: 1, md: 4 } }}>
             <Box sx={{ mb: 2 }}>
-                <Button component={Link} to='/admin' size='small' variant='text'>
+                <Button component={Link} to='/sidekick-studio/admin' size='small' variant='text'>
                     ← Back to admin
                 </Button>
             </Box>

--- a/packages-answers/ui/src/OrgCredentials/OrgCredentialsManager.tsx
+++ b/packages-answers/ui/src/OrgCredentials/OrgCredentialsManager.tsx
@@ -213,6 +213,11 @@ const OrgCredentialsManager: React.FC = () => {
     return (
         <Container maxWidth='lg'>
             <Box py={3}>
+                <Box sx={{ mb: 2 }}>
+                    <Button onClick={() => (window.location.href = '/sidekick-studio/admin')} size='small' variant='text'>
+                        ← Back to admin
+                    </Button>
+                </Box>
                 <Box display='flex' alignItems='center' mb={3}>
                     <SettingsIcon sx={{ mr: 2, fontSize: 32 }} />
                     <Typography variant='h4' component='h1'>

--- a/packages/components/src/flowCredentialExtractor.ts
+++ b/packages/components/src/flowCredentialExtractor.ts
@@ -7,6 +7,7 @@ interface FlowNode {
     data: {
         id: string
         type: string
+        category?: string
         credential?: string
         inputs?: {
             modelName?: string
@@ -37,6 +38,7 @@ interface CredentialInfo {
     nodeId: string
     nodeType: string
     credentialId: string
+    visibility?: string[]
 }
 
 /**
@@ -54,6 +56,7 @@ interface ModelInfo {
 interface ExtractionResult {
     credentials: CredentialInfo[]
     models: ModelInfo[]
+    hasPlatformAINodes: boolean
 }
 
 /**
@@ -68,13 +71,19 @@ function extractCredentialsAndModels(flowData: FlowData | string): ExtractionRes
     // Initialize result object
     const result: ExtractionResult = {
         credentials: [],
-        models: []
+        models: [],
+        hasPlatformAINodes: false
     }
 
     // Check if flow has nodes
     if (!flow.nodes || !Array.isArray(flow.nodes)) {
         return result
     }
+
+    // Check for AAI platform AI nodes
+    result.hasPlatformAINodes = flow.nodes.some(
+        (node) => node.data?.type?.startsWith('AAI') && ['Chat Models', 'Embeddings'].includes(node.data.category || '')
+    )
 
     // Iterate through nodes
     flow.nodes.forEach((node) => {

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -26,7 +26,18 @@ export const generateFollowUpPrompts = async (
         const providerConfig = followUpPromptsConfig[followUpPromptsConfig.selectedProvider]
         if (!providerConfig) return undefined
         const credentialId = providerConfig.credentialId as string
-        const credentialData = await getCredentialData(credentialId ?? '', options)
+
+        let credentialData: ICommonObject
+        try {
+            credentialData = await getCredentialData(credentialId ?? '', options)
+            if (!credentialData || Object.keys(credentialData).length === 0) {
+                console.warn('No credential data found for follow-up prompts, skipping generation')
+                return undefined
+            }
+        } catch (error) {
+            console.error('Error retrieving credential data for follow-up prompts:', error)
+            return undefined
+        }
         const followUpPromptsPrompt = providerConfig.prompt.replace('{history}', apiMessageContent)
 
         switch (followUpPromptsConfig.selectedProvider) {

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -42,6 +42,57 @@ import { AIMessageChunk, BaseMessageLike } from '@langchain/core/messages'
 import { Serialized } from '@langchain/core/load/serializable'
 import { JLINCTracer } from '@jlinc/langchain'
 
+/**
+ * Apply environment variable overrides for analytics providers
+ * This allows global analytics configuration via env vars without UI setup
+ *
+ * @param analyticConfig - Existing analytics config (may be empty, string, or object)
+ * @returns Analytics config with env overrides applied
+ */
+function applyEnvAnalyticsOverrides(analyticConfig?: string | object): any {
+    let analytic: any = {}
+
+    // Parse existing config if provided
+    if (typeof analyticConfig === 'string') {
+        try {
+            analytic = JSON.parse(analyticConfig)
+        } catch {
+            analytic = {}
+        }
+    } else if (analyticConfig && typeof analyticConfig === 'object') {
+        analytic = analyticConfig
+    }
+
+    // Langfuse env override - takes precedence over UI configuration
+    if (process.env.LANGFUSE_SECRET_KEY) {
+        analytic.langFuse = {
+            status: true,
+            release: process.env.LANGFUSE_RELEASE ?? process.env.GIT_COMMIT_HASH,
+            secretKey: process.env.LANGFUSE_SECRET_KEY,
+            publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+            endpoint: process.env.LANGFUSE_HOST ?? 'https://cloud.langfuse.com',
+            sdkIntegration: 'Flowise'
+        }
+    }
+
+    // Future providers can be added here:
+    // if (process.env.LANGSMITH_API_KEY) { analytic.langSmith = { ... } }
+    // if (process.env.ARIZE_API_KEY) { analytic.arize = { ... } }
+
+    return analytic
+}
+
+/**
+ * Check if analytics is enabled via UI config or environment variables
+ *
+ * @param analyticConfig - Analytics config from chatflow/agentflow
+ * @returns True if any analytics provider is configured
+ */
+export function isAnalyticsEnabled(analyticConfig?: string | object): boolean {
+    const analytic = applyEnvAnalyticsOverrides(analyticConfig)
+    return Object.keys(analytic).length > 0
+}
+
 interface AgentRun extends Run {
     actions: AgentAction[]
 }
@@ -487,20 +538,13 @@ class ExtendedLunaryHandler extends LunaryHandler {
 
 export const additionalCallbacks = async (nodeData: INodeData, options: ICommonObject) => {
     try {
-        if (!options.analytic && !process.env.LANGFUSE_SECRET_KEY) return []
+        const analytic = applyEnvAnalyticsOverrides(options.analytic)
+        if (Object.keys(analytic).length === 0) return []
 
-        const analytic = options.analytic ? JSON.parse(options.analytic) : {}
-        if (process.env.LANGFUSE_SECRET_KEY) {
-            analytic.langFuse = {
-                status: true,
-                release: process.env.LANGFUSE_RELEASE ?? process.env.GIT_COMMIT_HASH,
-                secretKey: process.env.LANGFUSE_SECRET_KEY,
-                publicKey: process.env.LANGFUSE_PUBLIC_KEY,
-                endpoint: process.env.LANGFUSE_HOST ?? 'https://cloud.langfuse.com',
-                sdkIntegration: 'Flowise'
-            }
-        }
         const callbacks: any = []
+        const parentLangfuseTrace = options.parentLangfuseTrace as LangfuseTraceClient | undefined
+        const parentLangfuseSpan = options.parentLangfuseSpan as LangfuseSpanClient | undefined
+        const analyticHandlersInstance = options.analyticHandlers as AnalyticHandler | undefined
 
         for (const provider in analytic) {
             const providerStatus = analytic[provider].status as boolean
@@ -613,7 +657,7 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                     //     metadata: metadata
                     // })
 
-                    const handler = new CallbackHandler({
+                    const handlerConfig: ICommonObject = {
                         ...langFuseOptions,
                         metadata: metadata,
                         userId: options?.user?.id,
@@ -625,7 +669,34 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                         // BUT Everything gets updatedon the root trace so the attributes and metadata are inconsistent
                         // root: trace,
                         // updateRoot: true
-                    })
+                    }
+
+                    if (parentLangfuseSpan || parentLangfuseTrace) {
+                        handlerConfig.root = parentLangfuseSpan ?? parentLangfuseTrace
+                        handlerConfig.updateRoot = false
+
+                        try {
+                            if (parentLangfuseTrace) {
+                                parentLangfuseTrace.update({
+                                    tags: [`Name:${chatflow.name}`],
+                                    metadata,
+                                    userId: options?.user?.id,
+                                    sessionId: options.sessionId,
+                                    version: chatflow.updatedDate
+                                })
+                            }
+                        } catch (err) {
+                            if (process.env.DEBUG === 'true') {
+                                console.error('Error updating Langfuse parent trace metadata:', err)
+                            }
+                        }
+
+                        analyticHandlersInstance?.setLangfuseCallbacksActive(true)
+                    } else {
+                        analyticHandlersInstance?.setLangfuseCallbacksActive(false)
+                    }
+
+                    const handler = new CallbackHandler(handlerConfig)
 
                     callbacks.push(handler)
                     //console.debug('Handler added to callbacks.')
@@ -762,13 +833,16 @@ export class AnalyticHandler {
     private analyticsConfig: string | undefined
     private chatId: string
     private createdAt: number
+    private langfuseCallbacksActive = false
+    private useNodeLevelLangfuseSpans = false
 
     private constructor(nodeData: INodeData, options: ICommonObject) {
         this.nodeData = nodeData
         this.options = options
-        this.analyticsConfig = options.analytic
+        this.analyticsConfig = JSON.stringify(applyEnvAnalyticsOverrides(options.analytic))
         this.chatId = options.chatId
         this.createdAt = Date.now()
+        this.useNodeLevelLangfuseSpans = Boolean(options.useNodeLevelLangfuseSpans)
     }
 
     static getInstance(nodeData: INodeData, options: ICommonObject): AnalyticHandler {
@@ -777,7 +851,8 @@ export class AnalyticHandler {
 
         // Reset instance if analytics config changed for this chat
         const instance = AnalyticHandler.instances.get(chatId)
-        if (instance?.analyticsConfig !== options.analytic) {
+        const currentProcessedConfig = JSON.stringify(applyEnvAnalyticsOverrides(options.analytic))
+        if (instance?.analyticsConfig !== currentProcessedConfig) {
             AnalyticHandler.resetInstance(chatId)
         }
 
@@ -805,9 +880,9 @@ export class AnalyticHandler {
         if (this.initialized) return
 
         try {
-            if (!this.options.analytic) return
+            const analytic = applyEnvAnalyticsOverrides(this.options.analytic)
+            if (Object.keys(analytic).length === 0) return
 
-            const analytic = JSON.parse(this.options.analytic)
             for (const provider in analytic) {
                 const providerStatus = analytic[provider].status as boolean
                 if (providerStatus) {
@@ -827,6 +902,22 @@ export class AnalyticHandler {
         return this.handlers
     }
 
+    setLangfuseCallbacksActive(active: boolean) {
+        this.langfuseCallbacksActive = active
+    }
+
+    isLangfuseCallbacksActive(): boolean {
+        return this.langfuseCallbacksActive
+    }
+
+    getParentTraceClient(provider: 'langFuse', traceId: string): LangfuseTraceClient | undefined {
+        if (!traceId) return undefined
+        const providerHandler = this.handlers[provider] as ICommonObject | undefined
+        const traces = providerHandler?.trace as Record<string, LangfuseTraceClient> | undefined
+        if (!traces) return undefined
+        return traces[traceId]
+    }
+
     async initializeProvider(provider: string, providerConfig: any, credentialData: any) {
         if (provider === 'langSmith') {
             const langSmithProject = providerConfig.projectName as string
@@ -841,9 +932,9 @@ export class AnalyticHandler {
             this.handlers['langSmith'] = { client, langSmithProject }
         } else if (provider === 'langFuse') {
             const release = providerConfig.release as string
-            const langFuseSecretKey = getCredentialParam('langFuseSecretKey', credentialData, this.nodeData)
-            const langFusePublicKey = getCredentialParam('langFusePublicKey', credentialData, this.nodeData)
-            const langFuseEndpoint = getCredentialParam('langFuseEndpoint', credentialData, this.nodeData)
+            const langFuseSecretKey = providerConfig?.secretKey ?? getCredentialParam('langFuseSecretKey', credentialData, this.nodeData)
+            const langFusePublicKey = providerConfig?.publicKey ?? getCredentialParam('langFusePublicKey', credentialData, this.nodeData)
+            const langFuseEndpoint = providerConfig?.endpoint ?? getCredentialParam('langFuseEndpoint', credentialData, this.nodeData)
 
             const langfuse = new Langfuse({
                 secretKey: langFuseSecretKey,
@@ -1371,15 +1462,21 @@ export class AnalyticHandler {
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langFuse')) {
-            const trace: LangfuseTraceClient | undefined = this.handlers['langFuse'].trace[parentIds['langFuse'].trace]
-            if (trace) {
-                const generation = trace.generation({
-                    name,
-                    input: input
-                })
-                this.handlers['langFuse'].generation = { [generation.id]: generation }
-                returnIds['langFuse'].generation = generation.id
-                // console.log(`Langfuse generation created: ${generation.id}`)
+            if (this.langfuseCallbacksActive || this.useNodeLevelLangfuseSpans) {
+                if (parentIds?.['langFuse']?.trace) {
+                    returnIds['langFuse'].trace = parentIds['langFuse'].trace
+                }
+            } else {
+                const trace: LangfuseTraceClient | undefined = this.handlers['langFuse'].trace[parentIds['langFuse'].trace]
+                if (trace) {
+                    const generation = trace.generation({
+                        name,
+                        input: input
+                    })
+                    this.handlers['langFuse'].generation = { [generation.id]: generation }
+                    returnIds['langFuse'].generation = generation.id
+                    // console.log(`Langfuse generation created: ${generation.id}`)
+                }
             }
         }
 
@@ -1486,12 +1583,16 @@ export class AnalyticHandler {
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langFuse')) {
-            const generation: LangfuseGenerationClient | undefined = this.handlers['langFuse'].generation[returnIds['langFuse'].generation]
-            if (generation) {
-                generation.end({
-                    output: output
-                })
-                // console.log(`Langfuse generation ended: ${generation.id}`)
+            if (!this.langfuseCallbacksActive && !this.useNodeLevelLangfuseSpans) {
+                const generationId = returnIds['langFuse'].generation
+                const generation: LangfuseGenerationClient | undefined = this.handlers['langFuse'].generation[generationId]
+                if (generation) {
+                    generation.end({
+                        output: output
+                    })
+                    delete this.handlers['langFuse'].generation[generationId]
+                    // console.log(`Langfuse generation ended: ${generation.id}`)
+                }
             }
         }
 
@@ -1561,12 +1662,16 @@ export class AnalyticHandler {
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langFuse')) {
-            const generation: LangfuseGenerationClient | undefined = this.handlers['langFuse'].generation[returnIds['langFuse'].generation]
-            if (generation) {
-                generation.end({
-                    output: error
-                })
-                // console.log(`Langfuse generation errored: ${generation.id}`)
+            if (!this.langfuseCallbacksActive && !this.useNodeLevelLangfuseSpans) {
+                const generationId = returnIds['langFuse'].generation
+                const generation: LangfuseGenerationClient | undefined = this.handlers['langFuse'].generation[generationId]
+                if (generation) {
+                    generation.end({
+                        output: error
+                    })
+                    delete this.handlers['langFuse'].generation[generationId]
+                    // console.log(`Langfuse generation errored: ${generation.id}`)
+                }
             }
         }
 
@@ -1899,6 +2004,74 @@ export class AnalyticHandler {
                 toolSpan.setStatus({ code: SpanStatusCode.ERROR, message: error.toString() })
                 toolSpan.end()
             }
+        }
+    }
+
+    /**
+     * Safely serialize a value for Langfuse trace payload
+     * Handles circular references and unserializable values
+     */
+    safeSerializeForTrace(value: any): any {
+        if (value === undefined || value === null) return value
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+        try {
+            return JSON.parse(JSON.stringify(value))
+        } catch (error) {
+            console.warn(`Failed to serialize payload for Langfuse trace: ${error instanceof Error ? error.message : String(error)}`)
+            return '[Unserializable]'
+        }
+    }
+
+    /**
+     * Create a Langfuse tool span for tracing tool execution
+     * @param parentSpan - Parent Langfuse span to attach this tool span to
+     * @param toolName - Name of the tool being executed
+     * @param args - Tool arguments/input
+     * @param metadata - Additional metadata to attach to the span
+     * @returns LangfuseSpanClient if successful, undefined otherwise
+     */
+    createToolSpan(
+        parentSpan: LangfuseSpanClient | undefined,
+        toolName: string,
+        args: any,
+        metadata?: ICommonObject
+    ): LangfuseSpanClient | undefined {
+        if (!parentSpan) return undefined
+        try {
+            return parentSpan.span({
+                name: `Tool:${toolName}`,
+                metadata: {
+                    toolName,
+                    status: 'IN_PROGRESS',
+                    ...(metadata ?? {})
+                },
+                input: {
+                    args: this.safeSerializeForTrace(args)
+                }
+            })
+        } catch (error) {
+            console.warn(`Failed to create Langfuse tool span for ${toolName}: ${error instanceof Error ? error.message : String(error)}`)
+            return undefined
+        }
+    }
+
+    /**
+     * Finalize a Langfuse tool span with status and output
+     * @param span - The Langfuse span to finalize
+     * @param status - Final status ('FINISHED' or 'ERROR')
+     * @param payload - Output data to attach to the span
+     */
+    finishToolSpan(span: LangfuseSpanClient | undefined, status: 'FINISHED' | 'ERROR', payload: ICommonObject): void {
+        if (!span) return
+        try {
+            span.update({
+                metadata: {
+                    status
+                }
+            })
+            span.end({ output: payload })
+        } catch (error) {
+            console.warn(`Failed to finalize Langfuse tool span: ${error instanceof Error ? error.message : String(error)}`)
         }
     }
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -12,5 +12,5 @@ export * from './handler'
 export * from './followUpPrompts'
 export * from './validator'
 export * from './agentflowv2Generator'
-
 export { ATLASSIAN_MCP_SERVER_URL } from './constants'
+export * from './flowCredentialExtractor'

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aai-embed-react",
-    "version": "1.0.7",
+    "version": "3.0.10",
     "description": "React library to display flowise chatbot on your website",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -35,7 +35,7 @@
         "typescript": "~5.5.4"
     },
     "peerDependencies": {
-        "aai-embed": "^3.0.0",
+        "aai-embed": "^3.0.10",
         "react": "18.x"
     }
 }

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -463,7 +463,7 @@ export interface IExecuteFlowParams extends IPredictionQueueAppServer {
     fileUploads?: IFileUpload[]
     uploadedFilesContent?: string
     isUpsert?: boolean
-    user: IUser
+    user?: IUser
     isRecursive?: boolean
     parentExecutionId?: string
     iterationContext?: ICommonObject

--- a/packages/server/src/aai-utils/billing/config.ts
+++ b/packages/server/src/aai-utils/billing/config.ts
@@ -8,7 +8,8 @@ export const log = console as unknown as Logger
 export const DEFAULT_CUSTOMER_ID = process.env.BILLING_DEFAULT_STRIPE_CUSTOMER_ID
 
 // Load environment variables with defaults
-const BILLING_CREDIT_PRICE_USD = parseFloat(process.env.BILLING_CREDIT_PRICE_USD || '0')
+// Base rate: $20 for 500,000 credits = $0.00004 per credit
+const BILLING_CREDIT_PRICE_USD = parseFloat(process.env.BILLING_CREDIT_PRICE_USD || '0.00004')
 const MARGIN_MULTIPLIER = parseFloat(process.env.BILLING_MARGIN_MULTIPLIER || '1')
 const BILLING_PRO_PLAN_CREDITS = parseInt(process.env.BILLING_PRO_PLAN_CREDITS || '500000')
 const BILLING_FREE_PLAN_CREDITS = parseInt(process.env.BILLING_FREE_PLAN_CREDITS || '10000')

--- a/packages/server/src/aai-utils/billing/core/BillingService.ts
+++ b/packages/server/src/aai-utils/billing/core/BillingService.ts
@@ -20,7 +20,7 @@ import {
 } from './types'
 import { LangfuseProvider } from '../langfuse/LangfuseProvider'
 import { StripeProvider } from '../stripe/StripeProvider'
-import { log } from '../config'
+import { log, BILLING_CONFIG } from '../config'
 import Stripe from 'stripe'
 import { MeterEventSummary } from '../stripe/types'
 
@@ -163,7 +163,7 @@ export class BillingService implements BillingProvider {
                     currency: invoice.currency,
                     dueDate: invoice.dueDate,
                     // Calculate total credits used based on the invoice amount
-                    totalCreditsUsed: Math.round(invoice.amount / (0.00004 * 100)) // Assuming $0.001 per credit
+                    totalCreditsUsed: Math.round(invoice.amount / (BILLING_CONFIG.CREDIT_TO_USD * 100))
                 }
             }
         } catch (error) {

--- a/packages/server/src/services/predictions/index.ts
+++ b/packages/server/src/services/predictions/index.ts
@@ -9,7 +9,7 @@ const buildChatflow = async (fullRequest: Request) => {
     try {
         const { chatId, question: prompt, overrideConfig } = fullRequest.body
         const chatflowId = fullRequest.params.id
-        const user = fullRequest.user!
+        const user = fullRequest.user
 
         // Ensure overrideConfig.sessionId is a valid UUID v4
         if (overrideConfig?.sessionId) {

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -89,7 +89,7 @@ const initEndingNode = async ({
     nodeOverrides,
     variableOverrides
 }: {
-    user: IUser
+    user?: IUser
     endingNodeIds: string[]
     componentNodes: IComponentNodes
     reactFlowNodes: IReactFlowNode[]
@@ -928,7 +928,7 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
             telemetry: appServer.telemetry,
             cachePool: appServer.cachePool,
             componentNodes: appServer.nodesPool.componentNodes,
-            user: req.user!,
+            user: req.user,
             isTool // used to disable streaming if incoming request its from ChatflowTool
         }
 

--- a/streaming-demo.html
+++ b/streaming-demo.html
@@ -1,0 +1,819 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>AnswerAI Streaming Demo</title>
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+
+            body {
+                font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                min-height: 100vh;
+                padding: 20px;
+            }
+
+            .container {
+                max-width: 1200px;
+                margin: 0 auto;
+                background: white;
+                border-radius: 15px;
+                box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+                overflow: hidden;
+            }
+
+            .header {
+                background: linear-gradient(135deg, #24c3a1 0%, #1a9b7f 100%);
+                color: white;
+                padding: 30px;
+                text-align: center;
+            }
+
+            .header h1 {
+                font-size: 2.5em;
+                margin-bottom: 10px;
+                font-weight: 300;
+            }
+
+            .header p {
+                font-size: 1.1em;
+                opacity: 0.9;
+            }
+
+            .content {
+                padding: 30px;
+            }
+
+            .form-section {
+                background: #f8f9fa;
+                padding: 25px;
+                border-radius: 10px;
+                margin-bottom: 30px;
+            }
+
+            .form-group {
+                margin-bottom: 20px;
+            }
+
+            label {
+                display: block;
+                margin-bottom: 8px;
+                font-weight: 600;
+                color: #333;
+            }
+
+            input,
+            select,
+            textarea {
+                width: 100%;
+                padding: 12px;
+                border: 2px solid #e1e5e9;
+                border-radius: 8px;
+                font-size: 16px;
+                transition: border-color 0.3s;
+            }
+
+            input:focus,
+            select:focus,
+            textarea:focus {
+                outline: none;
+                border-color: #24c3a1;
+            }
+
+            .button-group {
+                display: flex;
+                gap: 15px;
+                margin-top: 20px;
+            }
+
+            button {
+                padding: 12px 25px;
+                border: none;
+                border-radius: 8px;
+                font-size: 16px;
+                font-weight: 600;
+                cursor: pointer;
+                transition: all 0.3s;
+            }
+
+            .btn-primary {
+                background: #24c3a1;
+                color: white;
+            }
+
+            .btn-primary:hover:not(:disabled) {
+                background: #1a9b7f;
+                transform: translateY(-2px);
+            }
+
+            .btn-secondary {
+                background: #6c757d;
+                color: white;
+            }
+
+            .btn-secondary:hover:not(:disabled) {
+                background: #545b62;
+            }
+
+            button:disabled {
+                opacity: 0.6;
+                cursor: not-allowed;
+            }
+
+            .status-section {
+                background: #f8f9fa;
+                border-radius: 10px;
+                padding: 20px;
+                margin-bottom: 20px;
+            }
+
+            .status-header {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                margin-bottom: 15px;
+            }
+
+            .status-indicator {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #6c757d;
+            }
+
+            .status-indicator.active {
+                background: #24c3a1;
+                animation: pulse 2s infinite;
+            }
+
+            @keyframes pulse {
+                0% {
+                    opacity: 1;
+                }
+                50% {
+                    opacity: 0.5;
+                }
+                100% {
+                    opacity: 1;
+                }
+            }
+
+            .progress-bar {
+                width: 100%;
+                height: 6px;
+                background: #e1e5e9;
+                border-radius: 3px;
+                overflow: hidden;
+                margin-bottom: 15px;
+            }
+
+            .progress-fill {
+                height: 100%;
+                background: linear-gradient(90deg, #24c3a1, #1a9b7f);
+                width: 0%;
+                transition: width 0.3s;
+                animation: shimmer 2s infinite;
+            }
+
+            @keyframes shimmer {
+                0% {
+                    background-position: -200px 0;
+                }
+                100% {
+                    background-position: 200px 0;
+                }
+            }
+
+            .current-node {
+                background: #e3f2fd;
+                border-left: 4px solid #2196f3;
+                padding: 10px 15px;
+                margin-bottom: 15px;
+                border-radius: 0 8px 8px 0;
+            }
+
+            .progress-log {
+                background: #1e1e1e;
+                color: #00ff00;
+                padding: 20px;
+                border-radius: 8px;
+                font-family: 'Courier New', monospace;
+                font-size: 14px;
+                height: 200px;
+                overflow-y: auto;
+                white-space: pre-wrap;
+                margin-bottom: 20px;
+            }
+
+            .results-section {
+                background: #f8f9fa;
+                border-radius: 10px;
+                padding: 20px;
+            }
+
+            .result-item {
+                background: white;
+                border-radius: 8px;
+                padding: 20px;
+                margin-bottom: 15px;
+                border-left: 4px solid #24c3a1;
+            }
+
+            .result-title {
+                font-weight: 600;
+                color: #24c3a1;
+                margin-bottom: 10px;
+                font-size: 1.1em;
+            }
+
+            .result-content {
+                color: #333;
+                line-height: 1.6;
+            }
+
+            .streaming-response {
+                background: #fff3cd;
+                border: 1px solid #ffeaa7;
+                border-radius: 8px;
+                padding: 15px;
+                margin-bottom: 15px;
+            }
+
+            .streaming-response h4 {
+                color: #856404;
+                margin-bottom: 10px;
+            }
+
+            .event-counts {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+                gap: 10px;
+                margin-top: 20px;
+            }
+
+            .event-count {
+                background: white;
+                padding: 10px;
+                border-radius: 6px;
+                text-align: center;
+                border: 1px solid #e1e5e9;
+            }
+
+            .event-count-number {
+                font-size: 1.5em;
+                font-weight: bold;
+                color: #24c3a1;
+            }
+
+            .event-count-label {
+                font-size: 0.9em;
+                color: #666;
+            }
+
+            .hidden {
+                display: none;
+            }
+
+            .error-message {
+                background: #f8d7da;
+                color: #721c24;
+                padding: 15px;
+                border-radius: 8px;
+                margin-bottom: 15px;
+                border-left: 4px solid #dc3545;
+            }
+
+            .code-block {
+                background: #f4f4f4;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                padding: 10px;
+                font-family: 'Courier New', monospace;
+                font-size: 0.9em;
+                overflow-x: auto;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <div class="header">
+                <h1>🤖 AnswerAI Direct Streaming Demo</h1>
+                <p>Connect directly to AnswerAI for real-time AI agent streaming (no local service required)</p>
+            </div>
+
+            <div class="content">
+                <!-- Configuration Form -->
+                <div class="form-section">
+                    <h3>Configuration</h3>
+                    <div class="form-group">
+                        <label for="answerAiUrl">AnswerAI Server URL:</label>
+                        <input type="text" id="answerAiUrl" value="http://localhost:4000" placeholder="http://localhost:4000" />
+                        <small style="color: #666; font-size: 0.9em">Direct AnswerAI endpoint (not your local service)</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="chatflowId">Chatflow ID:</label>
+                        <input type="text" id="chatflowId" placeholder="8e56531d-f396-4afa-a864-fcea5dd97ab6" />
+                        <small style="color: #666; font-size: 0.9em">Your AnswerAI chatflow ID for domain research</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="question">Research Question:</label>
+                        <input
+                            type="text"
+                            id="question"
+                            value="Medical devices for cardiac monitoring"
+                            placeholder="What domain/topic to research"
+                        />
+                        <small style="color: #666; font-size: 0.9em">The domain or topic you want the AI to research</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="streamingMode">Streaming Mode:</label>
+                        <select id="streamingMode">
+                            <option value="user-friendly">User Friendly (Simplified)</option>
+                            <option value="verbose">Verbose (All Events)</option>
+                        </select>
+                    </div>
+                    <div class="button-group">
+                        <button id="startBtn" class="btn-primary">🚀 Start Analysis</button>
+                        <button id="stopBtn" class="btn-secondary" disabled>⏹ Stop Analysis</button>
+                        <button id="clearBtn" class="btn-secondary">🗑 Clear Results</button>
+                    </div>
+                </div>
+
+                <!-- Status Section -->
+                <div id="statusSection" class="status-section hidden">
+                    <div class="status-header">
+                        <div id="statusIndicator" class="status-indicator"></div>
+                        <h3>Analysis Status</h3>
+                        <span id="duration">0s</span>
+                    </div>
+                    <div class="progress-bar">
+                        <div id="progressFill" class="progress-fill"></div>
+                    </div>
+                    <div id="currentNode" class="current-node hidden">
+                        <strong>Current Node:</strong> <span id="currentNodeText">-</span>
+                    </div>
+                    <div class="progress-log" id="progressLog"></div>
+                </div>
+
+                <!-- Streaming Response -->
+                <div id="streamingSection" class="hidden">
+                    <div class="streaming-response">
+                        <h4>🤖 Live AI Response</h4>
+                        <div id="streamingContent"></div>
+                    </div>
+                </div>
+
+                <!-- Results Section -->
+                <div id="resultsSection" class="results-section hidden">
+                    <h3>Analysis Results</h3>
+                    <div id="resultsContainer"></div>
+
+                    <!-- Event Statistics -->
+                    <div class="event-counts" id="eventCounts"></div>
+                </div>
+
+                <!-- Error Section -->
+                <div id="errorSection" class="error-message hidden"><strong>Error:</strong> <span id="errorMessage"></span></div>
+            </div>
+        </div>
+
+        <script>
+            // Global variables
+            let abortController = null
+            let startTime = null
+            let durationInterval = null
+            let eventCounts = {}
+            let analysisResults = {}
+            let streamingResponse = ''
+            let elements = {}
+
+            // Initialize DOM elements when page loads
+            document.addEventListener('DOMContentLoaded', function () {
+                elements = {
+                    answerAiUrl: document.getElementById('answerAiUrl'),
+                    chatflowId: document.getElementById('chatflowId'),
+                    question: document.getElementById('question'),
+                    streamingMode: document.getElementById('streamingMode'),
+                    startBtn: document.getElementById('startBtn'),
+                    stopBtn: document.getElementById('stopBtn'),
+                    clearBtn: document.getElementById('clearBtn'),
+                    statusSection: document.getElementById('statusSection'),
+                    statusIndicator: document.getElementById('statusIndicator'),
+                    duration: document.getElementById('duration'),
+                    progressFill: document.getElementById('progressFill'),
+                    currentNode: document.getElementById('currentNode'),
+                    currentNodeText: document.getElementById('currentNodeText'),
+                    progressLog: document.getElementById('progressLog'),
+                    streamingSection: document.getElementById('streamingSection'),
+                    streamingContent: document.getElementById('streamingContent'),
+                    resultsSection: document.getElementById('resultsSection'),
+                    resultsContainer: document.getElementById('resultsContainer'),
+                    eventCounts: document.getElementById('eventCounts'),
+                    errorSection: document.getElementById('errorSection'),
+                    errorMessage: document.getElementById('errorMessage')
+                }
+
+                // Event listeners
+                elements.startBtn.addEventListener('click', startAnalysis)
+                elements.stopBtn.addEventListener('click', stopAnalysis)
+                elements.clearBtn.addEventListener('click', clearResults)
+
+                // Initialize
+                logProgress(
+                    '🚀 Direct AnswerAI Demo ready! Configure your AnswerAI server and chatflow, then click "Start Analysis"',
+                    'success'
+                )
+            })
+
+            // Utility functions
+            function generateChatId() {
+                return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+                    const r = (Math.random() * 16) | 0
+                    const v = c == 'x' ? r : (r & 0x3) | 0x8
+                    return v.toString(16)
+                })
+            }
+
+            function formatDuration(ms) {
+                const seconds = Math.floor(ms / 1000)
+                const minutes = Math.floor(seconds / 60)
+                if (minutes > 0) {
+                    return `${minutes}m ${seconds % 60}s`
+                }
+                return `${seconds}s`
+            }
+
+            function logProgress(message, type = 'info') {
+                const timestamp = new Date().toLocaleTimeString()
+                const colors = {
+                    info: '#00ff00',
+                    warning: '#ffff00',
+                    error: '#ff0000',
+                    success: '#00ff88'
+                }
+
+                const logEntry = `[${timestamp}] ${message}\n`
+                elements.progressLog.innerHTML += `<span style="color: ${colors[type] || colors.info}">${logEntry}</span>`
+                elements.progressLog.scrollTop = elements.progressLog.scrollHeight
+            }
+
+            function showError(message) {
+                elements.errorMessage.textContent = message
+                elements.errorSection.classList.remove('hidden')
+                logProgress(`❌ ${message}`, 'error')
+            }
+
+            function hideError() {
+                elements.errorSection.classList.add('hidden')
+            }
+
+            function updateEventCounts() {
+                elements.eventCounts.innerHTML = ''
+                Object.entries(eventCounts).forEach(([eventType, count]) => {
+                    const eventDiv = document.createElement('div')
+                    eventDiv.className = 'event-count'
+                    eventDiv.innerHTML = `
+                    <div class="event-count-number">${count}</div>
+                    <div class="event-count-label">${eventType}</div>
+                `
+                    elements.eventCounts.appendChild(eventDiv)
+                })
+            }
+
+            function updateResults() {
+                elements.resultsContainer.innerHTML = ''
+
+                // Show streaming response first if available
+                if (streamingResponse) {
+                    elements.streamingContent.innerHTML = streamingResponse.replace(/\n/g, '<br>')
+                    elements.streamingSection.classList.remove('hidden')
+                }
+
+                // Show other analysis results
+                Object.entries(analysisResults).forEach(([key, value]) => {
+                    if (key === 'streamingResponse') return // Skip, handled above
+
+                    const resultDiv = document.createElement('div')
+                    resultDiv.className = 'result-item'
+
+                    const title = key.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase())
+
+                    let content = value
+                    if (typeof value === 'object') {
+                        content = `<div class="code-block">${JSON.stringify(value, null, 2)}</div>`
+                    } else if (typeof value === 'string' && value.length > 200) {
+                        content = value.replace(/\n/g, '<br>')
+                    }
+
+                    resultDiv.innerHTML = `
+                    <div class="result-title">${title}</div>
+                    <div class="result-content">${content}</div>
+                `
+
+                    elements.resultsContainer.appendChild(resultDiv)
+                })
+
+                if (Object.keys(analysisResults).length > 0 || streamingResponse) {
+                    elements.resultsSection.classList.remove('hidden')
+                }
+            }
+
+            // SSE Parsing function (from streamingUtils.js)
+            function parseSSE(chunk) {
+                const lines = chunk.split('\n')
+                const events = []
+
+                for (let i = 0; i < lines.length; i++) {
+                    const line = lines[i].trim()
+                    if (line.startsWith('data:')) {
+                        const data = line.substring(5).trim()
+                        if (data && data !== '[DONE]') {
+                            try {
+                                const parsed = JSON.parse(data)
+                                events.push(parsed)
+                            } catch (e) {
+                                // Skip invalid JSON
+                            }
+                        }
+                    }
+                }
+
+                return events
+            }
+
+            // Event handlers
+            function handleUserFriendlyEvent(eventType, data) {
+                const isVerbose = elements.streamingMode.value === 'verbose'
+
+                switch (eventType) {
+                    case 'start':
+                        logProgress(`🚀 ${data}`, 'success')
+                        break
+
+                    case 'token':
+                        streamingResponse += data
+                        updateResults()
+                        if (isVerbose) {
+                            logProgress(`Token: ${data}`)
+                        }
+                        break
+
+                    case 'nextAgentFlow':
+                        if (data.status === 'INPROGRESS') {
+                            elements.currentNodeText.textContent = data.nodeLabel
+                            elements.currentNode.classList.remove('hidden')
+                            logProgress(`▶ ${data.nodeLabel}...`)
+                        } else if (data.status === 'FINISHED') {
+                            logProgress(`✓ ${data.nodeLabel} completed`, 'success')
+                        } else if (data.status === 'ERROR') {
+                            logProgress(`✗ ${data.nodeLabel} failed`, 'error')
+                            if (data.error) {
+                                logProgress(`  Error: ${data.error}`, 'error')
+                            }
+                        } else if (data.status === 'STOPPED') {
+                            logProgress(`⏸ ${data.nodeLabel} stopped`, 'warning')
+                        }
+                        break
+
+                    case 'agentFlowExecutedData':
+                        if (Array.isArray(data)) {
+                            data.forEach((node) => {
+                                if (node.output?.content) {
+                                    try {
+                                        const parsed = JSON.parse(node.output.content)
+                                        if (parsed && typeof parsed === 'object') {
+                                            analysisResults = { ...analysisResults, ...parsed }
+                                            logProgress(`📊 Received structured data from ${node.nodeLabel}`)
+                                        }
+                                    } catch (e) {
+                                        const nodeKey = node.nodeLabel || `Step_${Date.now()}`
+                                        analysisResults[nodeKey] = node.output.content
+                                        logProgress(`📝 Received text from ${node.nodeLabel}`)
+                                    }
+                                }
+                            })
+                            updateResults()
+                        }
+                        break
+
+                    case 'action':
+                        logProgress('⏸ Waiting for approval...', 'warning')
+                        break
+
+                    case 'error':
+                        logProgress(`❌ Error: ${data}`, 'error')
+                        showError(data)
+                        break
+
+                    case 'end':
+                        logProgress('✅ Analysis completed', 'success')
+                        stopAnalysis()
+                        break
+
+                    case 'domainUpdated':
+                        logProgress('💾 Analysis saved to database', 'success')
+                        break
+
+                    case 'abort':
+                        logProgress('⏸ Analysis cancelled', 'warning')
+                        break
+
+                    default:
+                        if (isVerbose) {
+                            logProgress(`📡 ${eventType}: ${JSON.stringify(data)}`)
+                        }
+
+                        // Try to extract useful data from unknown events
+                        if (data && typeof data === 'object') {
+                            if (data.text || data.response || data.content) {
+                                analysisResults[`${eventType}_response`] = data.text || data.response || data.content
+                                updateResults()
+                            }
+                            if (data.analysis || data.result) {
+                                analysisResults[eventType] = data.analysis || data.result
+                                updateResults()
+                            }
+                        }
+                }
+            }
+
+            // Main streaming function
+            async function startAnalysis() {
+                const answerAiUrl = elements.answerAiUrl.value.trim()
+                const chatflowId = elements.chatflowId.value.trim()
+                const question = elements.question.value.trim()
+
+                if (!answerAiUrl || !chatflowId || !question) {
+                    showError('Please fill in all required fields')
+                    return
+                }
+
+                hideError()
+
+                // Reset state
+                eventCounts = {}
+                analysisResults = {}
+                streamingResponse = ''
+                elements.progressLog.innerHTML = ''
+                elements.resultsContainer.innerHTML = ''
+                elements.streamingContent.innerHTML = ''
+
+                // Show status section
+                elements.statusSection.classList.remove('hidden')
+                elements.statusIndicator.classList.add('active')
+                elements.startBtn.disabled = true
+                elements.stopBtn.disabled = false
+
+                // Start duration timer
+                startTime = Date.now()
+                durationInterval = setInterval(() => {
+                    const elapsed = Date.now() - startTime
+                    elements.duration.textContent = formatDuration(elapsed)
+                }, 1000)
+
+                abortController = new AbortController()
+
+                try {
+                    const chatId = generateChatId()
+                    // Direct AnswerAI endpoint like in alpha.js
+                    const url = `${answerAiUrl}/api/v1/prediction/${chatflowId}`
+
+                    const payload = {
+                        question: question,
+                        streaming: true,
+                        chatId: chatId
+                    }
+
+                    logProgress(`🔗 Connecting to: ${url}`, 'info')
+                    logProgress(`📋 Chat ID: ${chatId}`, 'info')
+                    logProgress(`📋 Payload: ${JSON.stringify(payload)}`, 'info')
+
+                    const response = await fetch(url, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(payload),
+                        signal: abortController.signal
+                    })
+
+                    if (!response.ok) {
+                        const errorText = await response.text()
+                        throw new Error(`HTTP ${response.status}: ${errorText}`)
+                    }
+
+                    // Check if response is streaming or not
+                    const contentType = response.headers.get('content-type')
+                    logProgress(`📡 Response Content-Type: ${contentType}`, 'info')
+
+                    if (contentType && contentType.includes('application/json')) {
+                        // Non-streaming response - handle as single JSON
+                        logProgress('⚠️ Received non-streaming JSON response', 'warning')
+                        const jsonResponse = await response.json()
+                        logProgress('📄 Complete response received at once', 'info')
+
+                        // Display the non-streaming response
+                        if (jsonResponse.text) {
+                            streamingResponse = jsonResponse.text
+                            updateResults()
+                        }
+
+                        // Show the full response in results
+                        analysisResults['Complete Response'] = jsonResponse
+                        updateResults()
+
+                        logProgress('✅ Non-streaming analysis completed', 'success')
+                        stopAnalysis()
+                        return
+                    }
+
+                    if (!response.body) {
+                        throw new Error('No response body')
+                    }
+
+                    const reader = response.body.getReader()
+                    const decoder = new TextDecoder()
+                    let buffer = ''
+
+                    logProgress('📡 Streaming started... (SSE mode)', 'success')
+                    logProgress(`📡 Expected Content-Type: text/event-stream or text/plain`, 'info')
+
+                    while (true) {
+                        const { done, value } = await reader.read()
+
+                        if (done) {
+                            break
+                        }
+
+                        buffer += decoder.decode(value, { stream: true })
+
+                        // Process complete SSE messages
+                        const events = parseSSE(buffer)
+                        events.forEach((event) => {
+                            const { event: eventType, data } = event
+
+                            // Count events
+                            eventCounts[eventType] = (eventCounts[eventType] || 0) + 1
+                            updateEventCounts()
+
+                            // Handle event
+                            handleUserFriendlyEvent(eventType, data)
+                        })
+
+                        // Keep incomplete message in buffer
+                        const lastNewline = buffer.lastIndexOf('\n\n')
+                        if (lastNewline !== -1) {
+                            buffer = buffer.substring(lastNewline + 2)
+                        }
+                    }
+
+                    logProgress('🎉 Streaming completed successfully', 'success')
+                } catch (error) {
+                    if (error.name === 'AbortError') {
+                        logProgress('⏸ Stream was cancelled', 'warning')
+                    } else {
+                        showError(error.message)
+                        console.error('Streaming error:', error)
+                    }
+                } finally {
+                    stopAnalysis()
+                }
+            }
+
+            function stopAnalysis() {
+                if (abortController) {
+                    abortController.abort()
+                    abortController = null
+                }
+
+                if (durationInterval) {
+                    clearInterval(durationInterval)
+                    durationInterval = null
+                }
+
+                elements.statusIndicator.classList.remove('active')
+                elements.startBtn.disabled = false
+                elements.stopBtn.disabled = true
+                elements.currentNode.classList.add('hidden')
+            }
+
+            function clearResults() {
+                eventCounts = {}
+                analysisResults = {}
+                streamingResponse = ''
+                elements.progressLog.innerHTML = ''
+                elements.resultsContainer.innerHTML = ''
+                elements.streamingContent.innerHTML = ''
+                elements.statusSection.classList.add('hidden')
+                elements.streamingSection.classList.add('hidden')
+                elements.resultsSection.classList.add('hidden')
+                hideError()
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Title
feat: analytics tracing, billing accuracy, and admin navigation fixes (+ streaming demo & Copilot docs)

## Description

### Motivation & Scope
- Introduces robust analytics tracing via Langfuse with environment-based overrides, node-level spans, and safe serialization.
- Improves admin navigation and chatflow canvas linking under `/sidekick-studio`.
- Hardens follow-up prompts when credentials are unavailable.
- Corrects billing calculations and ownership attribution using platform node detection.
- Adds a direct SSE streaming demo and Copilot auto-deploy documentation.
- Synchronizes embed packages with latest versions.
- Includes staging merges reflected in server and component interfaces.

### UI — Admin & Org Credentials
- **`packages-answers/ui/src/Admin/Chatflows/index.tsx`**
  - Removed `react-router-dom` `Link` usage for certain elements; now uses absolute paths and `window.open` / anchor tags:
    - `getCanvasFullUrl(chatflow)` centralizes URL generation with `/sidekick-studio` prefix.
    - Template “View” now opens `getCanvasFullUrl(...)`.
    - Chatflow name is rendered as `<Typography component="a" href=... target="_blank">`.
  - Replaced full page reload on rollback with `refreshChatflows()` for smoother UX.
  - “Back to admin” now navigates to `/sidekick-studio/admin` via `window.location.href`.
- **`packages-answers/ui/src/OrgCredentials/OrgCredentialsManager.tsx`**
  - Adds a “Back to admin” button pointing to `/sidekick-studio/admin`.

### DevEx — Copilot
- **`.gitignore`**: track `scripts/copilot-auto-readme.md`.
- **`copilot/scripts/copilot-auto-readme.md`**: install & usage for `pnpm copilot:auto`.

### Components — Agentflow/LLM/ConditionAgent
- **Common Enhancements**
  - Import `additionalCallbacks` and wire **Langfuse** through `options._llmCallOptions.callbacks`.
  - Introduce `options._llmCallOptions` to pass `signal` and callbacks consistently to `invoke/stream`.
  - Streaming handlers now accept `options` instead of raw `AbortController`.
  - Summary buffer & history helpers accept `options` and use shared call options.
- **`Agent/Agent.ts`**
  - Import `LangfuseSpanClient`; attach `options._parentToolSpan`.
  - Create per-tool Langfuse spans (`createToolSpan`) and finalize with `finishToolSpan` on success/error.
  - Route all LLM calls through `options._llmCallOptions`; propagate spans during tool loops.
- **`ConditionAgent/ConditionAgent.ts` & `LLM/LLM.ts`**
  - Same callback + call-option wiring as Agent.
  - Token-limit summary paths now use `llmCallOptions`.

### Components — Utilities & Exports
- **`src/flowCredentialExtractor.ts`**
  - Adds `category?`, `visibility?`, and `hasPlatformAINodes` detection for AAI nodes (`Chat Models`, `Embeddings`).
  - Returned type `ExtractionResult` now includes `hasPlatformAINodes`.
- **`src/followUpPrompts.ts`**
  - Defensive credential fetch with try/catch; skip generation if missing/empty.
- **`src/handler.ts`**
  - New helpers:
    - `applyEnvAnalyticsOverrides()` – env-first analytics config (e.g., `LANGFUSE_*`).
    - `isAnalyticsEnabled()` – centralized enablement check.
  - `additionalCallbacks()` honors parent trace/span; toggles handler activity flags.
  - `AnalyticHandler`:
    - Tracks whether callback-based spans are active; supports node-level spans.
    - Safe JSON serialization for trace payloads.
    - Tool span helpers: `createToolSpan` / `finishToolSpan`.
    - Reads env overrides and supports provider config precedence.
  - **Exports**: re-exports `flowCredentialExtractor`.
- **`src/index.ts`**
  - Exports `flowCredentialExtractor`.

### Server — Billing, Interfaces, Predictions, Build
- **Billing**
  - **`aai-utils/billing/config.ts`**: default credit price set to **$0.00004** (base: $20 / 500k).
  - **`core/BillingService.ts`**: reads `BILLING_CONFIG.CREDIT_TO_USD` for credit calculations.
  - **`langfuse/LangfuseProvider.ts`**:
    - Determines `aiCredentialsOwnership` using `extractCredentialsAndModels` + DB check for AAI nodes.
    - Caches platform-node detection per chatflow during a sync; clears afterward.
    - Includes ownership flag in cost breakdown and credit conversion.
- **Interfaces**
  - **`server/src/Interface.ts`**: `IExecuteFlowParams.user` made optional.
- **Predictions**
  - **`services/predictions/index.ts`**: `user` now optional when building chatflow.
- **Agentflow/Chatflow Build**
  - **`utils/buildAgentflow.ts`**
    - Accepts optional `user`.
    - Uses `isAnalyticsEnabled()`; initializes `AnalyticHandler` with `useNodeLevelLangfuseSpans`.
    - Creates per-node **Langfuse spans** (`spanName=node label/name`), attaches inputs/outputs, status, timings.
    - Propagates `parentLangfuseTrace/span` through recursive and iteration paths.
    - Updates parent trace metadata (final output, status, node count).
  - **`utils/buildChatflow.ts`**: `user` optional during util build.

### Demos
- **`streaming-demo.html`**: Browser-only SSE demo to connect directly to `/api/v1/prediction/:chatflowId` with live token streaming, node progress, event counters, and structured result rendering.

### Embed Packages
- **Submodule** `packages/embed` → `fa836ede40e0e74fd7df445e367aeaaa2b3d8cfc`.
- **`packages/embed-react/package.json`**
  - Version **1.0.7 → 3.0.10**.
  - Peer dep `aai-embed` **^3.0.0 → ^3.0.10**.

### Expected Impact
- **Observability**: End-to-end tracing with parent trace/span chaining; per-tool spans; safer payloads.
- **UX**: Faster admin rollback refresh; consistent `/sidekick-studio` routing; explicit external links.
- **Stability**: Follow-up prompts no longer fail hard on missing creds.
- **Billing Accuracy**: Correct platform vs user ownership attribution; configurable credit pricing.
- **DX**: Turnkey SSE demo; environment-driven analytics setup.

### Breaking Changes
- **Type changes**: `user` is now optional in multiple server interfaces (`IExecuteFlowParams`, execute paths). Callers relying on non-null assertions may need adjustments.
- **Routing**: Admin links now favor absolute `/sidekick-studio/...` paths and direct navigation; any components expecting `react-router-dom Link` wrapping those elements may need review.
- **Analytics Behavior**: Environment variables can **override** UI analytics settings (Langfuse). Deployments should verify envs to avoid unintended tracing.

### Config / Env
- **New/Updated**:
  - `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST`, `LANGFUSE_RELEASE`, `GIT_COMMIT_HASH` (env override support).
  - `BILLING_CREDIT_PRICE_USD` default now `0.00004`.
  - `BILLING_MARGIN_MULTIPLIER` (existing).
- No DB schema changes apparent.

### Tests / Validation
- **Admin UI**
  - Verify canvas links open correct paths for `AGENTFLOW`, `MULTIAGENT`, and default types.
  - Confirm rollback uses `refreshChatflows()` without full reload.
  - Check “Back to admin” buttons in Admin & Org Credentials navigate to `/sidekick-studio/admin`.
- **Analytics**
  - With Langfuse envs set, confirm callbacks activate and node/tool spans appear with inputs/outputs and statuses.
  - Validate parent trace updates on flow completion, including node count and final output.
- **Billing**
  - Run Langfuse sync with traces from chatflows containing AAI nodes; ensure `aiCredentialsOwnership` resolves to `platform` and credits compute via `BILLING_CONFIG`.
- **Follow-up Prompts**
  - Remove/invalid credential → generation skipped without throwing; logs warning.
- **Streaming Demo**
  - Use `streaming-demo.html` against `/api/v1/prediction/:id` with `streaming: true` and confirm live tokens, events, and structured results render.
- **Embed**
  - Build `aai-embed-react@3.0.10` with `aai-embed@^3.0.10`; smoke test mounting.
