### PR TITLE
feat(ANS-25): improve credentials modal and assistant/sidekick card i…

### DIFF
--- a/packages-answers/ui/src/AssistantInfoCard.tsx
+++ b/packages-answers/ui/src/AssistantInfoCard.tsx
@@ -7,8 +7,8 @@ import {
     Edit as EditIcon,
     ExpandMore as ExpandMoreIcon,
     ContentCopy as ContentCopyIcon,
-    WarningAmber as WarningAmberIcon,
-    CheckCircle as CheckCircleIcon
+    LockOpen as LockOpenIcon,
+    Lock as LockIcon
 } from '@mui/icons-material'
 import { styled } from '@mui/system'
 import { useSelector } from 'react-redux'
@@ -342,7 +342,7 @@ const AssistantInfoCard = ({
                                         }
                                     }}
                                 >
-                                    {needsSetup ? <WarningAmberIcon /> : <CheckCircleIcon />}
+                                    {needsSetup ? <LockOpenIcon /> : <LockIcon />}
                                 </WhiteIconButton>
                             </Tooltip>
                         )}

--- a/packages-answers/ui/src/SidekickSelect/SidekickCard.tsx
+++ b/packages-answers/ui/src/SidekickSelect/SidekickCard.tsx
@@ -6,8 +6,8 @@ import {
     Visibility as VisibilityIcon,
     Edit as EditIcon,
     ContentCopy as IconCopy,
-    WarningAmber as WarningAmberIcon,
-    CheckCircle as CheckCircleIcon
+    LockOpen as LockOpenIcon,
+    Lock as LockIcon
 } from '@mui/icons-material'
 import { useCallback, useState } from 'react'
 import { Sidekick } from './SidekickSelect.types'
@@ -285,7 +285,7 @@ const SidekickCard = ({
                                         }
                                     }}
                                 >
-                                    {needsSetup ? <WarningAmberIcon /> : <CheckCircleIcon />}
+                                    {needsSetup ? <LockOpenIcon /> : <LockIcon />}
                                 </WhiteIconButton>
                             </Tooltip>
                         )}

--- a/packages/ui/src/utils/credentialModalPreference.js
+++ b/packages/ui/src/utils/credentialModalPreference.js
@@ -1,0 +1,40 @@
+const STORAGE_KEY_PREFIX = 'ta:credentialModal:dismissed:'
+
+const buildKey = (scope) => {
+    if (!scope) return null
+    return `${STORAGE_KEY_PREFIX}${scope}`
+}
+
+export const getCredentialModalDismissed = (scope) => {
+    if (typeof window === 'undefined') return false
+    const storageKey = buildKey(scope)
+    if (!storageKey) return false
+
+    try {
+        return window.localStorage.getItem(storageKey) === 'true'
+    } catch (error) {
+        console.warn('Failed to read credential modal preference:', error)
+        return false
+    }
+}
+
+export const setCredentialModalDismissed = (scope, value) => {
+    if (typeof window === 'undefined') return
+    const storageKey = buildKey(scope)
+    if (!storageKey) return
+
+    try {
+        if (value) {
+            window.localStorage.setItem(storageKey, 'true')
+        } else {
+            window.localStorage.removeItem(storageKey)
+        }
+    } catch (error) {
+        console.warn('Failed to persist credential modal preference:', error)
+    }
+}
+
+export default {
+    getCredentialModalDismissed,
+    setCredentialModalDismissed
+}

--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -17,8 +17,8 @@ import {
     IconX,
     IconCode,
     IconAdjustmentsHorizontal,
-    IconCircleCheck,
-    IconAlertCircle
+    IconLock,
+    IconLockOpen
 } from '@tabler/icons-react'
 
 // project imports
@@ -507,7 +507,7 @@ const CanvasHeader = forwardRef(({ chatflow, isAgentCanvas, isAgentflowV2, handl
                                 window.dispatchEvent(new Event('popstate'))
                             }}
                         >
-                            {needsSetup ? <IconAlertCircle stroke={1.5} size='1.3rem' /> : <IconCircleCheck stroke={1.5} size='1.3rem' />}
+                            {needsSetup ? <IconLockOpen stroke={1.5} size='1.3rem' /> : <IconLock stroke={1.5} size='1.3rem' />}
                         </Avatar>
                     </ButtonBase>
                     <ButtonBase title={`Save ${title}`} sx={{ borderRadius: '50%', mr: 2 }}>

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -110,7 +110,15 @@ const Canvas = ({ chatflowid: chatflowId }) => {
     const reactFlowWrapper = useRef(null)
     const canvasHeaderRef = useRef(null)
 
-    const { showCredentialModal, missingCredentials, checkCredentials, handleAssign, handleSkip, handleCancel } = useCredentialChecker()
+    const {
+        showCredentialModal,
+        missingCredentials,
+        checkCredentials,
+        initialDontShowAgain,
+        handleAssign,
+        handleSkip,
+        handleCancel
+    } = useCredentialChecker()
 
     // ==============================|| Chatflow API ||============================== //
 
@@ -812,6 +820,7 @@ const Canvas = ({ chatflowid: chatflowId }) => {
                 onSkip={handleSkip}
                 onCancel={handleCancel}
                 flowData={null}
+                initialDontShowAgain={initialDontShowAgain}
             />
         </>
     )

--- a/packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx
+++ b/packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx
@@ -38,7 +38,15 @@ const MarketplaceCanvas = () => {
     const reactFlowWrapper = useRef(null)
 
     // Credential checking hook
-    const { showCredentialModal, missingCredentials, checkCredentials, handleAssign, handleSkip, handleCancel } = useCredentialChecker()
+    const {
+        showCredentialModal,
+        missingCredentials,
+        checkCredentials,
+        initialDontShowAgain,
+        handleAssign,
+        handleSkip,
+        handleCancel
+    } = useCredentialChecker()
 
     // ==============================|| useEffect ||============================== //
 
@@ -135,6 +143,7 @@ const MarketplaceCanvas = () => {
                 onSkip={handleSkip}
                 onCancel={handleCancel}
                 flowData={flowData ? JSON.parse(flowData) : null}
+                initialDontShowAgain={initialDontShowAgain}
             />
         </>
     )


### PR DESCRIPTION
# 🔒 Improve Credentials Modal UX and Icon Semantics

## Overview
This PR enhances the user experience for credential management by improving icon semantics and introducing a "don't show again" preference system for the credentials modal.

## Changes

### 🎨 **Icon Improvements**
- **Replaced credential status icons** across Assistant and Sidekick cards:
  - ❌ `WarningAmberIcon` / `CheckCircleIcon` → ✅ `LockOpenIcon` / `LockIcon`
  - More semantic representation: unlocked = needs setup, locked = configured
- **Updated modal icons**:
  - Enhanced with `IconUserShield` and `IconShieldCheck` for better visual hierarchy
  - More intuitive representation of credential security states

**Files affected:**
- `packages-answers/ui/src/AssistantInfoCard.tsx`
- `packages-answers/ui/src/SidekickSelect/SidekickCard.tsx`
- `packages/ui/src/views/canvas/CanvasHeader.jsx`

### ✨ **"Don't Show Again" Feature**
Implemented persistent user preferences for the credentials modal:

- **New utility module** (`credentialModalPreference.js`):
  - LocalStorage-based preference management
  - Scoped preferences per sidekick/assistant (`sidekick:{id}`)
  - Safe error handling for storage operations
  - SSR-compatible (handles window undefined)

- **Enhanced UnifiedCredentialsModal**:
  - Added checkbox: "Don't show again for this sidekick"
  - Preferences passed through `onAssign`, `onSkip`, and `onCancel` callbacks
  - Tracks dirty state to only persist when user interacts with checkbox
  - Accepts `initialDontShowAgain` prop to reflect current preference state

- **Improved useCredentialChecker hook**:
  - Checks saved preferences before showing modal
  - Automatically suppresses modal for dismissed credentials (unless `forceShow` is true)
  - Persists user preference when modal is closed
  - Maintains scope context throughout lifecycle

**Files affected:**
- `packages/ui/src/utils/credentialModalPreference.js` (new file)
- `packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx`
- `packages/ui/src/hooks/useCredentialChecker.ts`

### 🔧 **Integration Updates**
Updated components that use the credentials modal to support new preference system:

- `packages/ui/src/components/SidekickSetupModal.jsx`
- `packages/ui/src/views/canvas/index.jsx`
- `packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx`

## Benefits

1. **Better UX**: Users can dismiss credential prompts they've already handled
2. **Clearer Icons**: Lock metaphor is more intuitive than warning/check symbols
3. **Flexible Control**: `forceShow` parameter bypasses suppression when needed
4. **Persistence**: Preferences survive browser sessions via localStorage
5. **Scoped Preferences**: Each sidekick/assistant has independent preference tracking

## Technical Notes

- **Backward Compatible**: Components without preference handling still work
- **Type Safe**: TypeScript interfaces added for credential modal options
- **Error Resilient**: LocalStorage failures won't break functionality
- **Performance**: No unnecessary re-renders; preferences checked only when needed

## Testing Considerations

- ✅ Verify modal shows for first-time credential requests
- ✅ Confirm "don't show again" persists across page reloads
- ✅ Test `forceShow` parameter overrides saved preferences
- ✅ Validate icons display correctly in all credential states
- ✅ Check localStorage scope isolation between different sidekicks

---

**Related Issue:** ANS-25

**Branch:** `ANS-25-improve-credentials-modal-and-icons`

**Stats:**
- 9 files changed
- 204 insertions(+), 52 deletions(-)
- 1 new utility file created

