### PR TITLE
fix: ensure installer exits properly on SIGINT/SIGTERM

### DIFF
--- a/scripts/bws-secure/bws-installer.sh
+++ b/scripts/bws-secure/bws-installer.sh
@@ -12,7 +12,9 @@ TMP_BASE="${TMPDIR:-${TEMP:-${TMP:-/tmp}}}"
 cleanup() {
   [ -n "$tmp_dir" ] && rm -rf "$tmp_dir" 2>/dev/null || true
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 main() {
   case "$1" in

--- a/scripts/bws-secure/install.sh
+++ b/scripts/bws-secure/install.sh
@@ -24,7 +24,9 @@ cleanup() {
   [ -n "$TMP_SCRIPT" ] && rm -f "$TMP_SCRIPT" 2>/dev/null || true
   [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE" 2>/dev/null || true
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # Helper function to check and initialize git submodules if needed
 check_git_submodules() {


### PR DESCRIPTION
## Problem
The previous trap handler (`trap cleanup EXIT INT TERM`) ran cleanup but didn't exit after receiving SIGINT (Ctrl-C) or SIGTERM. This caused the installer scripts to continue executing with deleted temp paths, leading to unpredictable failures.

## Solution
Split the trap handlers to ensure proper exit behavior:
- `trap cleanup EXIT` — runs cleanup on normal exit
- `trap 'cleanup; exit 130' INT` — runs cleanup then exits with code 130 on Ctrl-C
- `trap 'cleanup; exit 143' TERM` — runs cleanup then exits with code 143 on SIGTERM

## Changes
- **bws-installer.sh**: Split trap into separate EXIT/INT/TERM handlers
- **install.sh**: Split trap into separate EXIT/INT/TERM handlers

## Impact
- ✅ Maintains original abort behavior on interrupts
- ✅ No breaking changes to normal execution flow
- ✅ Follows standard shell exit code conventions (128+N for signal N)
- ✅ Prevents half-installed state after Ctrl-C

## Testing
- Normal completion: cleanup runs, exit code 0
- Ctrl-C during install: cleanup runs, script stops, exit code 130
- SIGTERM: cleanup runs, script stops, exit code 143

Addresses feedback from Codex bot review on BWS PR #53