### PR TITLE
refactor: limit S3 storage to version management only

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -113,8 +113,7 @@ const getChatflowById = async (req: Request, res: Response, next: NextFunction) 
         if (typeof req.params === 'undefined' || !req.params.id) {
             throw new InternalFlowiseError(StatusCodes.PRECONDITION_FAILED, `Error: chatflowsRouter.getChatflowById - id not provided!`)
         }
-        // Get fresh metadata from database (not S3 draft)
-        const apiResponse = await chatflowsService.getChatflowById(req.params.id, req.user, false)
+        const apiResponse = await chatflowsService.getChatflowById(req.params.id, req.user)
 
         // Check if the chatflow is public (Marketplace) for unauthenticated users
         if (!req.user && (!apiResponse.visibility || !apiResponse.visibility.includes('Marketplace') || !apiResponse.isPublic)) {
@@ -191,8 +190,7 @@ const updateChatflow = async (req: Request, res: Response, next: NextFunction) =
             throw new InternalFlowiseError(StatusCodes.PRECONDITION_FAILED, `Error: chatflowsRouter.updateChatflow - id not provided!`)
         }
 
-        // Get fresh metadata from database for updates (not S3 draft)
-        const chatflow = await chatflowsService.getChatflowById(req.params.id, req.user!, false)
+        const chatflow = await chatflowsService.getChatflowById(req.params.id, req.user!)
         if (!chatflow) {
             return res.status(404).send(`Chatflow ${req.params.id} not found`)
         }


### PR DESCRIPTION
## Summary
- Removed S3 draft lookup from `getChatflowById` - now always returns database version
- Removed S3 lookup from `getChatflowForPrediction` - predictions use database directly
- Removed `useDraft` parameter from `getChatflowById` signature
- Updated controller calls to remove unnecessary parameters
- S3 storage now exclusively used for version operations (list, get specific version, rollback)

## Changes
**Before:** S3 was used for both normal chatflow operations and version management
**After:** S3 only used for version history/rollback features

### Modified Files
- `packages/server/src/services/chatflows/index.ts`
  - Simplified `getChatflowById` to only use database
  - Simplified `getChatflowForPrediction` to only use database
- `packages/server/src/controllers/chatflows/index.ts`
  - Updated `getChatflowById` and `updateChatflow` calls

## Test Plan
- [ ] Verify chatflow loading works in editor
- [ ] Verify chatflow predictions/executions work
- [ ] Verify version history still shows correctly
- [ ] Verify rollback functionality still works
- [ ] Verify chatflow updates increment version and save to S3