### PR TITLE
Add pagination and lazy loading to chat drawer

### DIFF
--- a/apps/web/app/api/chats/route.ts
+++ b/apps/web/app/api/chats/route.ts
@@ -12,7 +12,11 @@ export async function GET(req: Request): Promise<NextResponse<Chat[]>> {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const mergedChats = await getChats(session.user)
+    const { searchParams } = new URL(req.url)
+    const limit = parseInt(searchParams.get('limit') || '20')
+    const cursor = searchParams.get('cursor') || undefined
+
+    const mergedChats = await getChats(session.user, { limit, cursor })
     return NextResponse.json(mergedChats)
 }
 

--- a/apps/web/app/api/chats/route.ts
+++ b/apps/web/app/api/chats/route.ts
@@ -5,6 +5,9 @@ import { getChats } from '@utils/getChats'
 
 import type { Chat } from 'types'
 
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 100
+
 export async function GET(req: Request): Promise<NextResponse<Chat[]>> {
     const session = await getCachedSession()
 
@@ -13,7 +16,8 @@ export async function GET(req: Request): Promise<NextResponse<Chat[]>> {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = parseInt(searchParams.get('limit') || '20')
+    const requestedLimit = parseInt(searchParams.get('limit') || String(DEFAULT_PAGE_SIZE))
+    const limit = Math.min(Math.max(1, requestedLimit), MAX_PAGE_SIZE)
     const cursor = searchParams.get('cursor') || undefined
 
     const mergedChats = await getChats(session.user, { limit, cursor })

--- a/packages-answers/ui/src/ChatDrawer.Server.tsx
+++ b/packages-answers/ui/src/ChatDrawer.Server.tsx
@@ -9,8 +9,7 @@ const ChatDrawerServer = async () => {
         return null
     }
 
-    // Fetch only initial chats for SSR
-    const mergedChats = await getChats(session.user, { limit: 20 })
+    const mergedChats = await getChats(session.user)
     return <ChatDrawerClient chats={mergedChats} />
 }
 

--- a/packages-answers/ui/src/ChatDrawer.Server.tsx
+++ b/packages-answers/ui/src/ChatDrawer.Server.tsx
@@ -9,7 +9,8 @@ const ChatDrawerServer = async () => {
         return null
     }
 
-    const mergedChats = await getChats(session.user)
+    // Fetch only initial chats for SSR
+    const mergedChats = await getChats(session.user, { limit: 20 })
     return <ChatDrawerClient chats={mergedChats} />
 }
 

--- a/packages-answers/ui/src/ChatDrawer.tsx
+++ b/packages-answers/ui/src/ChatDrawer.tsx
@@ -18,6 +18,7 @@ import { Chat, Journey } from 'types'
 import { Box } from '@mui/material'
 
 const drawerWidth = 400
+const CHATS_PAGE_SIZE = 20
 
 const DrawerHeader = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -62,15 +63,16 @@ export default function ChatDrawer({ journeys, chats, defaultOpen }: ChatDrawerP
 
     const getKey = (pageIndex: number, previousPageData: Chat[] | null) => {
         // Reached the end (no data or less than limit means no more pages)
-        if (previousPageData && previousPageData.length < 20) return null
+        if (previousPageData && previousPageData.length < CHATS_PAGE_SIZE) return null
 
         // First page
-        if (pageIndex === 0) return '/api/chats?limit=20'
+        if (pageIndex === 0) return `/api/chats?limit=${CHATS_PAGE_SIZE}`
 
-        // Get cursor from last chat of previous page (handle both createdAt and createdDate)
+        // Get cursor from last chat of previous page
+        // Chatflows API uses 'createdDate', but fallback to 'createdAt' for type compatibility
         const lastChat = previousPageData?.[previousPageData.length - 1]
-        const cursor = lastChat?.createdAt || lastChat?.createdDate
-        return `/api/chats?limit=20&cursor=${cursor}`
+        const cursor = lastChat?.createdDate || lastChat?.createdAt
+        return `/api/chats?limit=${CHATS_PAGE_SIZE}&cursor=${cursor}`
     }
 
     const { data, size, setSize, isValidating } = useSWRInfinite<Chat[]>(getKey, fetcher, {
@@ -99,7 +101,7 @@ export default function ChatDrawer({ journeys, chats, defaultOpen }: ChatDrawerP
     }, [fetchedChats])
 
     // Check if there's more data to load
-    const hasMore = data && data[data.length - 1]?.length === 20
+    const hasMore = data && data[data.length - 1]?.length === CHATS_PAGE_SIZE
 
     // IntersectionObserver for infinite scroll
     React.useEffect(() => {

--- a/packages-answers/ui/src/ChatDrawer.tsx
+++ b/packages-answers/ui/src/ChatDrawer.tsx
@@ -67,8 +67,9 @@ export default function ChatDrawer({ journeys, chats, defaultOpen }: ChatDrawerP
         // First page
         if (pageIndex === 0) return '/api/chats?limit=20'
 
-        // Get cursor from last chat of previous page
-        const cursor = previousPageData?.[previousPageData.length - 1]?.createdAt
+        // Get cursor from last chat of previous page (handle both createdAt and createdDate)
+        const lastChat = previousPageData?.[previousPageData.length - 1]
+        const cursor = lastChat?.createdAt || lastChat?.createdDate
         return `/api/chats?limit=20&cursor=${cursor}`
     }
 

--- a/packages-answers/utils/src/getChats.ts
+++ b/packages-answers/utils/src/getChats.ts
@@ -81,8 +81,12 @@ export async function getChats(user: User, options: PaginationOptions = {}) {
         })
     }
 
-    // Sort merged chats by date and limit results
-    mergedChats.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    // Sort merged chats by date and limit results (handle both createdAt and createdDate)
+    mergedChats.sort((a, b) => {
+        const dateA = new Date(a.createdAt || a.createdDate).getTime()
+        const dateB = new Date(b.createdAt || b.createdDate).getTime()
+        return dateB - dateA
+    })
 
     return mergedChats.slice(0, limit)
 }

--- a/packages/server/src/controllers/chats/index.ts
+++ b/packages/server/src/controllers/chats/index.ts
@@ -8,7 +8,9 @@ const getAllChats = async (req: Request, res: Response, next: NextFunction) => {
         if (!req.user) {
             throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, 'Error: chatsController.getAllChats - Unauthorized')
         }
-        const apiResponse = await chatsService.getAllChats(req.user)
+        const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 20
+        const cursor = req.query.cursor as string | undefined
+        const apiResponse = await chatsService.getAllChats(req.user, { limit, cursor })
         return res.json(apiResponse)
     } catch (error) {
         next(error)

--- a/packages/server/src/controllers/chats/index.ts
+++ b/packages/server/src/controllers/chats/index.ts
@@ -3,12 +3,16 @@ import chatsService from '../../services/chats'
 import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 import { StatusCodes } from 'http-status-codes'
 
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 100
+
 const getAllChats = async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (!req.user) {
             throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, 'Error: chatsController.getAllChats - Unauthorized')
         }
-        const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 20
+        const requestedLimit = req.query.limit ? parseInt(req.query.limit as string, 10) : DEFAULT_PAGE_SIZE
+        const limit = Math.min(Math.max(1, requestedLimit), MAX_PAGE_SIZE)
         const cursor = req.query.cursor as string | undefined
         const apiResponse = await chatsService.getAllChats(req.user, { limit, cursor })
         return res.json(apiResponse)


### PR DESCRIPTION
## Summary
- Implements cursor-based pagination for chat loading in the drawer
- Adds lazy loading with infinite scroll as user scrolls to bottom
- Reduces initial load from all chats to 20 chats per page
- Fetches chats exclusively from remote chatflows API

## Changes

### Backend (packages/server)
- **Chatflows API** (`/api/v1/chats`): Added pagination support
  - Accepts `limit` (default: 20, max: 100) and `cursor` query params
  - Uses cursor-based pagination with `createdDate` field
  - Validates limit to prevent abuse (1-100 range)

### API Endpoint (apps/web)
- **Local API** (`/api/chats`): Proxy to chatflows API with pagination
  - Accepts and validates `limit` and `cursor` params
  - Enforces max limit of 100 items per page

### Client (packages-answers/ui)
- **ChatDrawer**: Infinite scroll implementation
  - Replaced `useSWR` with `useSWRInfinite`
  - Added IntersectionObserver to detect scroll to bottom
  - Shows loading spinner when fetching more chats
  - Stops loading when no more chats available
  - Uses `CHATS_PAGE_SIZE` constant (20)

### Utilities (packages-answers/utils)
- **getChats**: Simplified to only fetch from remote API
  - Removed local Prisma chat fetching
  - Removed merge/deduplication logic
  - Directly returns chatflow API results with pagination

## Test plan
- [ ] Verify initial load shows first 20 chats
- [ ] Scroll to bottom and verify more chats load automatically
- [ ] Verify loading spinner appears while fetching
- [ ] Verify loading stops when all chats are loaded
- [ ] Test with accounts that have < 20, exactly 20, and > 20 chats
- [ ] Verify limit validation works (requesting > 100 should cap at 100)