### PR TITLE
fix: Handle Stripe 35-day limitation for historical billing data

### DIFF
--- a/packages/server/src/aai-utils/billing/stripe/StripeProvider.ts
+++ b/packages/server/src/aai-utils/billing/stripe/StripeProvider.ts
@@ -300,6 +300,42 @@ export class StripeProvider {
         }
     }
 
+    /**
+     * Adjust timestamp for Stripe's 35-day limitation on meter events
+     * Stripe doesn't accept meter events older than 35 days
+     *
+     * @param originalTimestamp - Original timestamp in seconds
+     * @returns Adjusted timestamp info with original date preserved
+     */
+    private adjustTimestampForStripe(originalTimestamp: number): {
+        adjustedTimestamp: number
+        wasAdjusted: boolean
+        originalDate?: string
+    } {
+        const now = Date.now() / 1000 // Current time in seconds
+        const thirtyFiveDaysAgo = now - 35 * 24 * 60 * 60
+        const thirtyFourDaysAgo = now - 34 * 24 * 60 * 60 // Use 34 days as the "historical catch-up" date
+
+        if (originalTimestamp < thirtyFiveDaysAgo) {
+            log.info('Adjusting old timestamp for Stripe', {
+                originalDate: new Date(originalTimestamp * 1000).toISOString(),
+                adjustedDate: new Date(thirtyFourDaysAgo * 1000).toISOString(),
+                ageInDays: Math.floor((now - originalTimestamp) / (24 * 60 * 60))
+            })
+
+            return {
+                adjustedTimestamp: Math.floor(thirtyFourDaysAgo),
+                wasAdjusted: true,
+                originalDate: new Date(originalTimestamp * 1000).toISOString()
+            }
+        }
+
+        return {
+            adjustedTimestamp: originalTimestamp,
+            wasAdjusted: false
+        }
+    }
+
     async syncUsageToStripe(creditsData: Array<CreditsData & { fullTrace: any }>): Promise<{
         meterEvents: Stripe.Billing.MeterEvent[]
         failedEvents: Array<{ traceId: string; error: string }>
@@ -319,6 +355,7 @@ export class StripeProvider {
             const processedTraces: string[] = []
             let selfHealedCount = 0
             let duplicateEventCount = 0
+            let adjustedTimestampCount = 0
 
             // console.log('Syncing usage to Stripe', {
             //     count: creditsData.length,
@@ -333,7 +370,10 @@ export class StripeProvider {
 
                 const batchResults = await Promise.allSettled(
                     batch.map(async (data) => {
-                        const timestamp = data.timestampEpoch || Math.floor(new Date(data.metadata.timestamp).getTime() / 1000)
+                        const originalTimestamp = data.timestampEpoch || Math.floor(new Date(data.metadata.timestamp).getTime() / 1000)
+
+                        // Adjust timestamp for Stripe's 35-day limitation
+                        const { adjustedTimestamp, wasAdjusted, originalDate } = this.adjustTimestampForStripe(originalTimestamp)
 
                         // Ensure all unknown credit types are counted as AI tokens
                         const aiTokens = data.credits.ai_tokens + (data.credits.unknown || 0)
@@ -346,12 +386,17 @@ export class StripeProvider {
 
                         let retryCount = 0
 
+                        // Track if this event's timestamp was adjusted
+                        if (wasAdjusted) {
+                            adjustedTimestampCount++
+                        }
+
                         while (retryCount < BILLING_CONFIG.VALIDATION.MAX_RETRIES) {
                             try {
                                 const stripeMeterEvent = {
                                     event_name: 'credits',
                                     identifier: `${data.traceId}_credits`,
-                                    timestamp,
+                                    timestamp: adjustedTimestamp, // Use adjusted timestamp
                                     payload: {
                                         value: totalCredits.toString(),
                                         stripe_customer_id: data.stripeCustomerId,
@@ -367,7 +412,9 @@ export class StripeProvider {
                                                 data.costs.base.storage +
                                                 (data.costs.base.unknown || 0)) *
                                             BILLING_CONFIG.MARGIN_MULTIPLIER
-                                        ).toFixed(6)
+                                        ).toFixed(6),
+                                        // Add original date to payload if timestamp was adjusted
+                                        ...(wasAdjusted && { original_date: originalDate, historical_data: 'true' })
                                     }
                                 }
                                 let result
@@ -450,6 +497,16 @@ export class StripeProvider {
                     totalProcessed: processedTraces.length,
                     percentage: ((duplicateEventCount / processedTraces.length) * 100).toFixed(2) + '%',
                     note: 'These traces were already in Stripe but not marked as processed in Langfuse'
+                })
+            }
+
+            // Log adjusted timestamps summary
+            if (adjustedTimestampCount > 0) {
+                log.info('Historical data: Adjusted timestamps for Stripe 35-day limitation', {
+                    count: adjustedTimestampCount,
+                    totalProcessed: processedTraces.length,
+                    percentage: ((adjustedTimestampCount / processedTraces.length) * 100).toFixed(2) + '%',
+                    note: 'Traces older than 35 days were batched to 34 days ago with original dates preserved in metadata'
                 })
             }
 

--- a/packages/server/src/aai-utils/billing/stripe/StripeProvider.ts
+++ b/packages/server/src/aai-utils/billing/stripe/StripeProvider.ts
@@ -316,6 +316,8 @@ export class StripeProvider {
         const thirtyFiveDaysAgo = now - 35 * 24 * 60 * 60
         const thirtyFourDaysAgo = now - 34 * 24 * 60 * 60 // Use 34 days as the "historical catch-up" date
 
+        // Stripe allows timestamps up to and including 35 days ago
+        // We only need to adjust if it's MORE than 35 days old
         if (originalTimestamp < thirtyFiveDaysAgo) {
             log.info('Adjusting old timestamp for Stripe', {
                 originalDate: new Date(originalTimestamp * 1000).toISOString(),


### PR DESCRIPTION
## Summary

This PR fixes the Stripe meter event 35-day limitation error that prevents processing of historical billing data older than 35 days.

### Problem
Stripe's billing meter API rejects events with timestamps older than 35 days:
```
error: 'The event timestamp cannot be more than 35 days in past. Expected a timestamp greater than or equal to 1758141836.'
```

### Solution
Implemented **Option 1: Batch to "Historical Catch-up" Date**
- Events older than 35 days are adjusted to have a timestamp of 34 days ago
- Original timestamp is preserved in the meter event payload metadata
- All historical usage is captured without data loss

### Implementation Details

1. **Added `adjustTimestampForStripe()` method** (`StripeProvider.ts:310-337`)
   - Checks if timestamp is older than 35 days
   - Returns adjusted timestamp (34 days ago) for old events
   - Preserves original date for reference

2. **Updated meter event creation** (`StripeProvider.ts:372-418`)
   - Uses adjusted timestamp for Stripe API
   - Adds `original_date` and `historical_data` fields to payload when adjusted
   - Tracks count of adjusted events

3. **Added logging summary** (`StripeProvider.ts:504-511`)
   - Reports count and percentage of adjusted timestamps
   - Clear indication of historical data processing

### Example Meter Event Payload (Adjusted)
```json
{
  "event_name": "credits",
  "identifier": "24d6140b-780f-4b76-9bdb-6c05c8819ae1_credits",
  "timestamp": 1754387332, // 34 days ago
  "payload": {
    "value": "1433",
    "stripe_customer_id": "cus_SGx0SYUXIfqZxQ",
    "trace_id": "24d6140b-780f-4b76-9bdb-6c05c8819ae1",
    "original_date": "2024-10-22T04:30:36.000Z", // Actual date preserved
    "historical_data": "true",
    // ... other fields
  }
}
```

### Testing
- ✅ TypeScript compilation successful
- ✅ No type errors
- ✅ Ready for staging deployment

### Benefits
- All historical billing data can now be processed
- No data loss - all usage is captured
- Clear audit trail with original dates preserved
- Graceful handling with informative logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)