### PR TITLE
Release: Staging to Production - 2025.10.24

### DIFF
--- a/packages/server/src/aai-utils/billing/README.md
+++ b/packages/server/src/aai-utils/billing/README.md
@@ -22,10 +22,10 @@ The billing configuration is centralized in `config.ts` and uses environment var
 | `BILLING_MARGIN_MULTIPLIER`    | Margin multiplier for billing           | 1.2 (20% margin)               |
 | `BILLING_PRO_PLAN_CREDITS`     | Number of Credits included in Pro plan  | 500000                         |
 | `BILLING_FREE_PLAN_CREDITS`    | Number of Credits included in Free plan | 10000                          |
-| `BILLING_STRIPE_SECRET_KEY`    | Stripe API secret key                   | -                              |
-| `STRIPE_CREDITS_METER_ID`      | Stripe meter ID for Credits             | -                              |
-| `STRIPE_FREE_PRICE_ID`         | Stripe price ID for Free plan           | -                              |
-| `BILLING_STRIPE_PAID_PRICE_ID` | Stripe price ID for Paid plan           | -                              |
+| `BILLING_STRIPE_SECRET_KEY`       | Stripe API secret key                   | -                              |
+| `BILLING_STRIPE_CREDITS_METER_ID` | Stripe meter ID for Credits             | -                              |
+| `BILLING_STRIPE_FREE_PRICE_ID`    | Stripe price ID for Free plan           | -                              |
+| `BILLING_STRIPE_PAID_PRICE_ID`    | Stripe price ID for Paid plan           | -                              |
 
 ### Resource Allocation
 

--- a/packages/server/src/aai-utils/billing/config.ts
+++ b/packages/server/src/aai-utils/billing/config.ts
@@ -6,6 +6,9 @@ export const log = console as unknown as Logger
 // Default customer ID for development
 export const DEFAULT_CUSTOMER_ID = process.env.BILLING_DEFAULT_STRIPE_CUSTOMER_ID
 
+// Override flag: When true, ALWAYS use DEFAULT_CUSTOMER_ID regardless of trace metadata or user data
+export const OVERRIDE_CUSTOMER_ID = process.env.BILLING_OVERRIDE_CUSTOMER_ID === 'true'
+
 // Load environment variables with defaults
 // Base rate: $20 for 500,000 credits = $0.00004 per credit
 const BILLING_CREDIT_PRICE_USD = parseFloat(process.env.BILLING_CREDIT_PRICE_USD || '0.00004')
@@ -16,13 +19,13 @@ const BILLING_FREE_PLAN_CREDITS = parseInt(process.env.BILLING_FREE_PLAN_CREDITS
 // Billing configuration
 export const BILLING_CONFIG = {
     PRICE_IDS: {
-        FREE_MONTHLY: process.env.STRIPE_FREE_PRICE_ID,
+        FREE_MONTHLY: process.env.BILLING_STRIPE_FREE_PRICE_ID,
         PAID_MONTHLY: process.env.BILLING_STRIPE_PAID_PRICE_ID
     },
     // Base rate: $20 for 500,000 credits = $0.00004 per credit
     CREDIT_TO_USD: BILLING_CREDIT_PRICE_USD,
     MARGIN_MULTIPLIER: MARGIN_MULTIPLIER,
-    BILLING_CREDITS_METER_ID: process.env.STRIPE_CREDITS_METER_ID,
+    BILLING_CREDITS_METER_ID: process.env.BILLING_STRIPE_CREDITS_METER_ID,
     BILLING_CREDITS_METER_NAME: 'credits',
 
     // Plan limits

--- a/packages/server/src/aai-utils/billing/core/BillingService.ts
+++ b/packages/server/src/aai-utils/billing/core/BillingService.ts
@@ -234,7 +234,7 @@ export class BillingService implements BillingProvider {
             // Map summaries to include meter_name
             const usage = allSummaries.map((summary) => ({
                 ...summary,
-                meter_name: summary.meter === process.env.STRIPE_CREDITS_METER_ID ? 'credits' : 'unknown'
+                meter_name: summary.meter === BILLING_CONFIG.BILLING_CREDITS_METER_ID ? 'credits' : 'unknown'
             }))
 
             return {

--- a/packages/server/src/aai-utils/billing/langfuse/LangfuseProvider.ts
+++ b/packages/server/src/aai-utils/billing/langfuse/LangfuseProvider.ts
@@ -1,5 +1,5 @@
 import { CreditsData, TraceMetadata, SyncUsageResponse, UsageEvent, UsageEventsResponse, GetUsageEventsParams } from '../core/types'
-import { log, DEFAULT_CUSTOMER_ID, BILLING_CONFIG } from '../config'
+import { log, DEFAULT_CUSTOMER_ID, OVERRIDE_CUSTOMER_ID, BILLING_CONFIG } from '../config'
 import axios from 'axios'
 import { StripeProvider } from '../stripe/StripeProvider'
 import { extractCredentialsAndModels } from 'flowise-components'
@@ -504,7 +504,8 @@ export class LangfuseProvider {
             userId: metadata.userId,
             organizationId: metadata.organizationId,
             aiCredentialsOwnership: metadata.aiCredentialsOwnership,
-            stripeCustomerId: metadata.customerId || DEFAULT_CUSTOMER_ID!,
+            // When OVERRIDE_CUSTOMER_ID is true, ALWAYS use DEFAULT_CUSTOMER_ID (ignores trace metadata and DB values)
+            stripeCustomerId: OVERRIDE_CUSTOMER_ID ? DEFAULT_CUSTOMER_ID! : metadata.customerId || DEFAULT_CUSTOMER_ID!,
             subscriptionTier: metadata.subscriptionTier || 'free',
             timestamp: trace.timestamp.toString(),
             timestampEpoch: timestampSeconds,
@@ -564,15 +565,18 @@ export class LangfuseProvider {
                 // We'll filter the results after fetching
             })
 
-            // Filter traces by customerId
+            // Filter traces by userId and customerId
+            // When organizational billing override is enabled, we skip the customerId check
+            // because all traces have individual user customer IDs but bill to the org customer ID
             const filteredTraces = (langfuseResponse?.data || []).filter((trace: Trace) => {
                 const metadata = trace.metadata as TraceMetadata
-                return (
-                    trace.userId === userId ||
-                    trace.userId === params.user.id ||
-                    params.user.roles?.includes('Admin') ||
-                    (metadata && metadata.stripeCustomerId === customerId)
-                )
+                // Always allow: own traces, admin access
+                const hasUserAccess = trace.userId === userId || trace.userId === params.user.id || params.user.roles?.includes('Admin')
+
+                // Only check customer ID when override is disabled
+                const hasCustomerAccess = !OVERRIDE_CUSTOMER_ID && metadata && metadata.stripeCustomerId === customerId
+
+                return hasUserAccess || hasCustomerAccess
             })
 
             // Transform traces to UsageEvent format

--- a/packages/server/src/aai-utils/billing/stripe/config.ts
+++ b/packages/server/src/aai-utils/billing/stripe/config.ts
@@ -2,7 +2,7 @@ import { BILLING_CONFIG } from '../config'
 
 // Load environment variables with defaults
 const BILLING_CREDIT_PRICE_USD = BILLING_CONFIG.CREDIT_TO_USD // Use the same value from billing config
-const MARGIN_MULTIPLIER = parseFloat(process.env.STRIPE_MARGIN_MULTIPLIER || '1.3') // 30% margin
+const MARGIN_MULTIPLIER = parseFloat(process.env.BILLING_STRIPE_MARGIN_MULTIPLIER || '1.3') // 30% margin
 
 // Stripe-specific billing configuration
 export const STRIPE_CONFIG = {
@@ -10,7 +10,7 @@ export const STRIPE_CONFIG = {
 
     // Single meter for total credits
     CREDITS: {
-        METER_ID: process.env.STRIPE_CREDITS_METER_ID || 'mtr_test_61S7tgODE3yzFip9Q41FeRAHyP6byJRI',
+        METER_ID: process.env.BILLING_STRIPE_CREDITS_METER_ID || 'mtr_test_61S7tgODE3yzFip9Q41FeRAHyP6byJRI',
         METER_NAME: 'credits',
         BASE_PRICE_USD: BILLING_CREDIT_PRICE_USD,
         MARGIN_MULTIPLIER: MARGIN_MULTIPLIER // 30% margin
@@ -19,7 +19,7 @@ export const STRIPE_CONFIG = {
     // Legacy meters configuration
     METERS: {
         AI_TOKENS: {
-            METER_ID: process.env.STRIPE_AI_TOKENS_METER_ID || 'mtr_test_61S7tgODE3yzFip9Q41FeRAHyP6byJRI',
+            METER_ID: process.env.BILLING_STRIPE_AI_TOKENS_METER_ID || 'mtr_test_61S7tgODE3yzFip9Q41FeRAHyP6byJRI',
             TOKENS_PER_CREDIT: BILLING_CONFIG.AI_TOKENS.TOKENS_PER_CREDIT,
             BASE_PRICE_USD: BILLING_CREDIT_PRICE_USD * 10, // 10x base price for tokens
             MARGIN_MULTIPLIER: 1.2,


### PR DESCRIPTION
# Release: Staging to Production - October 24, 2025

This PR releases all tested changes from staging to production.

## 🎯 Key Features

### Organizational Billing Override (#637)
- **NEW**: Support for organizational billing where all users' usage consolidates to a single Stripe customer
- Environment variable: `BILLING_OVERRIDE_CUSTOMER_ID=true` to enable
- Users maintain individual trace attribution while billing flows to organization
- Fixes P1 issue where usage events returned empty list for organizational accounts

### Langfuse API Optimization (#637)
- **PERFORMANCE**: Reduced parallel API load by 85%
  - PAGE_BATCH_SIZE: 15 → 3 pages
  - TRACE_BATCH_SIZE: 15 → 5 traces
  - RATE_LIMIT_DELAY_MS: 1000ms → 2000ms
  - LOOKBACK_DAYS: 90 → 7 days (default)
- Prevents "database resource limit exceeded" errors on large datasets
- All settings configurable via environment variables

### Environment Variable Standardization (#637)
- **BREAKING**: All billing-related env vars now use `BILLING_` prefix
  - `STRIPE_FREE_PRICE_ID` → `BILLING_STRIPE_FREE_PRICE_ID`
  - `STRIPE_CREDITS_METER_ID` → `BILLING_STRIPE_CREDITS_METER_ID`
  - `STRIPE_AI_TOKENS_METER_ID` → `BILLING_STRIPE_AI_TOKENS_METER_ID`
  - `STRIPE_MARGIN_MULTIPLIER` → `BILLING_STRIPE_MARGIN_MULTIPLIER`
- Updated documentation and code references

## 🐛 Bug Fixes

### P1: Usage Events Filter for Organizational Billing
- Fixed filter logic in `getUsageEvents` to handle organizational override
- Users now correctly see their own traces when override is enabled
- Admins continue to see all traces

### Billing Metadata and Tracking
- Previous releases included billing metadata filtering improvements
- Self-healing for billing tags
- Enhanced analytics tracing accuracy

## 📋 Other Improvements

- Chat drawer pagination enhancements
- Facebook Pixel tracking fixes
- JLINC audit log improvements
- Admin navigation fixes
- Dependencies updates (mammoth 1.10.0 → 1.11.0)

## 🔄 Migration Notes

**Required Environment Variable Updates:**
Update your production environment with the new `BILLING_STRIPE_*` prefixed variables. The old names will no longer work.

**New Optional Variables:**
- `BILLING_OVERRIDE_CUSTOMER_ID` - Set to "true" for organizational billing
- `BILLING_DEFAULT_STRIPE_CUSTOMER_ID` - Organization's Stripe customer ID
- `BILLING_SYNC_LOOKBACK_DAYS` - Days to look back for unprocessed traces (default: 7)
- `BILLING_SYNC_PAGE_BATCH_SIZE` - Parallel page fetches (default: 3)
- `BILLING_SYNC_TRACE_BATCH_SIZE` - Parallel trace fetches (default: 5)
- `BILLING_SYNC_RATE_LIMIT_MS` - Delay between API calls (default: 2000)

## ✅ Testing

All changes have been tested in staging environment including:
- Organizational billing override functionality
- Langfuse API optimization under load
- Usage events filtering with override enabled
- Environment variable migrations

## 📦 Included PRs

- #637 - Organizational billing override and Langfuse optimization
- #635 - Previous staging release
- #628 - Embed package updates
- #627 - Previous production release
- #622 - Billing metadata filtering
- #621 - Chat drawer pagination
- #617 - Billing tag self-healing
- And more (see commit history)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)