### PR TITLE
Fix: Remove type override to restore Agentflow templates display (ANS-59)

### DIFF
--- a/packages/server/src/services/marketplaces/index.ts
+++ b/packages/server/src/services/marketplaces/index.ts
@@ -390,7 +390,6 @@ const saveCustomTemplate = async (body: any, user: IUser): Promise<any> => {
             customTemplate.apiConfig = chatflow.apiConfig
             customTemplate.speechToText = chatflow.speechToText
             customTemplate.category = chatflow.category
-            customTemplate.type = chatflow.type
             customTemplate.description = customTemplate.description || chatflow.description
         } else if (body.tool) {
             const flowData = {


### PR DESCRIPTION
## Summary
Removed a type override in the marketplace service that was preventing Agentflow templates from showing up in the templates page.

## Changes
- Removed `customTemplate.type = chatflow.type` assignment in `saveCustomTemplate` function
- Allows Agentflow templates to maintain their correct type instead of being overridden by the chatflow type

## Problem
The type override was causing Agentflow templates to be incorrectly classified, which prevented them from displaying properly on the templates page.

## Solution
Removed the line that was overwriting the template type with the chatflow type, allowing the template's original type to be preserved correctly.

## Files Changed
- `packages/server/src/services/marketplaces/index.ts`

## Testing
Verify that Agentflow templates now appear correctly on the templates page.

