### PR TITLE
chore(release): staging to production - 2025.11.03

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
                       @semantic-release/changelog
                       @semantic-release/git
                       @semantic-release/github
+                      conventional-changelog-conventionalcommits
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -48,5 +49,6 @@ jobs:
                       @semantic-release/changelog
                       @semantic-release/git
                       @semantic-release/github
+                      conventional-changelog-conventionalcommits
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Release: Staging to Production - November 3, 2025

This release fixes the semantic-release workflow that failed in the previous merge.

---

## 🔧 Bug Fix

### Missing Dependency in Release Workflow
**Impact:** Fixed semantic-release workflow failure

The previous release PR (#657) merged successfully but the semantic-release workflow failed with:
```
Cannot find module 'conventional-changelog-conventionalcommits'
```

**Fix Applied:**
- Added `conventional-changelog-conventionalcommits` package to GitHub Actions workflow
- This package is required by the `conventionalcommits` preset we configured
- Both `release` and `dry-run` jobs now include the package

---

## 📊 Changes Since Last Production Release

**1 commit:**
- `fix(ci): add conventional-changelog-conventionalcommits to release workflow`

---

## ✅ Expected Outcome

After merging this PR:
1. semantic-release workflow will run successfully
2. A new GitHub release (v1.7.3) will be created automatically
3. Release notes will be properly generated from conventional commits
4. Future releases will work correctly

---

**Closes:** Workflow failure from PR #657