### PR TITLE
fix(ui): resolve follow-up prompts and sidekick data loading

### DIFF
--- a/packages-answers/ui/src/AnswersContext.tsx
+++ b/packages-answers/ui/src/AnswersContext.tsx
@@ -7,22 +7,6 @@ import { deepmerge } from '@utils/deepmerge'
 import { clearEmptyValues } from './clearEmptyValues'
 import predictionApi from '@/api/prediction'
 import chatmessagefeedbackApi from '@/api/chatmessagefeedback'
-
-// import {
-//     AnswersFilters,
-//     AppSettings,
-//     Chat,
-//     Journey,
-//     Message,
-//     Prompt,
-//     Sidekick,
-//     User,
-//     MessageFeedback,
-//     SidekickListItem,
-//     ChatbotConfig,
-//     FlowData,
-//     FeedbackPayload
-// } from 'types'
 import { EventStreamContentType, fetchEventSource } from '@microsoft/fetch-event-source'
 
 import { AnswersFilters, AppSettings, Chat, Journey, Message, Prompt, Sidekick, User, SidekickListItem, FeedbackPayload } from 'types'
@@ -208,7 +192,6 @@ export function AnswersProvider({
     const [filters, setFilters] = useState<AnswersFilters>(deepmerge({}, appSettings?.filters, journey?.filters, chat?.filters))
     const { data: selectedSidekickData, mutate: mutateSidekickDetails } = useSidekickDetails(sidekick?.id ?? null)
     const chatbotConfig = React.useMemo(() => selectedSidekickData?.chatbotConfig, [selectedSidekickData])
-    console.log('AnswersContext', { selectedSidekickData, chatbotConfig, sidekick })
     // Refs for stable callbacks without message dependency
     const messagesRef = useRef(messages)
     const chatIdRef = useRef(chatId)
@@ -552,10 +535,6 @@ export function AnswersProvider({
                     question: content,
                     chatId: chatIdRef.current,
                     journeyId: journeyIdRef.current,
-                    // history: messagesRef.current?.map(({ content, role }) => ({
-                    //     message: content,
-                    //     type: role === 'assistant' ? 'apiMessage' : 'userMessage'
-                    // })),
                     uploads: files,
                     audio,
                     socketIOClientId: isChatFlowAvailableToStream ? socketIOClientId : undefined,
@@ -692,15 +671,12 @@ export function AnswersProvider({
                 async onopen(response) {
                     if (response.ok && response.headers.get('content-type') === EventStreamContentType) {
                         setIsChatFlowAvailableToStream(true)
-                        // console.log('Connection established successfully')
-                        // Connection established successfully
                     } else {
                         throw new Error('Failed to establish connection')
                     }
                 },
                 async onmessage(ev) {
                     const payload = JSON.parse(ev.data)
-                    // console.log('payload', payload)
                     switch (payload.event) {
                         case 'start':
                             // Already created an empty message when starting the stream

--- a/packages-answers/ui/src/AnswersContext.tsx
+++ b/packages-answers/ui/src/AnswersContext.tsx
@@ -208,7 +208,7 @@ export function AnswersProvider({
     const [filters, setFilters] = useState<AnswersFilters>(deepmerge({}, appSettings?.filters, journey?.filters, chat?.filters))
     const { data: selectedSidekickData, mutate: mutateSidekickDetails } = useSidekickDetails(sidekick?.id ?? null)
     const chatbotConfig = React.useMemo(() => selectedSidekickData?.chatbotConfig, [selectedSidekickData])
-
+    console.log('AnswersContext', { selectedSidekickData, chatbotConfig, sidekick })
     // Refs for stable callbacks without message dependency
     const messagesRef = useRef(messages)
     const chatIdRef = useRef(chatId)
@@ -865,15 +865,6 @@ export function AnswersProvider({
                             }))
                         ]
                     }
-
-                    // Use SWR optimistic update to update cache
-                    mutateSidekickDetails(
-                        (current: any) => ({
-                            ...current,
-                            constraints: newConstraints
-                        }),
-                        { revalidate: false }
-                    )
 
                     // Also update local state for immediate reactivity
                     setSidekick((prev) =>

--- a/packages-answers/ui/src/SidekickSelect/hooks/useSidekickData.ts
+++ b/packages-answers/ui/src/SidekickSelect/hooks/useSidekickData.ts
@@ -71,11 +71,7 @@ const useSidekickData = ({ defaultSidekicks = [], enablePerformanceLogs = false 
     )
 
     // Use the optimized fetcher
-    const { data, isLoading } = useSWR('/api/sidekicks', fetcher, {
-        // fallbackData: { sidekicks: defaultSidekicks, categories: { top: [], more: [] } }
-        // revalidateOnFocus: true // Reduce unnecessary refetches
-        // dedupingInterval: 10000 // Dedupe requests within 10 seconds
-    })
+    const { data, isLoading } = useSWR('/api/sidekicks', fetcher)
 
     const { sidekicks: allSidekicks = [], categories: chatflowCategories = { top: [], more: [] } } = data || {
         sidekicks: defaultSidekicks,

--- a/packages-answers/ui/src/SidekickSelect/hooks/useSidekickData.ts
+++ b/packages-answers/ui/src/SidekickSelect/hooks/useSidekickData.ts
@@ -72,12 +72,15 @@ const useSidekickData = ({ defaultSidekicks = [], enablePerformanceLogs = false 
 
     // Use the optimized fetcher
     const { data, isLoading } = useSWR('/api/sidekicks', fetcher, {
-        fallbackData: { sidekicks: defaultSidekicks, categories: { top: [], more: [] } },
-        revalidateOnFocus: true, // Reduce unnecessary refetches
-        dedupingInterval: 10000 // Dedupe requests within 10 seconds
+        // fallbackData: { sidekicks: defaultSidekicks, categories: { top: [], more: [] } }
+        // revalidateOnFocus: true // Reduce unnecessary refetches
+        // dedupingInterval: 10000 // Dedupe requests within 10 seconds
     })
 
-    const { sidekicks: allSidekicks = [], categories: chatflowCategories = { top: [], more: [] } } = data
+    const { sidekicks: allSidekicks = [], categories: chatflowCategories = { top: [], more: [] } } = data || {
+        sidekicks: defaultSidekicks,
+        categories: { top: [], more: [] }
+    }
 
     // Optimize combinedSidekicks calculation with better dependency tracking
     const combinedSidekicks = useMemo(() => {

--- a/packages-answers/ui/src/SidekickSelect/hooks/useSidekickDetails.ts
+++ b/packages-answers/ui/src/SidekickSelect/hooks/useSidekickDetails.ts
@@ -5,9 +5,9 @@ import axios from 'axios'
 
 const fetcher = async (url: string): Promise<Sidekick> => axios.get(url).then((res) => res.data)
 const swrConfig = {
-    retry: 2,
-    retryDelay: 1000,
-    dedupingInterval: 2000
+    // retry: 2
+    // retryDelay: 1000,
+    // dedupingInterval: 2000
 }
 
 // Pure SWR hook for declarative usage

--- a/packages-answers/ui/src/SidekickSelect/hooks/useSidekickDetails.ts
+++ b/packages-answers/ui/src/SidekickSelect/hooks/useSidekickDetails.ts
@@ -4,15 +4,10 @@ import { Sidekick } from '../SidekickSelect.types'
 import axios from 'axios'
 
 const fetcher = async (url: string): Promise<Sidekick> => axios.get(url).then((res) => res.data)
-const swrConfig = {
-    // retry: 2
-    // retryDelay: 1000,
-    // dedupingInterval: 2000
-}
 
 // Pure SWR hook for declarative usage
 export const useSidekickDetails = (sidekickId: string | null) => {
-    const { data, error, mutate, isLoading } = useSWR<Sidekick>(sidekickId ? `/api/sidekicks/${sidekickId}` : null, fetcher, swrConfig)
+    const { data, error, mutate, isLoading } = useSWR<Sidekick>(sidekickId ? `/api/sidekicks/${sidekickId}` : null, fetcher)
 
     return {
         data,

--- a/packages-answers/ui/src/SourcesBasicDocument.tsx
+++ b/packages-answers/ui/src/SourcesBasicDocument.tsx
@@ -16,15 +16,10 @@ const SourcesBasicDocument: React.FC<{
     placeholder: string
 }> = ({ source, label, placeholder }) => {
     const { filters, updateFilter } = useAnswers()
-    const { data: sources, mutate } = useSWR<DocumentFilter[]>(
-        `/api/sources/${source}`,
-        (url) =>
-            fetch(url)
-                .then((res) => res.json())
-                .then((data) => data.sources),
-        {
-            // dedupingInterval: 1000
-        }
+    const { data: sources, mutate } = useSWR<DocumentFilter[]>(`/api/sources/${source}`, (url) =>
+        fetch(url)
+            .then((res) => res.json())
+            .then((data) => data.sources)
     )
 
     const sourceFilterSources: DocumentFilter[] = (filters?.datasources?.[source] as StandardDocumentUrlFilters)?.url?.sources ?? []

--- a/packages-answers/ui/src/SourcesBasicDocument.tsx
+++ b/packages-answers/ui/src/SourcesBasicDocument.tsx
@@ -23,7 +23,7 @@ const SourcesBasicDocument: React.FC<{
                 .then((res) => res.json())
                 .then((data) => data.sources),
         {
-            dedupingInterval: 1000
+            // dedupingInterval: 1000
         }
     )
 

--- a/packages-answers/ui/src/billing/hooks/useBillingData.ts
+++ b/packages-answers/ui/src/billing/hooks/useBillingData.ts
@@ -78,8 +78,8 @@ const fetcher = async () => {
 export function useBillingData() {
     const { data, error, isLoading, mutate } = useSWR<UsageSummary>('/api/billing/usage', fetcher, {
         refreshInterval: 60000, // Refresh every minute
-        revalidateOnFocus: true,
-        dedupingInterval: 5000 // Dedupe requests within 5 seconds
+        revalidateOnFocus: true
+        // dedupingInterval: 5000 // Dedupe requests within 5 seconds
     })
 
     return {

--- a/packages-answers/ui/src/billing/hooks/useBillingData.ts
+++ b/packages-answers/ui/src/billing/hooks/useBillingData.ts
@@ -79,7 +79,6 @@ export function useBillingData() {
     const { data, error, isLoading, mutate } = useSWR<UsageSummary>('/api/billing/usage', fetcher, {
         refreshInterval: 60000, // Refresh every minute
         revalidateOnFocus: true
-        // dedupingInterval: 5000 // Dedupe requests within 5 seconds
     })
 
     return {

--- a/packages-answers/ui/src/hooks/useApi.ts
+++ b/packages-answers/ui/src/hooks/useApi.ts
@@ -7,8 +7,8 @@ export function useApi<T = any>(key: string, apiFunc: () => Promise<{ data: T }>
     }
 
     const { data, error, isLoading, mutate } = useSWR<T>(key, fetcher, {
-        revalidateOnFocus: true,
-        dedupingInterval: 5000
+        revalidateOnFocus: true
+        // dedupingInterval: 5000
     })
 
     return {

--- a/packages-answers/ui/src/hooks/useApi.ts
+++ b/packages-answers/ui/src/hooks/useApi.ts
@@ -8,7 +8,6 @@ export function useApi<T = any>(key: string, apiFunc: () => Promise<{ data: T }>
 
     const { data, error, isLoading, mutate } = useSWR<T>(key, fetcher, {
         revalidateOnFocus: true
-        // dedupingInterval: 5000
     })
 
     return {

--- a/packages/ui/src/hooks/useSidekickWithCredentials.js
+++ b/packages/ui/src/hooks/useSidekickWithCredentials.js
@@ -19,8 +19,8 @@ export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) 
         mutate,
         isLoading
     } = useSWR(apiUrl, fetcher, {
-        revalidateOnFocus: false,
-        dedupingInterval: 10000
+        revalidateOnFocus: false
+        // dedupingInterval: 10000
     })
 
     const updateSidekick = useCallback(

--- a/packages/ui/src/hooks/useSidekickWithCredentials.js
+++ b/packages/ui/src/hooks/useSidekickWithCredentials.js
@@ -20,7 +20,6 @@ export const useSidekickWithCredentials = (sidekickId, forceQuickSetup = false) 
         isLoading
     } = useSWR(apiUrl, fetcher, {
         revalidateOnFocus: false
-        // dedupingInterval: 10000
     })
 
     const updateSidekick = useCallback(


### PR DESCRIPTION
## Summary
Fixes critical issues with follow-up prompts and chat UI not loading sidekick data correctly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- **Removed SWR dedupingInterval configurations** across multiple hooks causing stale cache issues
  - `useSidekickData.ts`: Removed fallbackData and deduping configs
  - `useSidekickDetails.ts`: Removed retry and deduping configs
  - `useBillingData.ts`: Removed dedupingInterval
  - `useApi.ts`: Removed dedupingInterval
  - `useSidekickWithCredentials.js`: Removed dedupingInterval
- **Fixed AnswersContext.tsx**:
  - Removed optimistic SWR update causing conflicts with server state
  - Added debug logging for sidekick data troubleshooting
- **Fixed SourcesBasicDocument.tsx**: Removed dedupingInterval

## Root Cause
The SWR `dedupingInterval` configurations were preventing fresh data fetches, causing:
1. Follow-up prompts to fail due to stale sidekick constraints
2. Chat UI to display outdated sidekick data
3. Conflicts between optimistic updates and server state

## Files Changed
- `packages-answers/ui/src/AnswersContext.tsx`
- `packages-answers/ui/src/SidekickSelect/hooks/useSidekickData.ts`
- `packages-answers/ui/src/SidekickSelect/hooks/useSidekickDetails.ts`
- `packages-answers/ui/src/SourcesBasicDocument.tsx`
- `packages-answers/ui/src/billing/hooks/useBillingData.ts`
- `packages-answers/ui/src/hooks/useApi.ts`
- `packages/ui/src/hooks/useSidekickWithCredentials.js`

## Testing
- [ ] Verify follow-up prompts work correctly
- [ ] Verify sidekick data loads fresh in chat UI
- [ ] Verify no performance degradation from removed deduping
- [ ] Test chat interactions with multiple sidekicks