### PR TITLE
fix(document-loaders): input validation type coercion for AAI loaders

### DIFF
--- a/packages/components/nodes/documentloaders/AAIDomains/AAIDomains.ts
+++ b/packages/components/nodes/documentloaders/AAIDomains/AAIDomains.ts
@@ -183,7 +183,7 @@ class AAIDomains_DocumentLoaders implements INode {
 
     async init(nodeData: INodeData): Promise<any> {
         const textSplitter = nodeData.inputs?.textSplitter as TextSplitter
-        const limit = nodeData.inputs?.limit as number
+        const limit = nodeData.inputs?.limit ? Number(nodeData.inputs.limit) : undefined
         const searchTerm = nodeData.inputs?.searchTerm as string
         const includeTags = nodeData.inputs?.includeTags as string
         const includeTagsLogic = (nodeData.inputs?.includeTagsLogic as string) || 'OR'
@@ -202,6 +202,9 @@ class AAIDomains_DocumentLoaders implements INode {
 
         // Validate inputs
         if (limit !== undefined && limit !== null) {
+            if (isNaN(limit)) {
+                throw new Error('Limit must be a valid number')
+            }
             if (limit <= 0) {
                 throw new Error('Limit must be a positive number')
             }

--- a/packages/components/nodes/documentloaders/AAITags/AAITags.ts
+++ b/packages/components/nodes/documentloaders/AAITags/AAITags.ts
@@ -117,11 +117,11 @@ class AAITags_DocumentLoaders implements INode {
 
     async init(nodeData: INodeData): Promise<any> {
         const textSplitter = nodeData.inputs?.textSplitter as TextSplitter
-        const limit = nodeData.inputs?.limit as number
+        const limit = nodeData.inputs?.limit ? Number(nodeData.inputs.limit) : undefined
         const searchTerm = nodeData.inputs?.searchTerm as string
-        const parentTagsOnly = nodeData.inputs?.parentTagsOnly as boolean
-        const childTagsOnly = nodeData.inputs?.childTagsOnly as boolean
-        const includeParentInfo = nodeData.inputs?.includeParentInfo as boolean
+        const parentTagsOnly = nodeData.inputs?.parentTagsOnly === true || nodeData.inputs?.parentTagsOnly === 'true'
+        const childTagsOnly = nodeData.inputs?.childTagsOnly === true || nodeData.inputs?.childTagsOnly === 'true'
+        const includeParentInfo = !(nodeData.inputs?.includeParentInfo === false || nodeData.inputs?.includeParentInfo === 'false')
         const metadata = nodeData.inputs?.metadata
         const _omitMetadataKeys = nodeData.inputs?.omitMetadataKeys as string
         const output = nodeData.outputs?.output as string
@@ -133,6 +133,9 @@ class AAITags_DocumentLoaders implements INode {
 
         // Validate inputs
         if (limit !== undefined && limit !== null) {
+            if (isNaN(limit)) {
+                throw new Error('Limit must be a valid number')
+            }
             if (limit <= 0) {
                 throw new Error('Limit must be a positive number')
             }

--- a/packages/components/nodes/documentloaders/AAITranscripts/AAITranscripts.ts
+++ b/packages/components/nodes/documentloaders/AAITranscripts/AAITranscripts.ts
@@ -184,7 +184,7 @@ class AAITranscripts_DocumentLoaders implements INode {
 
     async init(nodeData: INodeData): Promise<any> {
         const textSplitter = nodeData.inputs?.textSplitter as TextSplitter
-        const limit = nodeData.inputs?.limit as number
+        const limit = nodeData.inputs?.limit ? Number(nodeData.inputs.limit) : undefined
         const searchTerm = nodeData.inputs?.searchTerm as string
         const dateFrom = nodeData.inputs?.dateFrom as string
         const dateTo = nodeData.inputs?.dateTo as string
@@ -192,8 +192,8 @@ class AAITranscripts_DocumentLoaders implements INode {
         const includeTagsLogic = (nodeData.inputs?.includeTagsLogic as string) || 'OR'
         const excludeTags = nodeData.inputs?.excludeTags as string
         const hasAnalysis = (nodeData.inputs?.hasAnalysis as string) || 'all'
-        const sentimentMin = nodeData.inputs?.sentimentMin as number
-        const sentimentMax = nodeData.inputs?.sentimentMax as number
+        const sentimentMin = nodeData.inputs?.sentimentMin ? Number(nodeData.inputs.sentimentMin) : undefined
+        const sentimentMax = nodeData.inputs?.sentimentMax ? Number(nodeData.inputs.sentimentMax) : undefined
         const metadata = nodeData.inputs?.metadata
         const _omitMetadataKeys = nodeData.inputs?.omitMetadataKeys as string
         const output = nodeData.outputs?.output as string
@@ -205,6 +205,9 @@ class AAITranscripts_DocumentLoaders implements INode {
 
         // Validate inputs
         if (limit !== undefined && limit !== null) {
+            if (isNaN(limit)) {
+                throw new Error('Limit must be a valid number')
+            }
             if (limit <= 0) {
                 throw new Error('Limit must be a positive number')
             }
@@ -248,8 +251,8 @@ class AAITranscripts_DocumentLoaders implements INode {
         }
 
         if (sentimentMin !== undefined && sentimentMin !== null) {
-            if (typeof sentimentMin !== 'number' || isNaN(sentimentMin)) {
-                throw new Error('Sentiment Min must be a number')
+            if (isNaN(sentimentMin)) {
+                throw new Error('Sentiment Min must be a valid number')
             }
             if (sentimentMin < 1 || sentimentMin > 10) {
                 throw new Error('Sentiment Min must be between 1 and 10')
@@ -257,8 +260,8 @@ class AAITranscripts_DocumentLoaders implements INode {
         }
 
         if (sentimentMax !== undefined && sentimentMax !== null) {
-            if (typeof sentimentMax !== 'number' || isNaN(sentimentMax)) {
-                throw new Error('Sentiment Max must be a number')
+            if (isNaN(sentimentMax)) {
+                throw new Error('Sentiment Max must be a valid number')
             }
             if (sentimentMax < 1 || sentimentMax > 10) {
                 throw new Error('Sentiment Max must be between 1 and 10')

--- a/packages/components/nodes/documentloaders/AAIUrls/AAIUrls.ts
+++ b/packages/components/nodes/documentloaders/AAIUrls/AAIUrls.ts
@@ -167,7 +167,7 @@ class AAIUrls_DocumentLoaders implements INode {
 
     async init(nodeData: INodeData): Promise<any> {
         const textSplitter = nodeData.inputs?.textSplitter as TextSplitter
-        const limit = nodeData.inputs?.limit as number
+        const limit = nodeData.inputs?.limit ? Number(nodeData.inputs.limit) : undefined
         const searchTerm = nodeData.inputs?.searchTerm as string
         const includeTags = nodeData.inputs?.includeTags as string
         const includeTagsLogic = (nodeData.inputs?.includeTagsLogic as string) || 'OR'
@@ -186,6 +186,9 @@ class AAIUrls_DocumentLoaders implements INode {
 
         // Validate inputs
         if (limit !== undefined && limit !== null) {
+            if (isNaN(limit)) {
+                throw new Error('Limit must be a valid number')
+            }
             if (limit <= 0) {
                 throw new Error('Limit must be a positive number')
             }
@@ -209,7 +212,9 @@ class AAIUrls_DocumentLoaders implements INode {
 
                 if (!isCategory && (!isNumeric || statusCode === null || statusCode < 100 || statusCode > 599)) {
                     throw new Error(
-                        `Invalid status filter "${filter}". Must be one of: ${validCategories.join(', ')}, or a valid HTTP status code (100-599)`
+                        `Invalid status filter "${filter}". Must be one of: ${validCategories.join(
+                            ', '
+                        )}, or a valid HTTP status code (100-599)`
                     )
                 }
             }


### PR DESCRIPTION
## Summary
Fixed input validation bugs in all 4 AAI document loaders where numeric and boolean inputs from the UI were not being parsed before validation, causing validation errors even with valid values.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Made

### AAIUrls.ts
- Parse `limit` field using `Number()` before validation
- Added `isNaN()` check to numeric validation

### AAITranscripts.ts
- Parse `limit`, `sentimentMin`, and `sentimentMax` fields using `Number()`
- Replaced `typeof` checks with `isNaN()` checks
- Added NaN validation before range validation

### AAITags.ts
- Parse `limit` field using `Number()` before validation
- Handle boolean string values for `parentTagsOnly`, `childTagsOnly`, and `includeParentInfo`
- Added `isNaN()` check to limit validation

### AAIDomains.ts
- Parse `limit` field using `Number()` before validation
- Added `isNaN()` check to numeric validation

## Root Cause
TypeScript type assertions (`as number`, `as boolean`) don't perform runtime type conversion. When values come from the UI form, they arrive as strings ("100", "true", etc.), but the validation code expected actual JavaScript number/boolean types, causing validation to fail before the values could be used.

## Testing
- [x] Tested AAIUrls with custom limit values
- [x] Tested AAITranscripts with custom limit and sentiment filters
- [x] Tested AAITags with custom limit and boolean toggles
- [x] Tested AAIDomains with custom limit values
- [x] Verified default values still work correctly
- [x] Confirmed in WoW and Kumello docs environments

## Related Issues
Fixes AGENT-124

## Additional Notes
All numeric inputs now properly parse string values to numbers before validation, and all boolean inputs handle both boolean and string "true"/"false" values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)