### PR TITLE
Release: Follow-up prompts with Langfuse tracking

### DIFF
--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -461,6 +461,10 @@ export enum FollowUpPromptProvider {
     GOOGLE_GENAI = 'chatGoogleGenerativeAI',
     MISTRALAI = 'chatMistralAI',
     OPENAI = 'chatOpenAI',
+    AAI_OPENAI = 'aaiChatOpenAI',
+    AAI_ANTHROPIC = 'aaiChatAnthropic',
+    AAI_GOOGLE_GENAI = 'aaiChatGoogleGenerativeAI',
+    AAI_GROQ = 'aaiGroqChat',
     GROQ = 'groqChat',
     OLLAMA = 'ollama'
 }

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -23,6 +23,7 @@ const FollowUpPromptType = z
  */
 const createLangfuseCallbacks = (options: ICommonObject, followUpPromptsConfig: FollowUpPromptConfig, providerConfig: any): any[] => {
     const parentLangfuseTrace = options.parentLangfuseTrace
+    const messageId = options.messageId // The message this follow-up is for
 
     // Check if Langfuse is configured via env vars
     if (!process.env.LANGFUSE_SECRET_KEY) {
@@ -30,24 +31,30 @@ const createLangfuseCallbacks = (options: ICommonObject, followUpPromptsConfig: 
     }
 
     try {
+        // Build metadata with clear linkage to the conversation message
+        const metadata: any = {
+            chatId: options.chatId,
+            chatflowid: options.chatflowid,
+            component: 'follow-up-prompts',
+            provider: followUpPromptsConfig.selectedProvider,
+            modelName: providerConfig.modelName,
+            // Link to the specific message this follow-up is generated for
+            forMessageId: messageId,
+            traceType: 'follow-up-generation'
+        }
+
         const handlerConfig: any = {
             publicKey: process.env.LANGFUSE_PUBLIC_KEY,
             secretKey: process.env.LANGFUSE_SECRET_KEY,
             baseUrl: process.env.LANGFUSE_HOST ?? 'https://cloud.langfuse.com',
             sessionId: options.sessionId,
             userId: options.userId,
-            metadata: {
-                chatId: options.chatId,
-                chatflowid: options.chatflowid,
-                component: 'follow-up-prompts',
-                provider: followUpPromptsConfig.selectedProvider,
-                modelName: providerConfig.modelName
-            },
-            tags: ['follow-up-prompts']
+            metadata,
+            tags: ['follow-up-prompts', `chat:${options.chatId}`, messageId ? `message:${messageId}` : null].filter(Boolean)
         }
 
         // For agentflows: nest under parent trace
-        // For chatflows: create standalone trace linked by sessionId
+        // For chatflows: create standalone trace linked by sessionId + metadata
         if (parentLangfuseTrace) {
             handlerConfig.root = parentLangfuseTrace
             handlerConfig.updateRoot = false

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -103,6 +103,65 @@ export const generateFollowUpPrompts = async (
                 const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
                 return structuredResponse
             }
+            case FollowUpPromptProvider.AAI_OPENAI: {
+                const aaiOpenAIApiKey = process.env.AAI_DEFAULT_OPENAI_API_KEY
+                if (!aaiOpenAIApiKey) {
+                    throw new Error('AAI_DEFAULT_OPENAI_API_KEY environment variable is not set')
+                }
+                const model = new ChatOpenAI({
+                    apiKey: aaiOpenAIApiKey,
+                    model: providerConfig.modelName,
+                    temperature: parseFloat(`${providerConfig.temperature}`),
+                    useResponsesApi: true
+                })
+                // @ts-ignore
+                const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                return structuredResponse
+            }
+            case FollowUpPromptProvider.AAI_ANTHROPIC: {
+                const aaiAnthropicApiKey = process.env.AAI_DEFAULT_ANTHROPHIC
+                if (!aaiAnthropicApiKey) {
+                    throw new Error('AAI_DEFAULT_ANTHROPHIC environment variable is not set')
+                }
+                const llm = new ChatAnthropic({
+                    apiKey: aaiAnthropicApiKey,
+                    model: providerConfig.modelName,
+                    temperature: parseFloat(`${providerConfig.temperature}`)
+                })
+                // @ts-ignore
+                const structuredLLM = llm.withStructuredOutput(FollowUpPromptType)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                return structuredResponse
+            }
+            case FollowUpPromptProvider.AAI_GOOGLE_GENAI: {
+                const aaiGoogleGenAIApiKey = process.env.AAI_DEFAULT_GOOGLE_GENERATIVE_AI_API_KEY
+                if (!aaiGoogleGenAIApiKey) {
+                    throw new Error('AAI_DEFAULT_GOOGLE_GENERATIVE_AI_API_KEY environment variable is not set')
+                }
+                const model = new ChatGoogleGenerativeAI({
+                    apiKey: aaiGoogleGenAIApiKey,
+                    model: providerConfig.modelName,
+                    temperature: parseFloat(`${providerConfig.temperature}`)
+                })
+                const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                return structuredResponse
+            }
+            case FollowUpPromptProvider.AAI_GROQ: {
+                const aaiGroqApiKey = process.env.AAI_DEFAULT_GROQ
+                if (!aaiGroqApiKey) {
+                    throw new Error('AAI_DEFAULT_GROQ environment variable is not set')
+                }
+                const llm = new ChatGroq({
+                    apiKey: aaiGroqApiKey,
+                    model: providerConfig.modelName,
+                    temperature: parseFloat(`${providerConfig.temperature}`)
+                })
+                const structuredLLM = llm.withStructuredOutput(FollowUpPromptType)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                return structuredResponse
+            }
             case FollowUpPromptProvider.GROQ: {
                 const llm = new ChatGroq({
                     apiKey: credentialData.groqApiKey,

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -157,9 +157,9 @@ export const generateFollowUpPrompts = async (
                 return structuredResponse
             }
             case FollowUpPromptProvider.AAI_ANTHROPIC: {
-                const aaiAnthropicApiKey = process.env.AAI_DEFAULT_ANTHROPHIC
+                const aaiAnthropicApiKey = process.env.AAI_DEFAULT_ANTHROPIC
                 if (!aaiAnthropicApiKey) {
-                    throw new Error('AAI_DEFAULT_ANTHROPHIC environment variable is not set')
+                    throw new Error('AAI_DEFAULT_ANTHROPIC environment variable is not set')
                 }
                 const llm = new ChatAnthropic({
                     apiKey: aaiAnthropicApiKey,

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -157,9 +157,9 @@ export const generateFollowUpPrompts = async (
                 return structuredResponse
             }
             case FollowUpPromptProvider.AAI_ANTHROPIC: {
-                const aaiAnthropicApiKey = process.env.AAI_DEFAULT_ANTHROPIC
+                const aaiAnthropicApiKey = process.env.AAI_DEFAULT_ANTHROPHIC
                 if (!aaiAnthropicApiKey) {
-                    throw new Error('AAI_DEFAULT_ANTHROPIC environment variable is not set')
+                    throw new Error('AAI_DEFAULT_ANTHROPHIC environment variable is not set')
                 }
                 const llm = new ChatAnthropic({
                     apiKey: aaiAnthropicApiKey,

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -23,12 +23,17 @@ const FollowUpPromptType = z
  */
 const createLangfuseCallbacks = (options: ICommonObject, followUpPromptsConfig: FollowUpPromptConfig, providerConfig: any): any[] => {
     const parentLangfuseTrace = options.parentLangfuseTrace
-    if (!parentLangfuseTrace) return []
+
+    // Check if Langfuse is configured via env vars
+    if (!process.env.LANGFUSE_SECRET_KEY) {
+        return []
+    }
 
     try {
-        const handler = new CallbackHandler({
-            root: parentLangfuseTrace,
-            updateRoot: false,
+        const handlerConfig: any = {
+            publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+            secretKey: process.env.LANGFUSE_SECRET_KEY,
+            baseUrl: process.env.LANGFUSE_HOST ?? 'https://cloud.langfuse.com',
             sessionId: options.sessionId,
             userId: options.userId,
             metadata: {
@@ -39,7 +44,16 @@ const createLangfuseCallbacks = (options: ICommonObject, followUpPromptsConfig: 
                 modelName: providerConfig.modelName
             },
             tags: ['follow-up-prompts']
-        })
+        }
+
+        // For agentflows: nest under parent trace
+        // For chatflows: create standalone trace linked by sessionId
+        if (parentLangfuseTrace) {
+            handlerConfig.root = parentLangfuseTrace
+            handlerConfig.updateRoot = false
+        }
+
+        const handler = new CallbackHandler(handlerConfig)
         return [handler]
     } catch (error) {
         console.warn('Failed to create Langfuse handler for follow-up prompts:', error)
@@ -60,7 +74,7 @@ export const generateFollowUpPrompts = async (
         const credentialData = await getCredentialData(credentialId ?? '', options)
         const followUpPromptsPrompt = providerConfig.prompt.replace('{history}', apiMessageContent)
 
-        // Create Langfuse callback handlers for tracking (if parent trace exists)
+        // Create Langfuse callback handlers for tracking
         const callbacks = createLangfuseCallbacks(options, followUpPromptsConfig, providerConfig)
 
         switch (followUpPromptsConfig.selectedProvider) {

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -9,12 +9,43 @@ import { PromptTemplate } from '@langchain/core/prompts'
 import { StructuredOutputParser } from '@langchain/core/output_parsers'
 import { ChatGroq } from '@langchain/groq'
 import { Ollama } from 'ollama'
+import { CallbackHandler } from 'langfuse-langchain'
 
 const FollowUpPromptType = z
     .object({
         questions: z.array(z.string())
     })
     .describe('Generate Follow Up Prompts')
+
+/**
+ * Creates Langfuse callback handlers for follow-up prompts tracking
+ * Extracted to reduce merge conflicts and improve maintainability
+ */
+const createLangfuseCallbacks = (options: ICommonObject, followUpPromptsConfig: FollowUpPromptConfig, providerConfig: any): any[] => {
+    const parentLangfuseTrace = options.parentLangfuseTrace
+    if (!parentLangfuseTrace) return []
+
+    try {
+        const handler = new CallbackHandler({
+            root: parentLangfuseTrace,
+            updateRoot: false,
+            sessionId: options.sessionId,
+            userId: options.userId,
+            metadata: {
+                chatId: options.chatId,
+                chatflowid: options.chatflowid,
+                component: 'follow-up-prompts',
+                provider: followUpPromptsConfig.selectedProvider,
+                modelName: providerConfig.modelName
+            },
+            tags: ['follow-up-prompts']
+        })
+        return [handler]
+    } catch (error) {
+        console.warn('Failed to create Langfuse handler for follow-up prompts:', error)
+        return []
+    }
+}
 
 export const generateFollowUpPrompts = async (
     followUpPromptsConfig: FollowUpPromptConfig,
@@ -29,6 +60,9 @@ export const generateFollowUpPrompts = async (
         const credentialData = await getCredentialData(credentialId ?? '', options)
         const followUpPromptsPrompt = providerConfig.prompt.replace('{history}', apiMessageContent)
 
+        // Create Langfuse callback handlers for tracking (if parent trace exists)
+        const callbacks = createLangfuseCallbacks(options, followUpPromptsConfig, providerConfig)
+
         switch (followUpPromptsConfig.selectedProvider) {
             case FollowUpPromptProvider.ANTHROPIC: {
                 const llm = new ChatAnthropic({
@@ -38,7 +72,7 @@ export const generateFollowUpPrompts = async (
                 })
                 // @ts-ignore
                 const structuredLLM = llm.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.AZURE_OPENAI: {
@@ -64,10 +98,13 @@ export const generateFollowUpPrompts = async (
                     {format_instructions}
                 `)
                 const chain = prompt.pipe(llm).pipe(parser)
-                const structuredResponse = await chain.invoke({
-                    history: apiMessageContent,
-                    format_instructions: formatInstructions
-                })
+                const structuredResponse = await chain.invoke(
+                    {
+                        history: apiMessageContent,
+                        format_instructions: formatInstructions
+                    },
+                    callbacks.length ? { callbacks } : undefined
+                )
                 return structuredResponse
             }
             case FollowUpPromptProvider.GOOGLE_GENAI: {
@@ -77,7 +114,7 @@ export const generateFollowUpPrompts = async (
                     temperature: parseFloat(`${providerConfig.temperature}`)
                 })
                 const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.MISTRALAI: {
@@ -88,7 +125,7 @@ export const generateFollowUpPrompts = async (
                 })
                 // @ts-ignore
                 const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.OPENAI: {
@@ -100,7 +137,7 @@ export const generateFollowUpPrompts = async (
                 })
                 // @ts-ignore
                 const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.AAI_OPENAI: {
@@ -116,7 +153,7 @@ export const generateFollowUpPrompts = async (
                 })
                 // @ts-ignore
                 const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.AAI_ANTHROPIC: {
@@ -131,7 +168,7 @@ export const generateFollowUpPrompts = async (
                 })
                 // @ts-ignore
                 const structuredLLM = llm.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.AAI_GOOGLE_GENAI: {
@@ -145,7 +182,7 @@ export const generateFollowUpPrompts = async (
                     temperature: parseFloat(`${providerConfig.temperature}`)
                 })
                 const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.AAI_GROQ: {
@@ -159,7 +196,7 @@ export const generateFollowUpPrompts = async (
                     temperature: parseFloat(`${providerConfig.temperature}`)
                 })
                 const structuredLLM = llm.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.GROQ: {
@@ -169,7 +206,7 @@ export const generateFollowUpPrompts = async (
                     temperature: parseFloat(`${providerConfig.temperature}`)
                 })
                 const structuredLLM = llm.withStructuredOutput(FollowUpPromptType)
-                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt, callbacks.length ? { callbacks } : undefined)
                 return structuredResponse
             }
             case FollowUpPromptProvider.OLLAMA: {

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -1899,7 +1899,10 @@ export const executeAgentFlow = async ({
             chatId,
             chatflowid,
             appDataSource,
-            databaseEntities
+            databaseEntities,
+            parentLangfuseTrace,
+            sessionId,
+            userId: incomingInput.user?.id
         })
         if (followUpPrompts?.questions) {
             apiMessage.followUpPrompts = JSON.stringify(followUpPrompts.questions)

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -594,7 +594,10 @@ export const executeFlow = async ({
                     chatId,
                     chatflowid: agentflow.id,
                     appDataSource,
-                    databaseEntities
+                    databaseEntities,
+                    parentLangfuseTrace: undefined,
+                    sessionId,
+                    userId: user?.id ?? agentflow.userId
                 })
                 if (generatedFollowUpPrompts?.questions) {
                     apiMessage.followUpPrompts = JSON.stringify(generatedFollowUpPrompts.questions)
@@ -798,7 +801,10 @@ export const executeFlow = async ({
                 chatId,
                 chatflowid,
                 appDataSource,
-                databaseEntities
+                databaseEntities,
+                parentLangfuseTrace: undefined,
+                sessionId,
+                userId: user?.id
             })
             if (followUpPrompts?.questions) {
                 apiMessage.followUpPrompts = JSON.stringify(followUpPrompts.questions)

--- a/packages/ui/src/assets/images/google_gemini.svg
+++ b/packages/ui/src/assets/images/google_gemini.svg
@@ -1,0 +1,34 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_42_15021" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="4" y="4" width="24" height="24">
+<path d="M16.9976 4.93059C16.9611 4.40651 16.5253 4 16 4C15.4747 4 15.0389 4.40651 15.0024 4.93059L14.951 5.66926C14.6048 10.645 10.645 14.6048 5.66926 14.951L4.93059 15.0024C4.40651 15.0389 4 15.4747 4 16C4 16.5253 4.40651 16.9611 4.93059 16.9976L5.66926 17.049C10.645 17.3952 14.6048 21.355 14.951 26.3307L15.0024 27.0694C15.0389 27.5935 15.4747 28 16 28C16.5253 28 16.9611 27.5935 16.9976 27.0694L17.049 26.3307C17.3952 21.355 21.355 17.3952 26.3307 17.049L27.0694 16.9976C27.5935 16.9611 28 16.5253 28 16C28 15.4747 27.5935 15.0389 27.0694 15.0024L26.3307 14.951C21.355 14.6048 17.3952 10.645 17.049 5.66926L16.9976 4.93059Z" fill="black"/>
+</mask>
+<g mask="url(#mask0_42_15021)">
+<path d="M16.9976 4.93059C16.9611 4.40651 16.5253 4 16 4C15.4747 4 15.0389 4.40651 15.0024 4.93059L14.951 5.66926C14.6048 10.645 10.645 14.6048 5.66926 14.951L4.93059 15.0024C4.40651 15.0389 4 15.4747 4 16C4 16.5253 4.40651 16.9611 4.93059 16.9976L5.66926 17.049C10.645 17.3952 14.6048 21.355 14.951 26.3307L15.0024 27.0694C15.0389 27.5935 15.4747 28 16 28C16.5253 28 16.9611 27.5935 16.9976 27.0694L17.049 26.3307C17.3952 21.355 21.355 17.3952 26.3307 17.049L27.0694 16.9976C27.5935 16.9611 28 16.5253 28 16C28 15.4747 27.5935 15.0389 27.0694 15.0024L26.3307 14.951C21.355 14.6048 17.3952 10.645 17.049 5.66926L16.9976 4.93059Z" fill="white"/>
+<g filter="url(#filter0_f_42_15021)">
+<circle cx="10.4616" cy="13.2307" r="8.30769" fill="#77B6E5"/>
+</g>
+<g filter="url(#filter1_f_42_15021)">
+<circle cx="16" cy="22.4615" r="8.30769" fill="#1E90C9"/>
+</g>
+<g filter="url(#filter2_f_42_15021)">
+<ellipse cx="21.5385" cy="10.4615" rx="10.1538" ry="8.30769" fill="#E9E5DF"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_42_15021" x="-7.84613" y="-5.07697" width="36.6154" height="36.6154" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="5" result="effect1_foregroundBlur_42_15021"/>
+</filter>
+<filter id="filter1_f_42_15021" x="-0.307678" y="6.15381" width="32.6154" height="32.6154" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="4" result="effect1_foregroundBlur_42_15021"/>
+</filter>
+<filter id="filter2_f_42_15021" x="3.38464" y="-5.84619" width="36.3077" height="32.6154" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="4" result="effect1_foregroundBlur_42_15021"/>
+</filter>
+</defs>
+</svg>

--- a/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
+++ b/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
@@ -16,6 +16,7 @@ import mistralAiIcon from '@/assets/images/mistralai.svg'
 import openAiIcon from '@/assets/images/openai.svg'
 import groqIcon from '@/assets/images/groq.gif'
 import ollamaIcon from '@/assets/images/ollama.svg'
+import googleGeminiIcon from '@/assets/images/google_gemini.svg'
 import { TooltipWithParser } from '@/ui-component/tooltip/TooltipWithParser'
 import CredentialInputHandler from '@/views/canvas/CredentialInputHandler'
 import { Input } from '@/ui-component/input/Input'
@@ -109,7 +110,7 @@ const followUpPromptsOptions = {
     [FollowUpPromptProviders.AAI_GOOGLE_GENAI]: {
         label: 'Answer Google Gemini',
         name: FollowUpPromptProviders.AAI_GOOGLE_GENAI,
-        icon: azureOpenAiIcon,
+        icon: googleGeminiIcon,
         inputs: [
             {
                 label: 'Model Name',
@@ -281,7 +282,7 @@ const followUpPromptsOptions = {
     [FollowUpPromptProviders.GOOGLE_GENAI]: {
         label: 'Google Gemini',
         name: FollowUpPromptProviders.GOOGLE_GENAI,
-        icon: azureOpenAiIcon,
+        icon: googleGeminiIcon,
         inputs: [
             {
                 label: 'Connect Credential',

--- a/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
+++ b/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
@@ -32,6 +32,10 @@ const defaultPrompt =
 
 // update when adding new providers
 const FollowUpPromptProviders = {
+    AAI_OPENAI: 'aaiChatOpenAI',
+    AAI_ANTHROPIC: 'aaiChatAnthropic',
+    AAI_GOOGLE_GENAI: 'aaiChatGoogleGenerativeAI',
+    AAI_GROQ: 'aaiGroqChat',
     ANTHROPIC: 'chatAnthropic',
     AZURE_OPENAI: 'azureChatOpenAI',
     GOOGLE_GENAI: 'chatGoogleGenerativeAI',
@@ -42,6 +46,166 @@ const FollowUpPromptProviders = {
 }
 
 const followUpPromptsOptions = {
+    [FollowUpPromptProviders.AAI_OPENAI]: {
+        label: 'Answer OpenAI',
+        name: FollowUpPromptProviders.AAI_OPENAI,
+        icon: openAiIcon,
+        inputs: [
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'asyncOptions',
+                loadMethod: 'listModels'
+            },
+            {
+                label: 'Prompt',
+                name: 'prompt',
+                type: 'string',
+                rows: 4,
+                description: promptDescription,
+                optional: true,
+                default: defaultPrompt
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                default: 0.9
+            }
+        ]
+    },
+    [FollowUpPromptProviders.AAI_ANTHROPIC]: {
+        label: 'Answer Anthropic',
+        name: FollowUpPromptProviders.AAI_ANTHROPIC,
+        icon: anthropicIcon,
+        inputs: [
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'asyncOptions',
+                loadMethod: 'listModels'
+            },
+            {
+                label: 'Prompt',
+                name: 'prompt',
+                type: 'string',
+                rows: 4,
+                description: promptDescription,
+                optional: true,
+                default: defaultPrompt
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                default: 0.9
+            }
+        ]
+    },
+    [FollowUpPromptProviders.AAI_GOOGLE_GENAI]: {
+        label: 'Answer Google Gemini',
+        name: FollowUpPromptProviders.AAI_GOOGLE_GENAI,
+        icon: azureOpenAiIcon,
+        inputs: [
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'options',
+                default: 'gemini-1.5-pro-latest',
+                options: [
+                    { label: 'gemini-1.5-flash-latest', name: 'gemini-1.5-flash-latest' },
+                    { label: 'gemini-1.5-pro-latest', name: 'gemini-1.5-pro-latest' }
+                ]
+            },
+            {
+                label: 'Prompt',
+                name: 'prompt',
+                type: 'string',
+                rows: 4,
+                description: promptDescription,
+                optional: true,
+                default: defaultPrompt
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                default: 0.9
+            }
+        ]
+    },
+    [FollowUpPromptProviders.AAI_GROQ]: {
+        label: 'Answer Groq',
+        name: FollowUpPromptProviders.AAI_GROQ,
+        icon: groqIcon,
+        inputs: [
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'asyncOptions',
+                loadMethod: 'listModels'
+            },
+            {
+                label: 'Prompt',
+                name: 'prompt',
+                type: 'string',
+                rows: 4,
+                description: promptDescription,
+                optional: true,
+                default: defaultPrompt
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                default: 0.9
+            }
+        ]
+    },
+    [FollowUpPromptProviders.OPENAI]: {
+        label: 'OpenAI',
+        name: FollowUpPromptProviders.OPENAI,
+        icon: openAiIcon,
+        inputs: [
+            {
+                label: 'Connect Credential',
+                name: 'credential',
+                type: 'credential',
+                credentialNames: ['openAIApi']
+            },
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'asyncOptions',
+                loadMethod: 'listModels'
+            },
+            {
+                label: 'Prompt',
+                name: 'prompt',
+                type: 'string',
+                rows: 4,
+                description: promptDescription,
+                optional: true,
+                default: defaultPrompt
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                default: 0.9
+            }
+        ]
+    },
     [FollowUpPromptProviders.ANTHROPIC]: {
         label: 'Anthropic Claude',
         name: FollowUpPromptProviders.ANTHROPIC,


### PR DESCRIPTION
## Summary
- Add Answer FollowUpPrompts providers with Langfuse tracking
- Fix follow-up prompts display and format
- Fix env var typos and Google Gemini icons
- Create standalone Langfuse trace for chatflows

## Changes
- 9 files changed, 360 insertions(+), 26 deletions(-)

## Commits
- feat: add Langfuse tracking for AAI follow-up prompts
- feat: enhance follow-up prompt trace metadata with messageId
- fix: create standalone Langfuse trace for chatflows
- fix: revert to AAI_DEFAULT_ANTHROPHIC (existing env var)
- fix: correct env var typo and Google Gemini icons
- fix(ui): followup prompts displayed
- fix(ui): followup prompts wrong format