### PR TITLE
feat: pass chatflowid to AgentflowCanvas component for improved data …

### DIFF
--- a/apps/web/app/(Main UI)/(Studio Layout)/sidekick-studio/(minimal-layout)/v2/agentcanvas/[chatflowid]/page.tsx
+++ b/apps/web/app/(Main UI)/(Studio Layout)/sidekick-studio/(minimal-layout)/v2/agentcanvas/[chatflowid]/page.tsx
@@ -5,10 +5,10 @@ import dynamic from 'next/dynamic'
 
 const View = dynamic(() => import('@/views/agentflowsv2/Canvas'), { ssr: false })
 
-const Page = () => {
+const Page = ({ params }: { params: { chatflowid: string } }) => {
     return (
         <>
-            <View />
+            <View chatflowid={params.chatflowid} />
         </>
     )
 }

--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback, useContext } from 'react'
+import PropTypes from 'prop-types'
 import ReactFlow, { addEdge, Controls, MiniMap, Background, useNodesState, useEdgesState } from 'reactflow'
 import 'reactflow/dist/style.css'
 import './index.css'
@@ -66,7 +67,7 @@ const edgeTypes = { agentFlow: AgentFlowEdge }
 
 // ==============================|| CANVAS ||============================== //
 
-const AgentflowCanvas = () => {
+const AgentflowCanvas = ({ chatflowid: chatflowId }) => {
     const theme = useTheme()
     const navigate = useNavigate()
     const customization = useSelector((state) => state.customization)
@@ -74,10 +75,7 @@ const AgentflowCanvas = () => {
     const { state } = useLocation()
     const templateFlowData = state ? state.templateFlowData : ''
 
-    const URLpath = document.location.pathname.toString().split('/')
-    const chatflowId =
-        URLpath[URLpath.length - 1] === 'canvas' || URLpath[URLpath.length - 1] === 'agentcanvas' ? '' : URLpath[URLpath.length - 1]
-    const canvasTitle = URLpath.includes('agentcanvas') ? 'Agent' : 'Chatflow'
+    const canvasTitle = 'Agent'
 
     const { confirm } = useConfirm()
 
@@ -619,14 +617,7 @@ const AgentflowCanvas = () => {
                 console.error('[Canvas] Failed to open credential modal:', error)
             }
         })
-    }, [
-        canvasDataStore.chatflow?.flowData,
-        canvasDataStore.chatflow?.id,
-        canvasDataStore.chatflow?.canEdit,
-        canvasDataStore.chatflow?.isOwner,
-        openCredentialModal,
-        reactFlowInstance
-    ])
+    }, [canvasDataStore.chatflow, openCredentialModal, reactFlowInstance])
 
     // Handle QuickSetup URL parameter - opens modal in "manage credentials" mode
     useEffect(() => {
@@ -905,6 +896,10 @@ const AgentflowCanvas = () => {
             />
         </>
     )
+}
+
+AgentflowCanvas.propTypes = {
+    chatflowid: PropTypes.string
 }
 
 export default AgentflowCanvas


### PR DESCRIPTION
Fixes AgentFlows v2 canvas failing on navigation by properly passing chatflowid through React props instead of parsing from DOM.

  Problem

  The AgentflowCanvas component was extracting the chatflowid from document.location.pathname, which caused failures during client-side
  navigation but worked after full page refresh. This created inconsistent behavior when users navigated between different agent canvases.

  Solution

  - Route Parameters: Modified Next.js page component to accept chatflowid from route params and pass it as a prop to AgentflowCanvas
  - Props Over DOM: Removed URL parsing logic that relied on document.location.pathname
  - Cleaner Dependencies: Simplified useEffect dependency array by consolidating related canvasDataStore.chatflow properties
  - Type Safety: Added PropTypes validation for the new chatflowid prop

  Changes

  Files Modified:
  - apps/web/app/(Main UI)/(Studio Layout)/sidekick-studio/(minimal-layout)/v2/agentcanvas/[chatflowid]/page.tsx - Pass chatflowid from
  params to Canvas component
  - packages/ui/src/views/agentflowsv2/Canvas.jsx - Accept chatflowid as prop, remove URL parsing logic

  Testing

  - ✅ Navigate between different agent canvases (should load correctly without refresh)
  - ✅ Direct URL access to agent canvas (should continue working as before)
  - ✅ Verify canvas loads correct chatflow data on navigation