### PR TITLE
fix(AGENT-133): fix back button navigation for agent canvas

### DIFF
--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -328,7 +328,7 @@ const CanvasHeader = forwardRef(({ chatflow, isAgentCanvas, isAgentflowV2, handl
                                     if (window.history.state && window.history.state.idx > 0) {
                                         navigate(-1)
                                     } else {
-                                        navigate('/', { replace: true })
+                                        navigate(isAgentCanvas ? '/agentflows' : '/', { replace: true })
                                     }
                                 }}
                             >


### PR DESCRIPTION
## Summary

Fixes the agent canvas back button to correctly navigate to the agentflows list page (`/agentflows`) instead of incorrectly redirecting to the chatflows page (`/`).

**Linear Issue:** [AGENT-133](https://linear.app/answeragent/issue/AGENT-133/fix-agent-canvas-back-button-to-navigate-to-agentflows-list-instead-of)

## Problem

When viewing an agent in the canvas (`/v2/agentcanvas/[id]`), clicking the back button would incorrectly navigate to `/sidekick-studio` (chatflows list) instead of `/sidekick-studio/agentflows` (agentflows list), breaking the expected user navigation flow.

## Solution

Updated the back button click handler in `CanvasHeader.jsx` to check the `isAgentCanvas` prop and navigate to the appropriate list page:
- **Agent canvas** → `/agentflows`
- **Chatflow canvas** → `/` (unchanged)

## Changes

### Modified Files
- `packages/ui/src/views/canvas/CanvasHeader.jsx` - Updated back button fallback navigation logic (line 331)

### Code Change
```javascript
// Before
navigate('/', { replace: true })

// After
navigate(isAgentCanvas ? '/agentflows' : '/', { replace: true })
```

## Testing

### Manual Testing Checklist
- [x] Back button from `/v2/agentcanvas/[id]` navigates to `/agentflows`
- [x] Back button from `/agentcanvas/[id]` navigates to `/agentflows` 
- [x] Back button from `/canvas/[id]` still navigates to `/` (chatflows)
- [x] Browser back functionality works when history exists
- [x] No regression in other navigation patterns

### Test Steps
1. Navigate to Agentflows list page: `/sidekick-studio/agentflows`
2. Click on any agent to open it in the canvas
3. Verify URL is `/sidekick-studio/v2/agentcanvas/[id]`
4. Click the back button (left arrow icon) in canvas header
5. Verify navigation goes to `/sidekick-studio/agentflows` ✅

## Impact

- **Type:** Bug Fix (PATCH)
- **Severity:** Medium - UX issue affecting agent management workflow
- **Risk:** Low - Single line change, consistent with existing patterns in codebase
- **Breaking Changes:** None

## Related Context

This change aligns with existing patterns in the codebase:
- `packages/ui/src/views/canvas/index.jsx` (line 305) already uses `isAgentCanvas ? '/agentflows' : '/'` for delete flow navigation
- `packages/ui/src/views/agentflowsv2/Canvas.jsx` (line 200) correctly navigates to `/agentflows` on delete

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>