### PR TITLE
hotfix: remove Shai-Hulud-2 vulnerable dependencies (kill-port, posthog-node)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
         "eslint-plugin-unused-imports": "^2.0.0",
         "glob": "^11.0.3",
         "husky": "^8.0.3",
-        "kill-port": "^2.0.1",
         "knip": "^5.63.1",
         "lint-staged": "^15.5.2",
         "prettier": "^2.8.8",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -127,7 +127,6 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-oauth2": "^1.8.0",
         "pg": "^8.16.3",
-        "posthog-node": "^3.6.3",
         "prom-client": "^15.1.3",
         "rate-limit-redis": "^4.2.2",
         "reflect-metadata": "^0.1.14",

--- a/packages/server/src/utils/telemetry.ts
+++ b/packages/server/src/utils/telemetry.ts
@@ -1,18 +1,12 @@
 import { v4 as uuidv4 } from 'uuid'
-import { PostHog } from 'posthog-node'
 import path from 'path'
 import fs from 'fs'
 import { getUserHome, getUserSettingsFilePath } from '.'
 
 export class Telemetry {
-    postHog?: PostHog
-
     constructor() {
-        if (process.env.POSTHOG_PUBLIC_API_KEY) {
-            this.postHog = new PostHog(process.env.POSTHOG_PUBLIC_API_KEY)
-        } else {
-            this.postHog = undefined
-        }
+        // PostHog removed due to Shai-Hulud-2 security vulnerability
+        // Telemetry functionality disabled
     }
 
     async id(): Promise<string> {
@@ -34,19 +28,12 @@ export class Telemetry {
     }
 
     async sendTelemetry(event: string, properties = {}): Promise<void> {
-        if (this.postHog) {
-            const distinctId = await this.id()
-            this.postHog.capture({
-                event,
-                distinctId,
-                properties
-            })
-        }
+        // Telemetry disabled - PostHog removed due to Shai-Hulud-2 security vulnerability
+        // No-op implementation to maintain API compatibility
     }
 
     async flush(): Promise<void> {
-        if (this.postHog) {
-            await this.postHog.shutdownAsync()
-        }
+        // Telemetry disabled - PostHog removed due to Shai-Hulud-2 security vulnerability
+        // No-op implementation to maintain API compatibility
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,9 +122,6 @@ importers:
             husky:
                 specifier: ^8.0.3
                 version: 8.0.3
-            kill-port:
-                specifier: ^2.0.1
-                version: 2.0.1
             knip:
                 specifier: ^5.63.1
                 version: 5.63.1(@types/node@24.9.1)(typescript@5.5.4)
@@ -160,7 +157,7 @@ importers:
                 version: 2.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
             '@auth0/nextjs-auth0':
                 specifier: 3.5.0
-                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
+                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
             '@aws-sdk/client-s3':
                 specifier: ^3.887.0
                 version: 3.887.0(aws-crt@1.27.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
@@ -256,7 +253,7 @@ importers:
                 version: 14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1)
             next-auth:
                 specifier: ^4.24.11
-                version: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+                version: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
             openai:
                 specifier: 4.96.0
                 version: 4.96.0(encoding@0.1.13)(ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
@@ -326,7 +323,7 @@ importers:
                 version: 9.0.8
             copy-webpack-plugin:
                 specifier: ^11.0.0
-                version: 11.0.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
+                version: 11.0.0(webpack@5.101.3)
             dotenv:
                 specifier: ^17.2.2
                 version: 17.2.2
@@ -338,13 +335,13 @@ importers:
                 version: link:../../packages-answers/eslint-config-custom
             file-loader:
                 specifier: ^6.2.0
-                version: 6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
+                version: 6.2.0(webpack@5.101.3)
             terser-webpack-plugin:
                 specifier: ^5.3.14
-                version: 5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
+                version: 5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3)
             ts-loader:
                 specifier: ^9.5.4
-                version: 9.5.4(typescript@5.5.4)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
+                version: 9.5.4(typescript@5.5.4)(webpack@5.101.3)
             tsconfig:
                 specifier: workspace:*
                 version: link:../../packages-answers/tsconfig
@@ -356,7 +353,7 @@ importers:
                 version: 5.5.4
             url-loader:
                 specifier: ^4.1.1
-                version: 4.1.1(file-loader@6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
+                version: 4.1.1(file-loader@6.2.0(webpack@5.101.3))(webpack@5.101.3)
             webpack:
                 specifier: ^5.101.3
                 version: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
@@ -465,7 +462,7 @@ importers:
                 version: 2.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
             '@auth0/nextjs-auth0':
                 specifier: 3.5.0
-                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
+                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
             '@emotion/cache':
                 specifier: ^11.14.0
                 version: 11.14.0
@@ -546,7 +543,7 @@ importers:
                 version: 14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1)
             next-auth:
                 specifier: ^4.24.11
-                version: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+                version: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
             react:
                 specifier: 18.2.0
                 version: 18.2.0
@@ -637,7 +634,7 @@ importers:
                 version: 4.25.2
             '@auth0/nextjs-auth0':
                 specifier: 3.5.0
-                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
+                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
             '@aws-sdk/client-s3':
                 specifier: ^3.887.0
                 version: 3.887.0(aws-crt@1.27.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
@@ -736,7 +733,7 @@ importers:
                 version: 6.12.0(@aws-sdk/credential-providers@3.887.0(aws-crt@1.27.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)))(socks@2.8.7)
             next-auth:
                 specifier: ^4.24.11
-                version: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+                version: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
             node-fetch:
                 specifier: ^3.3.2
                 version: 3.3.2
@@ -1820,9 +1817,6 @@ importers:
             pg:
                 specifier: ^8.16.3
                 version: 8.16.3
-            posthog-node:
-                specifier: ^3.6.3
-                version: 3.6.3
             prom-client:
                 specifier: ^15.1.3
                 version: 15.1.3
@@ -1985,7 +1979,7 @@ importers:
                 version: 2.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
             '@auth0/nextjs-auth0':
                 specifier: 3.5.0
-                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
+                version: 3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))
             '@codemirror/lang-javascript':
                 specifier: ^6.2.4
                 version: 6.2.4
@@ -8918,7 +8912,7 @@ packages:
     '@types/react-dom@18.3.7':
         resolution: { integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ== }
         peerDependencies:
-            '@types/react': ^18.2.0
+            '@types/react': ^18.0.0
 
     '@types/react-redux@7.1.34':
         resolution: { integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ== }
@@ -13176,9 +13170,6 @@ packages:
         resolution: { integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg== }
         engines: { node: '>= 0.4' }
 
-    get-them-args@1.3.2:
-        resolution: { integrity: sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw== }
-
     get-tsconfig@4.10.1:
         resolution: { integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ== }
 
@@ -14793,10 +14784,6 @@ packages:
 
     khroma@2.1.0:
         resolution: { integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw== }
-
-    kill-port@2.0.1:
-        resolution: { integrity: sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ== }
-        hasBin: true
 
     kind-of@5.1.0:
         resolution: { integrity: sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw== }
@@ -18111,10 +18098,6 @@ packages:
         resolution: { integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ== }
         engines: { node: '>=0.10.0' }
 
-    posthog-node@3.6.3:
-        resolution: { integrity: sha512-JB+ei0LkwE+rKHyW5z79Nd1jUaGxU6TvkfjFqY9vQaHxU5aU8dRl0UUaEmZdZbHwjp3WmXCBQQRNyimwbNQfCw== }
-        engines: { node: '>=15.0.0' }
-
     postman-code-generators@1.14.2:
         resolution: { integrity: sha512-qZAyyowfQAFE4MSCu2KtMGGQE/+oG1JhMZMJNMdZHYCSfQiVVeKxgk3oI4+KJ3d1y5rrm2D6C6x+Z+7iyqm+fA== }
         engines: { node: '>=12' }
@@ -19231,9 +19214,6 @@ packages:
     runtypes@5.1.0:
         resolution: { integrity: sha512-OMHkz6dxysXj4E8Fj/HCGjtdJUhapQUN7puvqzuzvjaX28pd52PZmEMqQlkIzCfKdhXdM0ghx8PpvELprEnOLQ== }
 
-    rusha@0.8.14:
-        resolution: { integrity: sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA== }
-
     rw@1.3.3:
         resolution: { integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ== }
 
@@ -19477,9 +19457,6 @@ packages:
     shebang-regex@3.0.0:
         resolution: { integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A== }
         engines: { node: '>=8' }
-
-    shell-exec@1.0.2:
-        resolution: { integrity: sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg== }
 
     shell-quote@1.8.3:
         resolution: { integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw== }
@@ -22383,7 +22360,7 @@ snapshots:
             dpop: 2.1.1
             es-cookie: 1.3.2
 
-    '@auth0/nextjs-auth0@3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))':
+    '@auth0/nextjs-auth0@3.5.0(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))':
         dependencies:
             '@panva/hkdf': 1.2.1
             cookie: 1.0.2
@@ -28528,7 +28505,7 @@ snapshots:
     '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
         dependencies:
             '@prisma/client': 5.22.0(prisma@5.22.0)
-            next-auth: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+            next-auth: 4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
     '@next/bundle-analyzer@13.5.11(bufferutil@4.0.9)(utf-8-validate@6.0.5)':
         dependencies:
@@ -32518,17 +32495,17 @@ snapshots:
             '@webassemblyjs/ast': 1.14.1
             '@xtuc/long': 4.2.2
 
-    '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))':
+    '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.101.3)':
         dependencies:
             webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
             webpack-cli: 5.1.4(webpack@5.101.3)
 
-    '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))':
+    '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.101.3)':
         dependencies:
             webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
             webpack-cli: 5.1.4(webpack@5.101.3)
 
-    '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))':
+    '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.101.3)':
         dependencies:
             webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
             webpack-cli: 5.1.4(webpack@5.101.3)
@@ -34407,16 +34384,6 @@ snapshots:
         dependencies:
             toggle-selection: 1.0.6
 
-    copy-webpack-plugin@11.0.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)):
-        dependencies:
-            fast-glob: 3.3.3
-            glob-parent: 6.0.2
-            globby: 13.2.2
-            normalize-path: 3.0.0
-            schema-utils: 4.3.2
-            serialize-javascript: 6.0.2
-            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
-
     copy-webpack-plugin@11.0.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))):
         dependencies:
             fast-glob: 3.3.3
@@ -34426,6 +34393,16 @@ snapshots:
             schema-utils: 4.3.2
             serialize-javascript: 6.0.2
             webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+    copy-webpack-plugin@11.0.0(webpack@5.101.3):
+        dependencies:
+            fast-glob: 3.3.3
+            glob-parent: 6.0.2
+            globby: 13.2.2
+            normalize-path: 3.0.0
+            schema-utils: 4.3.2
+            serialize-javascript: 6.0.2
+            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
 
     core-js-compat@3.45.1:
         dependencies:
@@ -35972,8 +35949,8 @@ snapshots:
             '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
             eslint: 7.32.0
             eslint-import-resolver-node: 0.3.9
-            eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@7.32.0)
-            eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@7.32.0)
+            eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0)
+            eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0))(eslint@7.32.0)
             eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
             eslint-plugin-react: 7.37.5(eslint@7.32.0)
             eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -36056,7 +36033,7 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@7.32.0):
+    eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0):
         dependencies:
             '@nolyfill/is-core-module': 1.0.39
             debug: 4.4.1(supports-color@8.1.1)
@@ -36067,7 +36044,7 @@ snapshots:
             tinyglobby: 0.2.15
             unrs-resolver: 1.11.1
         optionalDependencies:
-            eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@7.32.0)
+            eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0))(eslint@7.32.0)
         transitivePeerDependencies:
             - supports-color
 
@@ -36086,18 +36063,18 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@7.32.0))(eslint@7.32.0):
+    eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0))(eslint@7.32.0):
         dependencies:
             debug: 3.2.7(supports-color@5.5.0)
         optionalDependencies:
             '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
             eslint: 7.32.0
             eslint-import-resolver-node: 0.3.9
-            eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@7.32.0)
+            eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0)
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+    eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
         dependencies:
             debug: 3.2.7(supports-color@5.5.0)
         optionalDependencies:
@@ -36126,7 +36103,7 @@ snapshots:
             lodash: 4.17.21
             string-natural-compare: 3.0.1
 
-    eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@7.32.0):
+    eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0))(eslint@7.32.0):
         dependencies:
             '@rtsao/scc': 1.1.0
             array-includes: 3.1.9
@@ -36137,7 +36114,7 @@ snapshots:
             doctrine: 2.1.0
             eslint: 7.32.0
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@7.32.0))(eslint@7.32.0)
+            eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0))(eslint@7.32.0))(eslint@7.32.0)
             hasown: 2.0.2
             is-core-module: 2.16.1
             is-glob: 4.0.3
@@ -36166,7 +36143,7 @@ snapshots:
             doctrine: 2.1.0
             eslint: 8.57.1
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+            eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
             hasown: 2.0.2
             is-core-module: 2.16.1
             is-glob: 4.0.3
@@ -36996,17 +36973,17 @@ snapshots:
         dependencies:
             flat-cache: 3.2.0
 
-    file-loader@6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)):
-        dependencies:
-            loader-utils: 2.0.4
-            schema-utils: 3.3.0
-            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
-
     file-loader@6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))):
         dependencies:
             loader-utils: 2.0.4
             schema-utils: 3.3.0
             webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+    file-loader@6.2.0(webpack@5.101.3):
+        dependencies:
+            loader-utils: 2.0.4
+            schema-utils: 3.3.0
+            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
 
     file-saver@2.0.5: {}
 
@@ -37454,8 +37431,6 @@ snapshots:
             call-bound: 1.0.4
             es-errors: 1.3.0
             get-intrinsic: 1.3.0
-
-    get-them-args@1.3.2: {}
 
     get-tsconfig@4.10.1:
         dependencies:
@@ -39764,11 +39739,6 @@ snapshots:
 
     khroma@2.1.0: {}
 
-    kill-port@2.0.1:
-        dependencies:
-            get-them-args: 1.3.2
-            shell-exec: 1.0.2
-
     kind-of@5.1.0: {}
 
     kind-of@6.0.3: {}
@@ -42006,7 +41976,7 @@ snapshots:
 
     netmask@2.0.2: {}
 
-    next-auth@4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    next-auth@4.24.11(next@14.2.32(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.92.1))(nodemailer@6.9.16)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
         dependencies:
             '@babel/runtime': 7.28.4
             '@panva/hkdf': 1.2.1
@@ -43780,13 +43750,6 @@ snapshots:
         dependencies:
             xtend: 4.0.2
 
-    posthog-node@3.6.3:
-        dependencies:
-            axios: 1.12.1
-            rusha: 0.8.14
-        transitivePeerDependencies:
-            - debug
-
     postman-code-generators@1.14.2:
         dependencies:
             async: 3.2.2
@@ -45326,8 +45289,6 @@ snapshots:
 
     runtypes@5.1.0: {}
 
-    rusha@0.8.14: {}
-
     rw@1.3.3: {}
 
     rxjs@7.8.2:
@@ -45633,8 +45594,6 @@ snapshots:
             shebang-regex: 3.0.0
 
     shebang-regex@3.0.0: {}
-
-    shell-exec@1.0.2: {}
 
     shell-quote@1.8.3: {}
 
@@ -46605,17 +46564,6 @@ snapshots:
             type-fest: 0.16.0
             unique-string: 2.0.0
 
-    terser-webpack-plugin@5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)):
-        dependencies:
-            '@jridgewell/trace-mapping': 0.3.31
-            jest-worker: 27.5.1
-            schema-utils: 4.3.2
-            serialize-javascript: 6.0.2
-            terser: 5.44.0
-            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
-        optionalDependencies:
-            '@swc/core': 1.13.5(@swc/helpers@0.5.17)
-
     terser-webpack-plugin@5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))):
         dependencies:
             '@jridgewell/trace-mapping': 0.3.31
@@ -46624,6 +46572,17 @@ snapshots:
             serialize-javascript: 6.0.2
             terser: 5.44.0
             webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))
+        optionalDependencies:
+            '@swc/core': 1.13.5(@swc/helpers@0.5.17)
+
+    terser-webpack-plugin@5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3):
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.31
+            jest-worker: 27.5.1
+            schema-utils: 4.3.2
+            serialize-javascript: 6.0.2
+            terser: 5.44.0
+            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
         optionalDependencies:
             '@swc/core': 1.13.5(@swc/helpers@0.5.17)
 
@@ -46870,7 +46829,7 @@ snapshots:
             babel-jest: 29.7.0(@babel/core@7.28.4)
             jest-util: 30.0.5
 
-    ts-loader@9.5.4(typescript@5.5.4)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)):
+    ts-loader@9.5.4(typescript@5.5.4)(webpack@5.101.3):
         dependencies:
             chalk: 4.1.2
             enhanced-resolve: 5.18.3
@@ -47577,15 +47536,6 @@ snapshots:
 
     url-join@4.0.1: {}
 
-    url-loader@4.1.1(file-loader@6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)):
-        dependencies:
-            loader-utils: 2.0.4
-            mime-types: 2.1.35
-            schema-utils: 3.3.0
-            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
-        optionalDependencies:
-            file-loader: 6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
-
     url-loader@4.1.1(file-loader@6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))):
         dependencies:
             loader-utils: 2.0.4
@@ -47594,6 +47544,15 @@ snapshots:
             webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))
         optionalDependencies:
             file-loader: 6.2.0(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
+
+    url-loader@4.1.1(file-loader@6.2.0(webpack@5.101.3))(webpack@5.101.3):
+        dependencies:
+            loader-utils: 2.0.4
+            mime-types: 2.1.35
+            schema-utils: 3.3.0
+            webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
+        optionalDependencies:
+            file-loader: 6.2.0(webpack@5.101.3)
 
     url-template@2.0.8: {}
 
@@ -48011,9 +47970,9 @@ snapshots:
     webpack-cli@5.1.4(webpack@5.101.3):
         dependencies:
             '@discoveryjs/json-ext': 0.5.7
-            '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
-            '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
-            '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
+            '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.101.3)
+            '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.101.3)
+            '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.101.3)
             colorette: 2.0.20
             commander: 10.0.1
             cross-spawn: 7.0.6
@@ -48179,7 +48138,7 @@ snapshots:
             neo-async: 2.6.2
             schema-utils: 4.3.2
             tapable: 2.2.3
-            terser-webpack-plugin: 5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@5.1.4))
+            terser-webpack-plugin: 5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3)
             watchpack: 2.4.4
             webpack-sources: 3.3.3
         optionalDependencies:


### PR DESCRIPTION
## Title
hotfix: remove Shai-Hulud-2 vulnerable dependencies (kill-port, posthog-node)

## Description

### Motivation & Scope
This change is a focused hotfix to address the Shai-Hulud-2 security vulnerability by removing the affected dependencies and disabling the associated telemetry functionality.

Scope is limited to:
- Removing vulnerable dependencies (`kill-port`, `posthog-node`) and their transitive deps from the dependency tree.
- Converting the telemetry implementation to a no-op while preserving its public API.

### Changes

- **Root `package.json`**
  - Removed dev dependency:
    - `"kill-port": "^2.0.1"`.

- **`packages/server/package.json`**
  - Removed dependency:
    - `"posthog-node": "^3.6.3"`.

- **`packages/server/src/utils/telemetry.ts`**
  - Removed `PostHog` import from `posthog-node`.
  - Removed `Telemetry.postHog` client field and initialization logic that depended on `POSTHOG_PUBLIC_API_KEY`.
  - Updated `Telemetry` constructor to document that PostHog has been removed due to the Shai-Hulud-2 security vulnerability and telemetry is now disabled.
  - Updated `sendTelemetry` and `flush` to be explicit no-op implementations with comments explaining that telemetry is disabled but the API is preserved.

- **`pnpm-lock.yaml`**
  - Lockfile updated to:
    - Remove `kill-port`, `posthog-node`, and their transitive dependencies (`get-them-args`, `shell-exec`, `rusha`, etc.).
    - Normalize a few dependency graph annotations (e.g., `@auth0/nextjs-auth0`, `next-auth`, webpack-related plugins, eslint-related packages) as a result of the lockfile regeneration without the removed packages.

### Impact

- **Functional Behavior**
  - Telemetry collection via PostHog is completely disabled.
  - Calls to `Telemetry.id()`, `Telemetry.sendTelemetry()`, and `Telemetry.flush()` still exist and remain callable, but `sendTelemetry` and `flush` are now no-ops.
  - No user-facing API or behavior should change outside of the absence of analytics/telemetry events.

- **Security**
  - Removes dependencies explicitly tied to the Shai-Hulud-2 vulnerability:
    - `kill-port`
    - `posthog-node`
  - Also drops their transitive dependencies from the install surface, reducing potential security exposure.

- **Dependencies / Build**
  - Dependency graph is simplified with the removal of `kill-port` and `posthog-node`.
  - No new dependencies are introduced.
  - Lockfile updates are consistent with the package.json removals and underlying resolver behavior.

### Breaking Changes / Migrations

- No breaking API or schema changes are apparent from the diff.
- Telemetry data will stop being recorded and sent, which may be a behavioral change for any downstream analytics or monitoring relying on PostHog events.
- Environment variable `POSTHOG_PUBLIC_API_KEY` is no longer used by the server code.

### Testing Notes

- No tests were added or modified in this diff.
- Recommended follow-up:
  - Ensure existing code paths that call `Telemetry` methods continue to function without relying on side effects.
  - Optionally, add unit tests asserting that `Telemetry.sendTelemetry` and `Telemetry.flush` are safe no-ops (do not throw, do not require any configuration).

