### PR TITLE
feat(AGENT-468): Improve error pages with glassmorphism and Report Issue button

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -276,3 +276,18 @@ DATA_ENGINE_AUTH_ALLOW_FALLBACK=true
 # API Key for test script (generated from TheAnswer API keys)
 # DATA_ENGINE_API_KEY=your-api-key-here
 
+# ==================================================
+# ERROR REPORTING (Linear Integration)
+# ==================================================
+# Linear API key for error reporting feature
+# When configured, enables "Report Issue" button on error pages
+LINEAR_API_KEY=
+
+# Linear team ID where error reports will be created
+# Find at: Linear → Settings → Teams → [Your Team] → Copy ID from URL
+LINEAR_ERROR_REPORT_TEAM_ID=
+
+# Linear label ID for bug reports (optional)
+# Find at: Linear → Settings → Labels → [Bug Label] → Copy ID
+LINEAR_ERROR_REPORT_BUG_LABEL_ID=
+

--- a/apps/web/app/api/report-issue/route.ts
+++ b/apps/web/app/api/report-issue/route.ts
@@ -137,6 +137,10 @@ export async function POST(request: NextRequest) {
             return NextResponse.json({ error: 'Invalid URL' }, { status: 400 })
         }
 
+        if (body.userAgent && (typeof body.userAgent !== 'string' || body.userAgent.length > 1000)) {
+            return NextResponse.json({ error: 'Invalid user agent' }, { status: 400 })
+        }
+
         // 5. Sanitize error content for title
         const sanitizedMessage = sanitizeErrorContent(body.errorMessage).substring(0, 100)
 
@@ -156,8 +160,8 @@ export async function POST(request: NextRequest) {
             '## Context',
             '',
             `**Reported by:** ${user.email}`,
-            user.organizationName ? `**Organization:** ${user.organizationName}` : null,
-            user.organizationId ? `**Organization ID:** \`${user.organizationId}\`` : null,
+            user.org_name ? `**Organization:** ${user.org_name}` : null,
+            user.org_id ? `**Organization ID:** \`${user.org_id}\`` : null,
             `**Timestamp:** ${body.timestamp}`,
             body.url ? `**URL:** ${body.url}` : null,
             body.userAgent ? `**User Agent:** ${body.userAgent}` : null,

--- a/apps/web/app/api/report-issue/route.ts
+++ b/apps/web/app/api/report-issue/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Redis } from 'ioredis'
+import getCachedSession from '@ui/getCachedSession'
+
+interface ReportIssueRequest {
+    errorMessage: string
+    errorDigest?: string
+    errorStack?: string
+    url?: string
+    userAgent?: string
+    timestamp: string
+}
+
+// Lazy Redis client - follows packages/server pattern
+let redisClient: Redis | null = null
+function getRedisClient(): Redis | null {
+    if (!process.env.REDIS_URL) return null
+    if (!redisClient) {
+        redisClient = new Redis(process.env.REDIS_URL)
+    }
+    return redisClient
+}
+
+const RATE_LIMIT_WINDOW_SECONDS = 60
+const RATE_LIMIT_MAX_REQUESTS = 5
+
+async function checkRateLimit(identifier: string): Promise<{ allowed: boolean; retryAfter?: number }> {
+    const redis = getRedisClient()
+
+    // If Redis not configured, allow request (fail open)
+    if (!redis) {
+        return { allowed: true }
+    }
+
+    const key = `rl:report-issue:${identifier}` // follows rl:{id} pattern from packages/server
+
+    try {
+        // Atomic increment - prevents race condition
+        const count = await redis.incr(key)
+
+        if (count === 1) {
+            await redis.expire(key, RATE_LIMIT_WINDOW_SECONDS)
+        }
+
+        if (count > RATE_LIMIT_MAX_REQUESTS) {
+            const ttl = await redis.ttl(key)
+            return { allowed: false, retryAfter: Math.max(ttl, 1) }
+        }
+
+        return { allowed: true }
+    } catch (error) {
+        console.error('Rate limit check failed:', error)
+        return { allowed: true } // fail open
+    }
+}
+
+/**
+ * Sanitize sensitive data from error messages and stack traces
+ */
+function sanitizeErrorContent(content: string): string {
+    return (
+        content
+            // Auth tokens and API keys
+            .replace(/Bearer\s+[^\s]+/gi, '[REDACTED]')
+            .replace(/password[=:]\s*[^\s&]+/gi, 'password=[REDACTED]')
+            .replace(/api[_-]?key[=:]\s*[^\s&]+/gi, 'api_key=[REDACTED]')
+            .replace(/secret[=:]\s*[^\s&]+/gi, 'secret=[REDACTED]')
+            .replace(/token[=:]\s*[^\s&]+/gi, 'token=[REDACTED]')
+            // AWS credentials
+            .replace(/AKIA[A-Z0-9]{16}/g, '[AWS_KEY_REDACTED]')
+            .replace(/AWS[A-Z0-9]{16,}/gi, '[AWS_REDACTED]')
+            // Database connection strings
+            .replace(/postgres(ql)?:\/\/[^\s]+/gi, '[DATABASE_URL_REDACTED]')
+            .replace(/mysql:\/\/[^\s]+/gi, '[DATABASE_URL_REDACTED]')
+            .replace(/mongodb(\+srv)?:\/\/[^\s]+/gi, '[DATABASE_URL_REDACTED]')
+            .replace(/redis:\/\/[^\s]+/gi, '[REDIS_URL_REDACTED]')
+            // Email addresses (fully redacted for privacy)
+            .replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[EMAIL_REDACTED]')
+            // IP addresses
+            .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[IP_REDACTED]')
+            // Session tokens (common patterns)
+            .replace(/sess[ion]*[=:_][^\s&;]+/gi, 'session=[REDACTED]')
+            // JWT tokens
+            .replace(/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '[JWT_REDACTED]')
+    )
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        // 1. Authentication check - reject unauthenticated requests
+        const session = await getCachedSession()
+        const user = session?.user
+
+        if (!user?.email) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        // 2. Rate limiting - prevent spam
+        const rateLimitResult = await checkRateLimit(user.email)
+        if (!rateLimitResult.allowed) {
+            return NextResponse.json(
+                { error: 'Too many requests. Please try again later.' },
+                {
+                    status: 429,
+                    headers: { 'Retry-After': String(rateLimitResult.retryAfter) }
+                }
+            )
+        }
+
+        // 3. Parse and validate request body
+        let body: ReportIssueRequest
+        try {
+            body = await request.json()
+        } catch {
+            return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+        }
+
+        // 4. Validate required fields with type and format checks
+        if (!body.errorMessage || typeof body.errorMessage !== 'string') {
+            return NextResponse.json({ error: 'Invalid or missing error message' }, { status: 400 })
+        }
+
+        if (body.errorMessage.length > 5000) {
+            return NextResponse.json({ error: 'Error message too long (max 5000 characters)' }, { status: 400 })
+        }
+
+        if (!body.timestamp || typeof body.timestamp !== 'string' || isNaN(Date.parse(body.timestamp))) {
+            return NextResponse.json({ error: 'Invalid or missing timestamp' }, { status: 400 })
+        }
+
+        // Optional field validation
+        if (body.errorStack && (typeof body.errorStack !== 'string' || body.errorStack.length > 10000)) {
+            return NextResponse.json({ error: 'Invalid error stack' }, { status: 400 })
+        }
+
+        if (body.url && (typeof body.url !== 'string' || body.url.length > 2000)) {
+            return NextResponse.json({ error: 'Invalid URL' }, { status: 400 })
+        }
+
+        // 5. Sanitize error content for title
+        const sanitizedMessage = sanitizeErrorContent(body.errorMessage).substring(0, 100)
+
+        const title = `[Error Report] ${sanitizedMessage}`
+
+        // Sanitize the full error message and stack for the description
+        const sanitizedFullMessage = sanitizeErrorContent(body.errorMessage)
+        const sanitizedStack = body.errorStack ? sanitizeErrorContent(body.errorStack).substring(0, 3000) : null
+
+        // Build description with context
+        const descriptionParts = [
+            '## Error Details',
+            '',
+            `**Message:** ${sanitizedFullMessage}`,
+            body.errorDigest ? `**Digest:** \`${body.errorDigest}\`` : null,
+            '',
+            '## Context',
+            '',
+            `**Reported by:** ${user.email}`,
+            user.organizationName ? `**Organization:** ${user.organizationName}` : null,
+            user.organizationId ? `**Organization ID:** \`${user.organizationId}\`` : null,
+            `**Timestamp:** ${body.timestamp}`,
+            body.url ? `**URL:** ${body.url}` : null,
+            body.userAgent ? `**User Agent:** ${body.userAgent}` : null,
+            '',
+            sanitizedStack ? '## Stack Trace' : null,
+            sanitizedStack ? '' : null,
+            sanitizedStack ? '```' : null,
+            sanitizedStack,
+            sanitizedStack ? '```' : null,
+            '',
+            '---',
+            '*This issue was automatically created via the error reporting feature.*'
+        ]
+
+        const description = descriptionParts.filter(Boolean).join('\n')
+
+        // Create Linear issue using the Linear API directly
+        const linearApiKey = process.env.LINEAR_API_KEY
+        if (!linearApiKey) {
+            console.error('LINEAR_API_KEY not configured')
+            return NextResponse.json({ error: 'Issue reporting is not configured' }, { status: 503 })
+        }
+
+        // Team and label IDs from environment variables with fallbacks
+        const teamId = process.env.LINEAR_ERROR_REPORT_TEAM_ID
+        const bugLabelId = process.env.LINEAR_ERROR_REPORT_BUG_LABEL_ID
+
+        const linearResponse = await fetch('https://api.linear.app/graphql', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: linearApiKey
+            },
+            body: JSON.stringify({
+                query: `
+                    mutation CreateIssue($input: IssueCreateInput!) {
+                        issueCreate(input: $input) {
+                            success
+                            issue {
+                                id
+                                identifier
+                                url
+                            }
+                        }
+                    }
+                `,
+                variables: {
+                    input: {
+                        title,
+                        description,
+                        teamId,
+                        labelIds: [bugLabelId],
+                        priority: 3 // Normal priority
+                    }
+                }
+            })
+        })
+
+        if (!linearResponse.ok) {
+            console.error('Linear API error:', await linearResponse.text())
+            return NextResponse.json({ error: 'Failed to create issue' }, { status: 500 })
+        }
+
+        const linearData = await linearResponse.json()
+
+        if (linearData.errors) {
+            console.error('Linear GraphQL errors:', linearData.errors)
+            return NextResponse.json({ error: 'Failed to create issue' }, { status: 500 })
+        }
+
+        const issue = linearData.data?.issueCreate?.issue
+
+        if (!issue) {
+            return NextResponse.json({ error: 'Failed to create issue' }, { status: 500 })
+        }
+
+        return NextResponse.json({
+            success: true,
+            issueId: issue.identifier,
+            issueUrl: issue.url
+        })
+    } catch (error) {
+        console.error('Error reporting issue:', error)
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    }
+}

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -30,6 +30,7 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
 
     const glass = glassmorphismTokens[mode]
     const colors = colorTokens[mode]
+    const reportingEnabled = !!process.env.NEXT_PUBLIC_ERROR_REPORTING_ENABLED
 
     const handleReportIssue = async () => {
         setReportState('loading')
@@ -160,31 +161,33 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
                         Try again
                     </Button>
 
-                    <Button
-                        onClick={handleReportIssue}
-                        variant='outlined'
-                        disabled={reportState === 'loading' || reportState === 'success'}
-                        startIcon={reportState === 'loading' ? <CircularProgress size={18} color='inherit' /> : <ReportProblemIcon />}
-                        sx={{
-                            ...glass.glassSubtle,
-                            color: colors.text.secondary,
-                            fontWeight: 500,
-                            textTransform: 'none',
-                            px: 3,
-                            py: 1.25,
-                            borderRadius: 2,
-                            '&:hover': {
-                                ...glass.glassHover,
-                                borderColor: colors.divider
-                            },
-                            '&:disabled': {
-                                opacity: 0.5,
-                                color: colors.text.disabled
-                            }
-                        }}
-                    >
-                        {reportState === 'loading' ? 'Reporting...' : reportState === 'success' ? 'Reported' : 'Report Issue'}
-                    </Button>
+                    {reportingEnabled && (
+                        <Button
+                            onClick={handleReportIssue}
+                            variant='outlined'
+                            disabled={reportState === 'loading' || reportState === 'success'}
+                            startIcon={reportState === 'loading' ? <CircularProgress size={18} color='inherit' /> : <ReportProblemIcon />}
+                            sx={{
+                                ...glass.glassSubtle,
+                                color: colors.text.secondary,
+                                fontWeight: 500,
+                                textTransform: 'none',
+                                px: 3,
+                                py: 1.25,
+                                borderRadius: 2,
+                                '&:hover': {
+                                    ...glass.glassHover,
+                                    borderColor: colors.divider
+                                },
+                                '&:disabled': {
+                                    opacity: 0.5,
+                                    color: colors.text.disabled
+                                }
+                            }}
+                        >
+                            {reportState === 'loading' ? 'Reporting...' : reportState === 'success' ? 'Reported' : 'Report Issue'}
+                        </Button>
+                    )}
                 </Box>
 
                 {reportState === 'success' && (

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,40 +1,227 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Typography from '@mui/material/Typography'
+import Alert from '@mui/material/Alert'
+import CircularProgress from '@mui/material/CircularProgress'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import ReportProblemIcon from '@mui/icons-material/ReportProblem'
+import { glassmorphismTokens } from '@ui/theme/tokens/glassmorphism'
+import { colorTokens, statusColors } from '@ui/theme/tokens/colors'
+
+type ReportState = 'idle' | 'loading' | 'success' | 'error'
+type ThemeMode = 'light' | 'dark'
 
 export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+    const [reportState, setReportState] = useState<ReportState>('idle')
+    const [reportMessage, setReportMessage] = useState('')
+    const [reportUrl, setReportUrl] = useState('')
+    const [mode, setMode] = useState<ThemeMode>('dark')
+
     useEffect(() => {
         console.error('Error boundary caught:', error)
+        // Read theme from localStorage (source of truth for the app)
+        const storedDarkMode = localStorage.getItem('isDarkMode')
+        setMode(storedDarkMode === 'false' ? 'light' : 'dark')
     }, [error])
 
+    const glass = glassmorphismTokens[mode]
+    const colors = colorTokens[mode]
+
+    const handleReportIssue = async () => {
+        setReportState('loading')
+        setReportMessage('')
+
+        try {
+            const response = await fetch('/api/report-issue', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    errorMessage: error.message || 'Unknown error',
+                    errorDigest: error.digest,
+                    errorStack: error.stack?.substring(0, 5000),
+                    url: typeof window !== 'undefined' ? window.location.href : undefined,
+                    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+                    timestamp: new Date().toISOString()
+                })
+            })
+
+            const data = await response.json()
+
+            if (response.ok && data.success) {
+                setReportState('success')
+                setReportMessage(data.issueId)
+                setReportUrl(data.issueUrl)
+            } else {
+                setReportState('error')
+                setReportMessage(data.error || 'Failed to report issue')
+            }
+        } catch {
+            setReportState('error')
+            setReportMessage('Failed to report issue. Please try again.')
+        }
+    }
+
     return (
-        <div
-            style={{
+        <Box
+            sx={{
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
                 justifyContent: 'center',
-                minHeight: '100vh',
-                padding: '20px',
-                textAlign: 'center'
+                padding: 3,
+                background: colors.background.default,
+                zIndex: 9999
             }}
         >
-            <h2 style={{ fontSize: '24px', marginBottom: '16px' }}>Something went wrong!</h2>
-            <p style={{ marginBottom: '24px', color: '#666' }}>{error.message || 'An unexpected error occurred'}</p>
-            <button
-                onClick={reset}
-                style={{
-                    padding: '12px 24px',
-                    backgroundColor: '#0070f3',
-                    color: 'white',
-                    border: 'none',
-                    borderRadius: '6px',
-                    cursor: 'pointer',
-                    fontSize: '16px'
+            <Box
+                sx={{
+                    background: glass.glassSecondary.background,
+                    backdropFilter: glass.glassSecondary.backdropFilter,
+                    WebkitBackdropFilter: glass.glassSecondary.WebkitBackdropFilter,
+                    border: glass.glassSecondary.border,
+                    boxShadow: glass.glassSecondary.boxShadow,
+                    transition: glass.transition,
+                    padding: 4,
+                    borderRadius: 3,
+                    maxWidth: 480,
+                    width: '100%',
+                    textAlign: 'center'
                 }}
             >
-                Try again
-            </button>
-        </div>
+                <ErrorOutlineIcon
+                    sx={{
+                        fontSize: 72,
+                        color: statusColors.error.main,
+                        mb: 2
+                    }}
+                />
+
+                <Typography
+                    variant='h5'
+                    component='h2'
+                    sx={{
+                        fontWeight: 600,
+                        mb: 2,
+                        color: colors.text.primary
+                    }}
+                >
+                    Something went wrong!
+                </Typography>
+
+                <Typography
+                    sx={{
+                        mb: 3,
+                        color: colors.text.secondary,
+                        wordBreak: 'break-word',
+                        fontSize: '0.95rem',
+                        lineHeight: 1.6
+                    }}
+                >
+                    {error.message || 'An unexpected error occurred'}
+                </Typography>
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: { xs: 'column', sm: 'row' },
+                        gap: 2,
+                        justifyContent: 'center',
+                        mb: reportState !== 'idle' ? 3 : 0
+                    }}
+                >
+                    <Button
+                        onClick={reset}
+                        variant='contained'
+                        startIcon={<RefreshIcon />}
+                        sx={{
+                            background: 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)',
+                            color: 'white',
+                            fontWeight: 500,
+                            textTransform: 'none',
+                            px: 3,
+                            py: 1.25,
+                            borderRadius: 2,
+                            boxShadow: '0 4px 14px rgba(59, 130, 246, 0.4)',
+                            '&:hover': {
+                                background: 'linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%)',
+                                boxShadow: '0 6px 20px rgba(59, 130, 246, 0.5)'
+                            }
+                        }}
+                    >
+                        Try again
+                    </Button>
+
+                    <Button
+                        onClick={handleReportIssue}
+                        variant='outlined'
+                        disabled={reportState === 'loading' || reportState === 'success'}
+                        startIcon={reportState === 'loading' ? <CircularProgress size={18} color='inherit' /> : <ReportProblemIcon />}
+                        sx={{
+                            ...glass.glassSubtle,
+                            color: colors.text.secondary,
+                            fontWeight: 500,
+                            textTransform: 'none',
+                            px: 3,
+                            py: 1.25,
+                            borderRadius: 2,
+                            '&:hover': {
+                                ...glass.glassHover,
+                                borderColor: colors.divider
+                            },
+                            '&:disabled': {
+                                opacity: 0.5,
+                                color: colors.text.disabled
+                            }
+                        }}
+                    >
+                        {reportState === 'loading' ? 'Reporting...' : reportState === 'success' ? 'Reported' : 'Report Issue'}
+                    </Button>
+                </Box>
+
+                {reportState === 'success' && (
+                    <Alert
+                        severity='success'
+                        sx={{
+                            mt: 2,
+                            bgcolor: 'rgba(76, 175, 80, 0.1)',
+                            color: statusColors.success.main,
+                            border: `1px solid ${statusColors.success.main}30`,
+                            '& .MuiAlert-icon': { color: statusColors.success.main },
+                            '& a': { color: 'inherit', fontWeight: 600 }
+                        }}
+                    >
+                        Issue{' '}
+                        <a href={reportUrl} target='_blank' rel='noopener noreferrer'>
+                            {reportMessage}
+                        </a>{' '}
+                        created successfully
+                    </Alert>
+                )}
+
+                {reportState === 'error' && (
+                    <Alert
+                        severity='error'
+                        sx={{
+                            mt: 2,
+                            bgcolor: 'rgba(244, 67, 54, 0.1)',
+                            color: statusColors.error.main,
+                            border: `1px solid ${statusColors.error.main}30`,
+                            '& .MuiAlert-icon': { color: statusColors.error.main }
+                        }}
+                    >
+                        {reportMessage}
+                    </Alert>
+                )}
+            </Box>
+        </Box>
     )
 }

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,43 +1,330 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+
+type ReportState = 'idle' | 'loading' | 'success' | 'error'
+
+// Inline glassmorphism tokens (can't import since global-error renders outside app)
+const glassTokens = {
+    light: {
+        background: '#ffffff',
+        glass: {
+            background: 'rgba(255, 255, 255, 0.85)',
+            backdropFilter: 'blur(16px)',
+            border: '1px solid rgba(15, 23, 42, 0.1)',
+            boxShadow: '0 4px 16px 0 rgba(0, 0, 0, 0.08)'
+        },
+        glassSubtle: {
+            background: 'rgba(255, 255, 255, 0.7)',
+            backdropFilter: 'blur(12px)',
+            border: '1px solid rgba(15, 23, 42, 0.15)',
+            boxShadow: '0 2px 8px 0 rgba(0, 0, 0, 0.05)'
+        },
+        text: {
+            primary: '#1e293b',
+            secondary: '#64748b'
+        }
+    },
+    dark: {
+        background: '#0b0b0b',
+        glass: {
+            background: 'rgba(255, 255, 255, 0.03)',
+            backdropFilter: 'blur(12px)',
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+            boxShadow: '0 4px 16px 0 rgba(0, 0, 0, 0.3)'
+        },
+        glassSubtle: {
+            background: 'rgba(255, 255, 255, 0.05)',
+            backdropFilter: 'blur(8px)',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            boxShadow: '0 2px 8px 0 rgba(0, 0, 0, 0.2)'
+        },
+        text: {
+            primary: '#ffffff',
+            secondary: '#9e9e9e'
+        }
+    }
+}
+
+const statusColors = {
+    error: '#f44336',
+    success: '#4caf50'
+}
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+    const [reportState, setReportState] = useState<ReportState>('idle')
+    const [reportMessage, setReportMessage] = useState('')
+    const [reportUrl, setReportUrl] = useState('')
+    const [isDarkMode, setIsDarkMode] = useState(true)
+
     useEffect(() => {
         console.error('Global error boundary caught:', error)
+        // Read dark mode from localStorage (source of truth for the app)
+        const storedDarkMode = localStorage.getItem('isDarkMode')
+        setIsDarkMode(storedDarkMode !== 'false') // Default to dark if not set
     }, [error])
+
+    const theme = isDarkMode ? glassTokens.dark : glassTokens.light
+
+    const handleReportIssue = async () => {
+        setReportState('loading')
+        setReportMessage('')
+
+        try {
+            const response = await fetch('/api/report-issue', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    errorMessage: error.message || 'Unknown error',
+                    errorDigest: error.digest,
+                    errorStack: error.stack?.substring(0, 5000),
+                    url: typeof window !== 'undefined' ? window.location.href : undefined,
+                    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+                    timestamp: new Date().toISOString()
+                })
+            })
+
+            const data = await response.json()
+
+            if (response.ok && data.success) {
+                setReportState('success')
+                setReportMessage(data.issueId)
+                setReportUrl(data.issueUrl)
+            } else {
+                setReportState('error')
+                setReportMessage(data.error || 'Failed to report issue')
+            }
+        } catch {
+            setReportState('error')
+            setReportMessage('Failed to report issue. Please try again.')
+        }
+    }
 
     return (
         <html>
-            <body>
+            <body
+                style={{
+                    margin: 0,
+                    padding: 0,
+                    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+                    background: theme.background,
+                    minHeight: '100vh',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    boxSizing: 'border-box'
+                }}
+            >
                 <div
                     style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        minHeight: '100vh',
-                        padding: '20px',
-                        textAlign: 'center'
+                        background: theme.glass.background,
+                        backdropFilter: theme.glass.backdropFilter,
+                        WebkitBackdropFilter: theme.glass.backdropFilter,
+                        border: theme.glass.border,
+                        boxShadow: theme.glass.boxShadow,
+                        padding: '32px',
+                        borderRadius: '16px',
+                        maxWidth: '480px',
+                        width: 'calc(100% - 48px)',
+                        margin: '24px',
+                        textAlign: 'center',
+                        boxSizing: 'border-box'
                     }}
                 >
-                    <h2 style={{ fontSize: '24px', marginBottom: '16px' }}>Application Error</h2>
-                    <p style={{ marginBottom: '24px', color: '#666' }}>{error.message || 'A critical error occurred'}</p>
-                    <button
-                        onClick={reset}
+                    {/* Error Icon */}
+                    <svg
+                        xmlns='http://www.w3.org/2000/svg'
+                        width='72'
+                        height='72'
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke={statusColors.error}
+                        strokeWidth='1.5'
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        style={{ marginBottom: '16px' }}
+                    >
+                        <circle cx='12' cy='12' r='10'></circle>
+                        <line x1='12' y1='8' x2='12' y2='12'></line>
+                        <line x1='12' y1='16' x2='12.01' y2='16'></line>
+                    </svg>
+
+                    <h2
                         style={{
-                            padding: '12px 24px',
-                            backgroundColor: '#0070f3',
-                            color: 'white',
-                            border: 'none',
-                            borderRadius: '6px',
-                            cursor: 'pointer',
-                            fontSize: '16px'
+                            fontSize: '1.5rem',
+                            fontWeight: 600,
+                            color: theme.text.primary,
+                            margin: '0 0 16px 0'
                         }}
                     >
-                        Try again
-                    </button>
+                        Application Error
+                    </h2>
+
+                    <p
+                        style={{
+                            color: theme.text.secondary,
+                            wordBreak: 'break-word',
+                            margin: '0 0 24px 0',
+                            lineHeight: 1.6,
+                            fontSize: '0.95rem'
+                        }}
+                    >
+                        {error.message || 'A critical error occurred'}
+                    </p>
+
+                    <div
+                        style={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            gap: '12px',
+                            justifyContent: 'center',
+                            marginBottom: reportState !== 'idle' ? '24px' : '0'
+                        }}
+                    >
+                        <button
+                            onClick={reset}
+                            style={{
+                                padding: '10px 24px',
+                                background: 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)',
+                                color: 'white',
+                                border: 'none',
+                                borderRadius: '8px',
+                                cursor: 'pointer',
+                                fontSize: '0.95rem',
+                                fontWeight: 500,
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: '8px',
+                                boxShadow: '0 4px 14px rgba(59, 130, 246, 0.4)',
+                                transition: 'all 0.2s ease'
+                            }}
+                            onMouseOver={(e) => {
+                                e.currentTarget.style.background = 'linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%)'
+                                e.currentTarget.style.boxShadow = '0 6px 20px rgba(59, 130, 246, 0.5)'
+                            }}
+                            onMouseOut={(e) => {
+                                e.currentTarget.style.background = 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)'
+                                e.currentTarget.style.boxShadow = '0 4px 14px rgba(59, 130, 246, 0.4)'
+                            }}
+                        >
+                            <svg
+                                xmlns='http://www.w3.org/2000/svg'
+                                width='18'
+                                height='18'
+                                viewBox='0 0 24 24'
+                                fill='none'
+                                stroke='currentColor'
+                                strokeWidth='2'
+                                strokeLinecap='round'
+                                strokeLinejoin='round'
+                            >
+                                <path d='M21 2v6h-6'></path>
+                                <path d='M3 12a9 9 0 0 1 15-6.7L21 8'></path>
+                                <path d='M3 22v-6h6'></path>
+                                <path d='M21 12a9 9 0 0 1-15 6.7L3 16'></path>
+                            </svg>
+                            Try again
+                        </button>
+
+                        <button
+                            onClick={handleReportIssue}
+                            disabled={reportState === 'loading' || reportState === 'success'}
+                            style={{
+                                padding: '10px 24px',
+                                background: theme.glassSubtle.background,
+                                backdropFilter: theme.glassSubtle.backdropFilter,
+                                color: theme.text.secondary,
+                                border: theme.glassSubtle.border,
+                                borderRadius: '8px',
+                                cursor: reportState === 'loading' || reportState === 'success' ? 'not-allowed' : 'pointer',
+                                fontSize: '0.95rem',
+                                fontWeight: 500,
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: '8px',
+                                transition: 'all 0.2s ease',
+                                opacity: reportState === 'loading' || reportState === 'success' ? 0.5 : 1
+                            }}
+                        >
+                            {reportState === 'loading' ? (
+                                <svg
+                                    xmlns='http://www.w3.org/2000/svg'
+                                    width='18'
+                                    height='18'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                    strokeLinecap='round'
+                                    strokeLinejoin='round'
+                                    style={{ animation: 'spin 1s linear infinite' }}
+                                >
+                                    <path d='M21 12a9 9 0 1 1-6.219-8.56'></path>
+                                </svg>
+                            ) : (
+                                <svg
+                                    xmlns='http://www.w3.org/2000/svg'
+                                    width='18'
+                                    height='18'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                    strokeLinecap='round'
+                                    strokeLinejoin='round'
+                                >
+                                    <path d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z'></path>
+                                    <line x1='12' y1='9' x2='12' y2='13'></line>
+                                    <line x1='12' y1='17' x2='12.01' y2='17'></line>
+                                </svg>
+                            )}
+                            {reportState === 'loading' ? 'Reporting...' : reportState === 'success' ? 'Reported' : 'Report Issue'}
+                        </button>
+                    </div>
+
+                    {reportState === 'success' && (
+                        <div
+                            style={{
+                                padding: '12px 16px',
+                                background: 'rgba(76, 175, 80, 0.1)',
+                                color: statusColors.success,
+                                border: '1px solid rgba(76, 175, 80, 0.3)',
+                                borderRadius: '8px',
+                                fontSize: '0.9rem',
+                                marginTop: '16px'
+                            }}
+                        >
+                            Issue{' '}
+                            <a href={reportUrl} target='_blank' rel='noopener noreferrer' style={{ color: 'inherit', fontWeight: 600 }}>
+                                {reportMessage}
+                            </a>{' '}
+                            created successfully
+                        </div>
+                    )}
+
+                    {reportState === 'error' && (
+                        <div
+                            style={{
+                                padding: '12px 16px',
+                                background: 'rgba(244, 67, 54, 0.1)',
+                                color: statusColors.error,
+                                border: '1px solid rgba(244, 67, 54, 0.3)',
+                                borderRadius: '8px',
+                                fontSize: '0.9rem',
+                                marginTop: '16px'
+                            }}
+                        >
+                            {reportMessage}
+                        </div>
+                    )}
                 </div>
+
+                <style>{`
+                    @keyframes spin {
+                        from { transform: rotate(0deg); }
+                        to { transform: rotate(360deg); }
+                    }
+                `}</style>
             </body>
         </html>
     )

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -65,6 +65,7 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
     }, [error])
 
     const theme = isDarkMode ? glassTokens.dark : glassTokens.light
+    const reportingEnabled = !!process.env.NEXT_PUBLIC_ERROR_REPORTING_ENABLED
 
     const handleReportIssue = async () => {
         setReportState('loading')
@@ -226,60 +227,62 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
                             Try again
                         </button>
 
-                        <button
-                            onClick={handleReportIssue}
-                            disabled={reportState === 'loading' || reportState === 'success'}
-                            style={{
-                                padding: '10px 24px',
-                                background: theme.glassSubtle.background,
-                                backdropFilter: theme.glassSubtle.backdropFilter,
-                                color: theme.text.secondary,
-                                border: theme.glassSubtle.border,
-                                borderRadius: '8px',
-                                cursor: reportState === 'loading' || reportState === 'success' ? 'not-allowed' : 'pointer',
-                                fontSize: '0.95rem',
-                                fontWeight: 500,
-                                display: 'inline-flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                transition: 'all 0.2s ease',
-                                opacity: reportState === 'loading' || reportState === 'success' ? 0.5 : 1
-                            }}
-                        >
-                            {reportState === 'loading' ? (
-                                <svg
-                                    xmlns='http://www.w3.org/2000/svg'
-                                    width='18'
-                                    height='18'
-                                    viewBox='0 0 24 24'
-                                    fill='none'
-                                    stroke='currentColor'
-                                    strokeWidth='2'
-                                    strokeLinecap='round'
-                                    strokeLinejoin='round'
-                                    style={{ animation: 'spin 1s linear infinite' }}
-                                >
-                                    <path d='M21 12a9 9 0 1 1-6.219-8.56'></path>
-                                </svg>
-                            ) : (
-                                <svg
-                                    xmlns='http://www.w3.org/2000/svg'
-                                    width='18'
-                                    height='18'
-                                    viewBox='0 0 24 24'
-                                    fill='none'
-                                    stroke='currentColor'
-                                    strokeWidth='2'
-                                    strokeLinecap='round'
-                                    strokeLinejoin='round'
-                                >
-                                    <path d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z'></path>
-                                    <line x1='12' y1='9' x2='12' y2='13'></line>
-                                    <line x1='12' y1='17' x2='12.01' y2='17'></line>
-                                </svg>
-                            )}
-                            {reportState === 'loading' ? 'Reporting...' : reportState === 'success' ? 'Reported' : 'Report Issue'}
-                        </button>
+                        {reportingEnabled && (
+                            <button
+                                onClick={handleReportIssue}
+                                disabled={reportState === 'loading' || reportState === 'success'}
+                                style={{
+                                    padding: '10px 24px',
+                                    background: theme.glassSubtle.background,
+                                    backdropFilter: theme.glassSubtle.backdropFilter,
+                                    color: theme.text.secondary,
+                                    border: theme.glassSubtle.border,
+                                    borderRadius: '8px',
+                                    cursor: reportState === 'loading' || reportState === 'success' ? 'not-allowed' : 'pointer',
+                                    fontSize: '0.95rem',
+                                    fontWeight: 500,
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: '8px',
+                                    transition: 'all 0.2s ease',
+                                    opacity: reportState === 'loading' || reportState === 'success' ? 0.5 : 1
+                                }}
+                            >
+                                {reportState === 'loading' ? (
+                                    <svg
+                                        xmlns='http://www.w3.org/2000/svg'
+                                        width='18'
+                                        height='18'
+                                        viewBox='0 0 24 24'
+                                        fill='none'
+                                        stroke='currentColor'
+                                        strokeWidth='2'
+                                        strokeLinecap='round'
+                                        strokeLinejoin='round'
+                                        style={{ animation: 'spin 1s linear infinite' }}
+                                    >
+                                        <path d='M21 12a9 9 0 1 1-6.219-8.56'></path>
+                                    </svg>
+                                ) : (
+                                    <svg
+                                        xmlns='http://www.w3.org/2000/svg'
+                                        width='18'
+                                        height='18'
+                                        viewBox='0 0 24 24'
+                                        fill='none'
+                                        stroke='currentColor'
+                                        strokeWidth='2'
+                                        strokeLinecap='round'
+                                        strokeLinejoin='round'
+                                    >
+                                        <path d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z'></path>
+                                        <line x1='12' y1='9' x2='12' y2='13'></line>
+                                        <line x1='12' y1='17' x2='12.01' y2='17'></line>
+                                    </svg>
+                                )}
+                                {reportState === 'loading' ? 'Reporting...' : reportState === 'success' ? 'Reported' : 'Report Issue'}
+                            </button>
+                        )}
                     </div>
 
                     {reportState === 'success' && (

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,9 @@
 const { PrismaPlugin } = require('experimental-prisma-webpack-plugin')
+const path = require('path')
+
+// Load root .env file for monorepo compatibility
+// This ensures env vars like LINEAR_API_KEY are available when running from apps/web/
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const webpack = require('webpack')
 const withBundleAnalyzer = require('@next/bundle-analyzer')({

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -99,7 +99,9 @@ let nextConfig = withBundleAnalyzer({
             process.env.AUTH0_BASE_URL ?? (process.env.VERCEL_BRANCH_URL ? `https://${process.env.VERCEL_BRANCH_URL}` : undefined),
         AUTH0_SECRET: process.env.AUTH0_SECRET,
         CHATFLOW_DOMAIN_OVERRIDE: process.env.CHATFLOW_DOMAIN_OVERRIDE,
-        LANGFUSE_HOST: process.env.LANGFUSE_HOST
+        LANGFUSE_HOST: process.env.LANGFUSE_HOST,
+        // Error reporting availability (derived from LINEAR_API_KEY)
+        NEXT_PUBLIC_ERROR_REPORTING_ENABLED: process.env.LINEAR_API_KEY ? 'true' : ''
     },
     webpack: (config, { isServer }) => {
         config.externals = [...config.externals, 'db', 'puppeteer', 'handlebars']


### PR DESCRIPTION
## Summary

- Update `error.tsx` and `global-error.tsx` with glassmorphism design tokens from the unified theme system
- Add "Report Issue" button that creates Linear bug tickets with error context (message, digest, URL, user agent, timestamp)
- Create `/api/report-issue` endpoint for Linear integration using the Linear GraphQL API
- Support light/dark theme based on localStorage `isDarkMode` setting
- Display clickable ticket URL in success message after reporting

## Changes

### New Files
- `apps/web/app/api/report-issue/route.ts` - API endpoint that creates Linear issues with error context

### Modified Files
- `apps/web/app/error.tsx` - Route-level error boundary with glassmorphism styling
- `apps/web/app/global-error.tsx` - App-level error boundary with inline glassmorphism styles

## Technical Details

- Uses `glassmorphismTokens` and `colorTokens` from `@ui/theme/tokens` for consistent styling
- `global-error.tsx` uses inline token copies since it renders outside the app context
- Theme detection reads from localStorage (`isDarkMode`) which is the app's source of truth
- Rate limiting uses Redis following the existing `packages/server` pattern
- Linear tickets are created with:
  - Team: AnswerAgentAI
  - Label: Bug
  - Priority: Normal (3)
  - Includes user email, organization name, and organization ID for multi-tenancy filtering

## Test Plan

- [ ] Trigger an error boundary by introducing a runtime error in a component
- [ ] Verify error page displays with glassmorphism styling
- [ ] Toggle theme to light mode and verify error page updates
- [ ] Click "Report Issue" and verify Linear ticket is created
- [ ] Verify ticket URL is clickable in success message
- [ ] Test "Try again" button functionality
- [ ] Verify rate limiting (6th request within 1 minute should return 429)

## Linear Ticket

[AGENT-468](https://linear.app/answeragent/issue/AGENT-468/improve-error-page-styling-and-add-report-issue-button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)