### PR TITLE
fix(AGENT-467): resolve removeChild DOM exception in agentflow canvas

### DIFF
--- a/packages/ui/src/ui-component/credentials/ConnectedToolsIndicator.jsx
+++ b/packages/ui/src/ui-component/credentials/ConnectedToolsIndicator.jsx
@@ -156,50 +156,37 @@ const ConnectedToolsIndicator = ({ credentials = [], flowData = null, onClick })
                                     pointerEvents: 'none' // Let parent handle clicks
                                 }}
                             >
-                                <Box
+                                <Avatar
+                                    src={iconUrl}
+                                    alt={item.label}
                                     sx={{
                                         width: 28,
                                         height: 28,
-                                        borderRadius: '50%',
                                         border: `2px solid ${theme.palette.background.paper}`,
                                         bgcolor: 'rgba(255, 255, 255, 0.9)',
                                         boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
                                         transition: 'transform 0.2s ease',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                        overflow: 'hidden',
+                                        fontSize: '0.65rem',
+                                        fontWeight: 600,
+                                        color: theme.palette.text.primary,
+                                        '& img': {
+                                            padding: '4px',
+                                            objectFit: 'contain'
+                                        },
                                         '&:hover': {
                                             transform: 'scale(1.1)',
                                             zIndex: visibleItems.length + 1
                                         }
                                     }}
                                 >
-                                    <img
-                                        src={iconUrl}
-                                        alt={item.label}
-                                        style={{
-                                            width: '100%',
-                                            height: '100%',
-                                            padding: '4px',
-                                            objectFit: 'contain'
-                                        }}
-                                        onError={(e) => {
-                                            // Fallback to initials on error
-                                            e.target.style.display = 'none'
-                                            const parent = e.target.parentElement
-                                            parent.style.fontSize = '0.65rem'
-                                            parent.style.fontWeight = '600'
-                                            parent.style.color = theme.palette.text.primary
-                                            parent.innerHTML = item.label
-                                                .split(' ')
-                                                .map((word) => word[0])
-                                                .join('')
-                                                .toUpperCase()
-                                                .slice(0, 2)
-                                        }}
-                                    />
-                                </Box>
+                                    {/* Fallback to initials - Avatar handles this automatically when image fails */}
+                                    {item.label
+                                        .split(' ')
+                                        .map((word) => word[0])
+                                        .join('')
+                                        .toUpperCase()
+                                        .slice(0, 2)}
+                                </Avatar>
 
                                 {/* Green checkmark indicator for connected items */}
                                 {item.isConnected && (

--- a/packages/ui/src/ui-component/credentials/CredentialLogo.jsx
+++ b/packages/ui/src/ui-component/credentials/CredentialLogo.jsx
@@ -1,6 +1,6 @@
+import { useState } from 'react'
 import { Box, Avatar, Tooltip, Typography } from '@mui/material'
 import { IconCheck, IconAlertTriangle, IconCircle } from '@tabler/icons-react'
-import { useTheme } from '@mui/material/styles'
 import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import { baseURL } from '@/store/constant'
@@ -11,9 +11,9 @@ import { getGlassStyle, statusColors } from './glassmorphismStyles'
  * Shows logo with status indicator (connected/required/optional)
  */
 const CredentialLogo = ({ credential, size = 'medium', showLabel = false, onClick }) => {
-    const theme = useTheme()
     const customization = useSelector((state) => state.customization)
     const isDarkMode = customization.isDarkMode
+    const [imageError, setImageError] = useState(false)
 
     const { credentialType, label, isAssigned, isRequired } = credential
 
@@ -62,7 +62,7 @@ const CredentialLogo = ({ credential, size = 'medium', showLabel = false, onClic
                     }}
                 >
                     <Avatar
-                        src={logoUrl}
+                        src={imageError ? undefined : logoUrl}
                         alt={label}
                         sx={{
                             width: config.avatar,
@@ -71,15 +71,9 @@ const CredentialLogo = ({ credential, size = 'medium', showLabel = false, onClic
                             p: 1
                         }}
                         imgProps={{
-                            onError: (e) => {
-                                // Fallback to initials if image fails to load
-                                e.target.style.display = 'none'
-                                e.target.parentElement.innerHTML = label
-                                    .split(' ')
-                                    .map((word) => word[0])
-                                    .join('')
-                                    .toUpperCase()
-                                    .slice(0, 2)
+                            onError: () => {
+                                // Use React state to trigger fallback instead of direct DOM manipulation
+                                setImageError(true)
                             }
                         }}
                     >

--- a/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
+++ b/packages/ui/src/ui-component/dialog/UnifiedCredentialsModal.jsx
@@ -609,6 +609,7 @@ const UnifiedCredentialsModal = ({ show, missingCredentials, onAssign, onSkip, o
             >
                 <Typography
                     variant='h4'
+                    component='span'
                     sx={{
                         fontWeight: 700,
                         fontSize: '1.75rem',

--- a/packages/ui/src/views/agentflowsv2/AgentFlowNode.jsx
+++ b/packages/ui/src/views/agentflowsv2/AgentFlowNode.jsx
@@ -266,7 +266,7 @@ const AgentFlowNode = ({ data }) => {
                     )}
 
                     <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                        <Box item style={{ width: 50 }}>
+                        <Box style={{ width: 50 }}>
                             {data.color && !data.icon ? (
                                 <div
                                     style={{


### PR DESCRIPTION
## Summary

Fixes critical bug where LastRev customer cannot access agentflow canvas due to `removeChild` DOM exception.

**Root Cause:** Direct DOM manipulation with `innerHTML` in `onError` handlers caused React to lose track of its virtual DOM. When React tried to update or unmount components, it couldn't find nodes it expected, triggering `Failed to execute 'removeChild' on 'Node'` errors.

### Changes

- **CredentialLogo.jsx**: Replace direct DOM manipulation with React state (`useState`) for image error handling
- **ConnectedToolsIndicator.jsx**: Replace raw `<img>` with MUI `Avatar` component which handles fallbacks natively
- **AgentFlowNode.jsx**: Remove invalid `item` prop from Box component (fixes console warning)
- **UnifiedCredentialsModal.jsx**: Add `component='span'` to Typography inside DialogTitle (fixes HTML nesting warning)

## Test plan

- [ ] Load agentflow canvas at `https://lastrev.theanswer.ai/sidekick-studio/v2/agentcanvas/e45320ea-f916-4134-860d-eb56a83e9ae8`
- [ ] Verify no `removeChild` DOM exceptions in browser console
- [ ] Verify credential logos display correctly (with fallback to initials when image fails)
- [ ] Verify no React warnings about `item` prop or HTML nesting
- [ ] Test adding/removing nodes on canvas

## Linear Ticket

[AGENT-467](https://linear.app/answeragent/issue/AGENT-467/fix-agentflow-loading-error-removechild-dom-exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)