### PR TITLE
feat(AGENT-573): use default chatflow for chat navigation

### DIFF
--- a/packages-answers/ui/src/AppDrawer.tsx
+++ b/packages-answers/ui/src/AppDrawer.tsx
@@ -166,7 +166,7 @@ export const AppDrawer = ({ session }: AppDrawerProps) => {
         {
             id: 'chat',
             text: 'Chat',
-            link: '/chat',
+            link: user?.defaultChatflowId ? `/chat/${user.defaultChatflowId}` : '/chat',
             icon: <ChatBubbleOutlineIcon />
         },
         {


### PR DESCRIPTION
## Summary
- Update AppDrawer chat link to navigate to user's default chatflow when available
- Falls back to `/chat` if no default chatflow is set
- Improves user experience by taking users directly to their preferred chatflow

## Changes
- Modified `packages-answers/ui/src/AppDrawer.tsx` to use `user?.defaultChatflowId` for chat navigation

## Test plan
- [ ] Verify chat navigation goes to `/chat/{defaultChatflowId}` when user has a default chatflow set
- [ ] Verify chat navigation goes to `/chat` when user has no default chatflow
- [ ] Verify navigation works correctly in both logged-in and logged-out states

## Linear ticket
[AGENT-573](https://linear.app/answerai/issue/AGENT-573)

🤖 Generated with [Claude Code](https://claude.com/claude-code)