### PR TITLE
docs: clarify FLOWISE_SECRETKEY_OVERWRITE requirement for ephemeral deployments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,10 @@ services:
             - AAI_DEFAULT_REDIS_URL=redis://redis:6379
             - REDIS_URL=redis://redis:6379
             - DISABLE_FLOWISE_TELEMETRY=${DISABLE_FLOWISE_TELEMETRY:-true}
+            # ⚠️ CRITICAL: Required for credential encryption persistence in container deployments
+            # Without this, each container rebuild generates a new encryption key, making all stored credentials permanently unreadable.
+            # Generate with: openssl rand -base64 32
+            - FLOWISE_SECRETKEY_OVERWRITE=${FLOWISE_SECRETKEY_OVERWRITE}
         volumes:
             - flowise_data:/root/.flowise
         depends_on:

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,43 @@
 
 Starts Flowise from [DockerHub Image](https://hub.docker.com/r/flowiseai/flowise)
 
+## ⚠️ CRITICAL: Encryption Key for Production Deployments
+
+**Docker and container deployments MUST set `FLOWISE_SECRETKEY_OVERWRITE` to ensure credential encryption persistence.**
+
+### Why This Matters
+
+Flowise encrypts all stored credentials (API keys, secrets, etc.) using an encryption key. By default, this key is:
+1. Read from a file at `SECRETKEY_PATH/encryption.key`
+2. If the file doesn't exist, a **new random key is generated**
+
+In ephemeral container environments (Docker, Render, Kubernetes, ECS, etc.), the filesystem resets on each rebuild. Without `FLOWISE_SECRETKEY_OVERWRITE`:
+- Each deployment generates a **new encryption key**
+- All previously encrypted credentials become **permanently unreadable**
+- **Data loss occurs with no recovery option**
+
+### Required Configuration
+
+```bash
+# Generate a secure key (run once, save securely)
+openssl rand -base64 32
+
+# Add to your .env file or environment
+FLOWISE_SECRETKEY_OVERWRITE=your-generated-key-here
+```
+
+### Alternative: AWS Secrets Manager
+
+For AWS deployments, you can use AWS Secrets Manager instead:
+
+```bash
+SECRETKEY_STORAGE_TYPE=aws
+SECRETKEY_AWS_REGION=us-east-1
+SECRETKEY_AWS_NAME=FlowiseEncryptionKey
+```
+
+---
+
 ## Usage
 
 1. Create `.env` file and specify the `PORT` (refer to `.env.example`)

--- a/packages/docs/docs/developers/environment-variables.md
+++ b/packages/docs/docs/developers/environment-variables.md
@@ -59,7 +59,7 @@ There are three different .env files you can set environment variables for Answe
 | DATABASE_SSL_KEY_BASE64       | Base64 encoded SSL key for database (commented out)      | Server                      |
 | FLOWISE_USERNAME              | Flowise username (commented out)                         | Server                      |
 | FLOWISE_PASSWORD              | Flowise password (commented out)                         | Server                      |
-| FLOWISE_SECRETKEY_OVERWRITE   | Encryption key for Flowise (commented out)               | Server                      |
+| FLOWISE_SECRETKEY_OVERWRITE   | **⚠️ REQUIRED for container deployments** - Encryption key for credentials | Server                      |
 | FLOWISE_FILE_SIZE_LIMIT       | File size limit for Flowise (commented out)              | Server                      |
 | DISABLE_CHATFLOW_REUSE        | Disable chatflow reuse when set to true (commented out)  | Server                      |
 | DEBUG                         | Enable debug mode when set to true (commented out)       | Server                      |
@@ -152,6 +152,56 @@ AAI-branded nodes use environment variables with the `AAI_DEFAULT_` prefix to pr
 | `AAI_DEFAULT_GOOGLE_SEARCH_API`           | Google Custom Search API key   | Google search integrations |
 | `AAI_DEFAULT_GOOGLE_SEARCH_API_ENGINE_ID` | Google Custom Search Engine ID | Google search integrations |
 | `AAI_DEFAULT_GITHUB_TOKEN`                | GitHub personal access token   | GitHub integrations        |
+
+## ⚠️ CRITICAL: Encryption Key for Container Deployments
+
+:::danger Required for Docker/Container Deployments
+**All container-based deployments (Docker, Render, Kubernetes, ECS, etc.) MUST configure `FLOWISE_SECRETKEY_OVERWRITE` to prevent data loss.**
+:::
+
+### The Problem
+
+Flowise encrypts all stored credentials (API keys, secrets, database passwords) using an encryption key. By default:
+1. The system reads the key from `SECRETKEY_PATH/encryption.key`
+2. If the file doesn't exist, **a new random key is automatically generated**
+
+In ephemeral container environments, the filesystem resets on each deployment. Without explicit key configuration:
+- Each container rebuild generates a **new encryption key**
+- All previously encrypted credentials become **permanently unreadable**
+- **This results in unrecoverable data loss**
+
+### Solution: Set FLOWISE_SECRETKEY_OVERWRITE
+
+```bash
+# Generate a secure key (run ONCE, save securely)
+openssl rand -base64 32
+
+# Add to your environment
+FLOWISE_SECRETKEY_OVERWRITE=your-generated-key-here
+```
+
+**Important:**
+- Generate this key **once** and store it securely (e.g., secrets manager, encrypted vault)
+- **Never regenerate** unless you intend to rotate credentials (which requires re-entering all credentials)
+- Treat this key like a database master password
+
+### Alternative: AWS Secrets Manager
+
+For AWS deployments, use AWS Secrets Manager for automatic key management:
+
+```bash
+SECRETKEY_STORAGE_TYPE=aws
+SECRETKEY_AWS_REGION=us-east-1
+SECRETKEY_AWS_NAME=FlowiseEncryptionKey
+```
+
+Benefits:
+- Keys encrypted at rest and in transit
+- Automatic rotation capabilities
+- Full audit trail and access logging
+- IAM-based access control
+
+---
 
 ### Security Considerations
 

--- a/render.yaml
+++ b/render.yaml
@@ -245,9 +245,13 @@ services:
           # =========================================
           # Flowise Security & API Keys
           # =========================================
-          # Flowise Encryption Key Override
-          # - key: FLOWISE_SECRETKEY_OVERWRITE
-          #   sync: false
+          # ⚠️ CRITICAL: FLOWISE_SECRETKEY_OVERWRITE is REQUIRED for Render deployments
+          # Render containers are ephemeral - without this variable, each deploy generates
+          # a new encryption key, making ALL stored credentials permanently unreadable.
+          # Generate once with: openssl rand -base64 32
+          # Store as a Render secret and NEVER regenerate unless rotating credentials.
+          - key: FLOWISE_SECRETKEY_OVERWRITE
+            sync: false
           - key: SECRETKEY_PATH
             value: '/var/data'
           - key: APIKEY_STORAGE_TYPE


### PR DESCRIPTION
docs: clarify FLOWISE_SECRETKEY_OVERWRITE requirement for ephemeral deployments

Document that Docker/container deployments MUST use FLOWISE_SECRETKEY_OVERWRITE
environment variable to ensure credential encryption key persistence.

Without this, each container rebuild generates a new encryption key, making all
previously stored credentials permanently unreadable.

Changes:
- Add critical warning to docker/README.md
- Add env var to root docker-compose.yml with documentation
- Uncomment and document in render.yaml
- Expand environment-variables.md with dedicated section