### PR TITLE
feat(AGENT-610): enable multi-workspace resource sharing via Smart Repository Decorator

### DIFF
--- a/packages/server/src/aai/context.ts
+++ b/packages/server/src/aai/context.ts
@@ -1,0 +1,20 @@
+/**
+ * AAI Context - Configuration and request-scoped AsyncLocalStorage for workspace filtering.
+ */
+import { AsyncLocalStorage } from 'async_hooks'
+
+// Config - Feature DISABLED by default for safety
+const config = {
+    enabled: process.env.AAI_MULTI_WORKSPACE_SHARING === 'true',
+    sharedWorkspaceName: process.env.AAI_SHARED_WORKSPACE_NAME || 'Default Workspace',
+    debug: process.env.AAI_WORKSPACE_DEBUG === 'true'
+}
+
+export const isMultiWorkspaceSharingEnabled = () => config.enabled
+export const getSharedWorkspaceName = () => config.sharedWorkspaceName
+export const isDebugEnabled = () => config.debug
+export const debugLog = (msg: string, data?: any) => config.debug && console.log(`[AAI] ${msg}`, data ?? '')
+
+// Request context
+export const requestContext = new AsyncLocalStorage<{ workspaceIds?: string[] }>()
+export const getWorkspaceIdsFromContext = () => requestContext.getStore()?.workspaceIds

--- a/packages/server/src/aai/middleware.ts
+++ b/packages/server/src/aai/middleware.ts
@@ -1,0 +1,30 @@
+/**
+ * AAI Middleware - Populates AsyncLocalStorage with workspace context.
+ * IMPORTANT: Must run AFTER authentication middleware to access req.user.assignedWorkspaces
+ */
+import { Request, Response, NextFunction } from 'express'
+import { requestContext, isMultiWorkspaceSharingEnabled, getSharedWorkspaceName, debugLog } from './context'
+
+export const requestContextMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (!isMultiWorkspaceSharingEnabled() || !req.user?.assignedWorkspaces) return next()
+
+        const sharedWs = req.user.assignedWorkspaces.find((ws: { name: string }) => ws.name === getSharedWorkspaceName())
+        const sharedId = sharedWs?.id
+        const activeId = req.user.activeWorkspaceId
+
+        if (!sharedWs) {
+            debugLog(`Shared workspace "${getSharedWorkspaceName()}" not found for user`)
+        }
+
+        const workspaceIds = activeId && sharedId && activeId !== sharedId
+            ? [activeId, sharedId]
+            : [activeId || sharedId].filter(Boolean) as string[]
+
+        debugLog('Context setup', { activeId, sharedId, workspaceIds })
+        requestContext.run({ workspaceIds }, () => next())
+    } catch (error) {
+        console.error('[AAI Middleware] Error setting up context:', error)
+        next() // Continue without multi-workspace context rather than failing
+    }
+}

--- a/packages/server/src/aai/repository.ts
+++ b/packages/server/src/aai/repository.ts
@@ -1,0 +1,95 @@
+/**
+ * AAI Repository - Workspace-aware repository decorator that upgrades single-workspace filters to multi-workspace.
+ */
+import { DataSource, Repository, SelectQueryBuilder, ObjectLiteral, FindManyOptions, FindOptionsWhere, In } from 'typeorm'
+import { getWorkspaceIdsFromContext, isMultiWorkspaceSharingEnabled, debugLog } from './context'
+
+// Entities with workspaceId field - add new workspace-scoped entities here
+const WORKSPACE_ENTITIES = new Set([
+    'ChatFlow', 'Tool', 'Variable', 'DocumentStore', 'Credential',
+    'Assistant', 'Apikey', 'Dataset', 'Evaluation', 'Evaluator', 'Execution'
+])
+
+export function initAAI(dataSource: DataSource) {
+    const originalGetRepository = dataSource.getRepository.bind(dataSource)
+    dataSource.getRepository = function <T extends ObjectLiteral>(target: any): any {
+        const repo = originalGetRepository(target)
+        const entityName = typeof target === 'function' ? target.name : String(target)
+        return createWorkspaceAwareRepository(repo, entityName)
+    }
+}
+
+function createWorkspaceAwareRepository<T extends ObjectLiteral>(repository: Repository<T>, entityName: string): Repository<T> {
+    if (!WORKSPACE_ENTITIES.has(entityName)) return repository
+
+    return new Proxy(repository, {
+        get(target, prop: string | symbol) {
+            const original = target[prop as keyof Repository<T>]
+            if (typeof original !== 'function') return original
+            const propName = String(prop)
+
+            if (['find', 'findBy', 'findOne', 'findOneBy', 'findAndCount', 'findAndCountBy', 'count'].includes(propName)) {
+                return async (...args: any[]) => {
+                    if (!isMultiWorkspaceSharingEnabled()) return (original as Function).apply(target, args)
+                    return (original as Function).call(target, enhanceFindOptions(args[0], entityName))
+                }
+            }
+
+            if (propName === 'createQueryBuilder') {
+                return (alias?: string) => {
+                    const qb = (original as Function).call(target, alias)
+                    if (!isMultiWorkspaceSharingEnabled()) return qb
+                    return wrapQueryBuilder(qb, alias || entityName.toLowerCase())
+                }
+            }
+
+            return typeof original === 'function' ? (original as Function).bind(target) : original
+        }
+    })
+}
+
+function enhanceFindOptions<T>(options: FindManyOptions<T> | FindOptionsWhere<T> | undefined, entityName: string): any {
+    const wsIds = getWorkspaceIdsFromContext()
+    if (!wsIds || wsIds.length <= 1) return options || {}
+    if (!options) {
+        debugLog(`${entityName}.find - adding multi-workspace filter`, { wsIds })
+        return { workspaceId: In(wsIds) }
+    }
+
+    const where = 'where' in options ? options.where : options
+    if (where && typeof where === 'object' && 'workspaceId' in where) {
+        const { workspaceId: _, ...rest } = where as any
+        debugLog(`${entityName}.find - upgraded workspaceId filter`, { wsIds })
+        const upgraded = { ...rest, workspaceId: In(wsIds) }
+        return 'where' in options ? { ...options, where: upgraded } : upgraded
+    }
+
+    debugLog(`${entityName}.find - adding multi-workspace filter`, { wsIds })
+    const filter = { workspaceId: In(wsIds) }
+    return 'where' in options && options.where ? { ...options, where: { ...options.where, ...filter } } : { ...options, ...filter }
+}
+
+function wrapQueryBuilder<T extends ObjectLiteral>(qb: SelectQueryBuilder<T>, alias: string): SelectQueryBuilder<T> {
+    const wsIds = getWorkspaceIdsFromContext()
+    if (!wsIds || wsIds.length <= 1) return qb
+
+    const origAnd = qb.andWhere.bind(qb), origWhere = qb.where.bind(qb)
+
+    const upgrade = (orig: Function, method: string) => (cond: any, params?: any): SelectQueryBuilder<T> => {
+        if (typeof cond === 'string' && cond.includes('.workspaceId')) {
+            if (cond.includes('= :workspaceId') && params?.workspaceId) {
+                const newCond = cond.replace(/(\w+)\.workspaceId\s*=\s*:workspaceId/, '$1.workspaceId IN (:...aaiWsIds)')
+                const newParams = { ...params, aaiWsIds: wsIds }
+                delete newParams.workspaceId
+                debugLog(`QB.${method} - upgraded`, { original: cond, wsIds })
+                return orig(newCond, newParams)
+            }
+            debugLog(`QB.${method} - workspace filter not upgraded (unexpected format)`, { cond })
+        }
+        return orig(cond, params)
+    }
+
+    qb.andWhere = upgrade(origAnd, 'andWhere') as typeof qb.andWhere
+    qb.where = upgrade(origWhere, 'where') as typeof qb.where
+    return qb
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,6 +45,8 @@ import { aaiPostAuthMiddleware } from './middlewares/authentication/aaiPostAuthM
 import { verifyAAIToken } from './middlewares/authentication/verifyAAIToken'
 import { populateWorkspaceData } from './middlewares/authentication/populateWorkspaceData'
 import { User } from './database/entities/User'
+import { initAAI } from './aai/repository'
+import { requestContextMiddleware } from './aai/middleware'
 declare global {
     namespace Express {
         interface User extends LoggedInUser {}
@@ -170,6 +172,9 @@ export class App {
     }
 
     async config() {
+        // Initialize AAI overrides with DataSource for repository wrapping
+        initAAI(this.AppDataSource)
+
         // Limit is needed to allow sending/receiving base64 encoded string
         const flowise_file_size_limit = process.env.FLOWISE_FILE_SIZE_LIMIT || '50mb'
         this.app.use(express.json({ limit: flowise_file_size_limit }))
@@ -364,6 +369,10 @@ export class App {
         // AAI Post-Auth Middleware - runs AFTER passport auth to enhance req.user with AAI data
         // This bridges enterprise passport auth with AAI business logic (Stripe, workspaces, chatflows)
         this.app.use(aaiPostAuthMiddleware(this.AppDataSource))
+
+        // AAI Request Context Middleware - populates AsyncLocalStorage with workspace context
+        // IMPORTANT: Must run AFTER aaiPostAuthMiddleware to access req.user.assignedWorkspaces
+        this.app.use(requestContextMiddleware)
 
         if (process.env.ENABLE_METRICS === 'true') {
             switch (process.env.METRICS_PROVIDER) {


### PR DESCRIPTION
## Summary

Enables users in Personal Workspaces to access resources from the Default Workspace (organization-shared resources) through intelligent query interception.

**Key achievement: ZERO service file modifications.** The decorator intercepts and UPGRADES existing workspace filters instead of adding new ones.

## How It Works

```
Service code UNCHANGED:
  queryBuilder.andWhere('tool.workspaceId = :workspaceId', { workspaceId })

Decorator intercepts and upgrades to:
  queryBuilder.andWhere('tool.workspaceId IN (:...ids)', { ids: [currentWs, defaultWs] })
```

## Implementation

### Smart andWhere Interception
- Detects workspace filter pattern: `alias.workspaceId = :workspaceId`
- Upgrades to multi-workspace IN clause: `alias.workspaceId IN (:...aaiWsIds)`
- For find methods: upgrades existing `workspaceId` in options to `In(workspaceIds)`
- Logs warning when workspace filter format is unexpected (with debug enabled)

### AAI Files (145 lines, 3 files)
| File | Lines | Purpose |
|------|-------|---------|
| `context.ts` | 20 | Config + AsyncLocalStorage + debug logging |
| `middleware.ts` | 30 | Request context middleware with error handling |
| `repository.ts` | 95 | Smart Repository Decorator + init |

### Configuration
| Variable | Default | Description |
|----------|---------|-------------|
| `AAI_MULTI_WORKSPACE_SHARING` | `false` | Set to `true` to enable feature |
| `AAI_SHARED_WORKSPACE_NAME` | `Default Workspace` | Name of the shared workspace |
| `AAI_WORKSPACE_DEBUG` | `false` | Set to `true` for debug logging |

## Test Plan

- [ ] Set `AAI_MULTI_WORKSPACE_SHARING=true`
- [ ] Login as user with Personal Workspace
- [ ] Navigate to Chatflows list
- [ ] Verify chatflows from Default Workspace are visible
- [ ] Set `AAI_WORKSPACE_DEBUG=true`
- [ ] Check logs for filter upgrade messages

## Backwards Compatibility

✅ **Fully backwards compatible:**
- Feature **disabled by default** (must explicitly enable with `AAI_MULTI_WORKSPACE_SHARING=true`)
- No service file changes
- Single-workspace users unaffected
- Original workspace filtering preserved when feature disabled
- Graceful error handling (continues without multi-workspace on errors)

## Critical Issues Addressed

- ✅ Feature flag now disabled by default (`=== 'true'` instead of `!== 'false'`)
- ✅ Environment variable naming consistent (`AAI_SHARED_WORKSPACE_NAME`)
- ✅ Error handling added to middleware (try-catch with graceful fallback)
- ✅ Debug logging infrastructure added (`AAI_WORKSPACE_DEBUG`)
- ✅ Middleware ordering documented in index.ts
- ✅ Warning logged when shared workspace not found

## Related

- Linear: [AGENT-610](https://linear.app/answerai/issue/AGENT-610)