### PR TITLE
fix(AGENT-615): remove duplicate Add New Field button in User Variables

### DIFF
--- a/packages-answers/ui/src/UserProfile/UserProfile.tsx
+++ b/packages-answers/ui/src/UserProfile/UserProfile.tsx
@@ -618,11 +618,6 @@ const UserProfile = ({ appSettings: _appSettings, user }: { appSettings?: AppSet
                             </Table>
                         </TableContainer>
                     </Grid>
-                    <Grid item sm={12} sx={{ textAlign: 'right' }}>
-                        <Button variant='outlined' onClick={handleAddNewField}>
-                            Add New Field
-                        </Button>
-                    </Grid>
                 </Grid>
                 {/* Need to check both because the context fields don't trigger dirtyFields unless a new one is added */}
                 <Box sx={{ display: 'flex', gap: 1 }}>


### PR DESCRIPTION
## Summary
- Removes duplicate "Add New Field" button from User Variables section
- Keeps the button above the table (standard UI pattern for action buttons near section heading)
- Better visibility before scrolling and consistent with other table interfaces

## Test plan
- [ ] Verify only ONE "Add New Field" button is visible in User Variables section
- [ ] Click button adds new field row correctly
- [ ] Form submission works as expected

Fixes AGENT-615