### PR TITLE
fix(AGENT-609): add missing handleTabChange function to Variables page

### DIFF
--- a/packages/ui/src/views/variables/index.jsx
+++ b/packages/ui/src/views/variables/index.jsx
@@ -93,6 +93,9 @@ const Variables = () => {
     const [variables, setVariables] = useState([])
     const [showHowToDialog, setShowHowToDialog] = useState(false)
     const [tabValue, setTabValue] = useState(0)
+    const handleTabChange = (event, newValue) => {
+        setTabValue(newValue)
+    }
     const { hasFeature } = usePermissions()
     const isAdmin = hasFeature('org:manage')
     const [myVariables, setMyVariables] = useState([])


### PR DESCRIPTION
## Summary
- Adds missing `handleTabChange` function to Variables page that was causing "handleTabChange is not defined" error
- The Tabs component at line 259 referenced this handler but it was never defined

## Test plan
- [ ] Navigate to Variables page - should load without errors
- [ ] Switch between "My Variables" and "Organization Variables" tabs (as admin)
- [ ] Verify tab switching works correctly