### PR TITLE
fix(AGENT-597): correct z-index values so modals render above drawer

### DIFF
--- a/packages-answers/ui/src/AppDrawer.tsx
+++ b/packages-answers/ui/src/AppDrawer.tsx
@@ -608,7 +608,7 @@ export const AppDrawer = ({ session }: AppDrawerProps) => {
                 open={drawerOpen}
                 variant='permanent'
                 className={drawerOpen ? 'MuiDrawer-open' : 'MuiDrawer-closed'}
-                sx={{ zIndex: 2000 }}
+                sx={{ zIndex: 1200 }}
             >
                 <Box
                     sx={{
@@ -920,12 +920,12 @@ export const AppDrawer = ({ session }: AppDrawerProps) => {
                                 slotProps={{
                                     root: {
                                         sx: {
-                                            zIndex: 3000
+                                            zIndex: 1400
                                         }
                                     },
                                     paper: {
                                         sx: {
-                                            zIndex: 3000,
+                                            zIndex: 1400,
                                             minWidth: 220,
                                             maxHeight: 'calc(100vh - 100px)'
                                         }


### PR DESCRIPTION
## Summary
- Updates AppDrawer z-index from 2000 to 1200 (MUI drawer standard)
- Updates user menu z-index from 3000 to 1400 (above modal for dropdown behavior)
- Ensures modals (z-index 1300) render above the drawer

## Why These Values
Aligns with MUI's standard z-index scale:
- drawer: 1200 (below modal)
- modal: 1300 (above drawer)
- menu: 1400 (above modal for proper dropdown behavior)

## Test Plan
- [ ] Open a modal while drawer is visible - modal should appear above drawer
- [ ] Drawer should be behind modal backdrop when modal is open
- [ ] User menu in drawer still renders above drawer content

Fixes AGENT-597