### PR TITLE
fix(AGENT-614): use useParams for dataset ID extraction

### DIFF
--- a/packages/ui/src/views/datasets/DatasetItems.jsx
+++ b/packages/ui/src/views/datasets/DatasetItems.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { useParams } from 'react-router-dom'
 
 // material-ui
 import {
@@ -74,8 +75,7 @@ const EvalDatasetRows = () => {
     const getDatasetRows = useApi(datasetsApi.getDataset)
     const reorderDatasetRowApi = useApi(datasetsApi.reorderDatasetRow)
 
-    const URLpath = document.location.pathname.toString().split('/')
-    const datasetId = URLpath[URLpath.length - 1] === 'dataset_rows' ? '' : URLpath[URLpath.length - 1]
+    const { id: datasetId } = useParams()
 
     const { hasPermission } = useAuth()
 
@@ -89,6 +89,12 @@ const EvalDatasetRows = () => {
     const [currentPage, setCurrentPage] = useState(1)
     const [pageLimit, setPageLimit] = useState(DEFAULT_ITEMS_PER_PAGE)
     const [total, setTotal] = useState(0)
+
+    // Early return if datasetId is invalid (after all hooks)
+    if (!datasetId) {
+        console.error('Invalid dataset ID')
+        return null
+    }
     const onChange = (page, pageLimit) => {
         setCurrentPage(page)
         setPageLimit(pageLimit)


### PR DESCRIPTION
## Summary
- Replace URL string parsing with React Router's `useParams()` hook for dataset ID extraction
- Add early return validation if datasetId is invalid
- Fixes 500 error on client-side navigation from datasets list to dataset rows

## Root Cause
Component was using `document.location.pathname.toString().split('/')` which fails during client-side navigation because it reads the URL before React Router updates it.

## Changes
- Added `useParams` import from `react-router-dom`
- Replaced URL parsing logic with `const { id: datasetId } = useParams()`
- Added validation check after all hooks (to comply with Rules of Hooks)

## Test Plan
- [ ] Client-side navigation from datasets list to dataset rows works
- [ ] Page refresh still works
- [ ] No 500 error on navigation
- [ ] Correct dataset rows are displayed

Linear: AGENT-614