### PR TITLE
fix(AGENT-588): fix tab images in AddNodes

### DIFF
--- a/packages/ui/src/views/canvas/AddNodes.jsx
+++ b/packages/ui/src/views/canvas/AddNodes.jsx
@@ -369,8 +369,15 @@ const AddNodes = ({ nodesData, node, isAgentCanvas, isAgentflowv2, onFlowGenerat
         } else {
             img = utilNodesPNG // Utilities and Tools tab
         }
-        // Handle both Next.js (object with src) and Vite (string) image imports
-        return typeof img === 'object' && img?.src ? img.src : img
+        // Handle various import formats from transpiled packages
+        if (typeof img === 'string') return img
+        if (img && typeof img === 'object') {
+            if (img.src) return img.src
+            if (img.default?.src) return img.default.src
+            if (typeof img.default === 'string') return img.default
+        }
+        console.warn(`[AddNodes] Unable to extract image URL from:`, img)
+        return ''
     }
 
     const renderIcon = (node) => {


### PR DESCRIPTION
## Summary
- Fix broken tab images in AddNodes.jsx when clicking + to add nodes
- Handle various ESM import formats from transpiled packages
- The `transpilePackages: ['ui']` config processes imports before webpack rules apply

## Changes
Enhanced `getImage()` function to handle:
- Direct string imports
- Object with `src` property
- Nested `default.src` structure
- Nested `default` string

## Test plan
- [ ] Open canvas editor
- [ ] Click + to add nodes
- [ ] Verify tab images render correctly (AAI, LangChain, LlamaIndex, Utilities)

Closes AGENT-588