### PR TITLE
fix(AGENT-589): Prevent cross-workspace chat data leak [SECURITY]

### DIFF
--- a/packages/server/src/services/chats/index.ts
+++ b/packages/server/src/services/chats/index.ts
@@ -24,11 +24,8 @@ const getAllChats = async (user: IUser, options: PaginationOptions = {}) => {
     try {
         const appServer = getRunningExpressApp()
 
-        // Get user's assigned workspace IDs for workspace-based access
-        const workspaceIds = user.assignedWorkspaces?.map((ws) => ws.id) || []
-
         // Build query to fetch chats accessible via:
-        // 1. Workspace membership (chatflow.workspaceId in user's workspaces)
+        // 1. Active workspace (chatflow.workspaceId matches user's active workspace)
         // 2. Legacy userId ownership (ownerId matches user.id)
         const queryBuilder = appServer.AppDataSource.getRepository(Chat)
             .createQueryBuilder('chat')
@@ -36,14 +33,15 @@ const getAllChats = async (user: IUser, options: PaginationOptions = {}) => {
             .where('chat.chatflowChatId IS NOT NULL')
             .andWhere('chat.organizationId = :organizationId', { organizationId: user.organizationId })
 
-        // Access control: workspace membership OR legacy userId ownership
-        if (workspaceIds.length > 0) {
+        // Access control: Filter by ACTIVE workspace only (security fix for cross-workspace leak)
+        if (user.activeWorkspaceId) {
+            // Show chats from active workspace OR user's own chats (legacy ownership)
             queryBuilder.andWhere(
-                '(chatflow.workspaceId IN (:...workspaceIds) OR chat.ownerId = :userId)',
-                { workspaceIds, userId: user.id }
+                '(chatflow.workspaceId = :activeWorkspaceId OR chat.ownerId = :userId)',
+                { activeWorkspaceId: user.activeWorkspaceId, userId: user.id }
             )
         } else {
-            // Fallback to legacy userId-only access if no workspaces assigned
+            // Fallback to legacy userId-only access if no active workspace
             queryBuilder.andWhere('chat.ownerId = :userId', { userId: user.id })
         }
 
@@ -66,24 +64,22 @@ const getChatById = async (chatId: string, user: IUser) => {
     try {
         const appServer = getRunningExpressApp()
 
-        // Get user's assigned workspace IDs for workspace-based access
-        const workspaceIds = user.assignedWorkspaces?.map((ws) => ws.id) || []
-
-        // Build query with workspace-based OR legacy userId access control
+        // Build query with active workspace OR legacy userId access control
         const queryBuilder = appServer.AppDataSource.getRepository(Chat)
             .createQueryBuilder('chat')
             .leftJoinAndSelect('chat.chatflow', 'chatflow')
             .where('chat.id = :chatId', { chatId })
             .andWhere('chat.organizationId = :organizationId', { organizationId: user.organizationId })
 
-        // Access control: workspace membership OR legacy userId ownership
-        if (workspaceIds.length > 0) {
+        // Access control: Filter by ACTIVE workspace only (security fix for cross-workspace leak)
+        if (user.activeWorkspaceId) {
+            // Allow access to chat from active workspace OR user's own chat (legacy ownership)
             queryBuilder.andWhere(
-                '(chatflow.workspaceId IN (:...workspaceIds) OR chat.ownerId = :userId)',
-                { workspaceIds, userId: user.id }
+                '(chatflow.workspaceId = :activeWorkspaceId OR chat.ownerId = :userId)',
+                { activeWorkspaceId: user.activeWorkspaceId, userId: user.id }
             )
         } else {
-            // Fallback to legacy userId-only access if no workspaces assigned
+            // Fallback to legacy userId-only access if no active workspace
             queryBuilder.andWhere('chat.ownerId = :userId', { userId: user.id })
         }
 


### PR DESCRIPTION
## Summary
**🚨 SECURITY FIX:** Prevents chat messages from being visible across workspaces.

### Root Cause
The chat service was filtering by `user.assignedWorkspaces` (ALL workspaces the user has access to) instead of `user.activeWorkspaceId` (the currently selected workspace). This caused chats from all workspaces to be visible regardless of which workspace was active.

### Changes
- `getAllChats`: Now filters by `activeWorkspaceId` instead of all assigned workspaces
- `getChatById`: Same fix applied for consistency
- Preserves fallback to userId-only access for backwards compatibility

### Files Changed
- `packages/server/src/services/chats/index.ts`

## Test Plan
- [ ] Switch between workspaces and verify only current workspace chats are visible
- [ ] Verify chat history clears/refreshes on workspace switch
- [ ] Verify users can still see their own chats (ownerId match)
- [ ] Verify no regression in chat functionality

## Linear
Fixes AGENT-589