### PR TITLE
fix(AGENT-617): Fix Google Drive document loader ReferenceError

### DIFF
--- a/packages/ui/src/views/canvas/NodeInputHandler.jsx
+++ b/packages/ui/src/views/canvas/NodeInputHandler.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { Handle, Position, useUpdateNodeInternals } from 'reactflow'
-import { useEffect, useRef, useState, useContext } from 'react'
+import { useEffect, useRef, useState, useContext, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { cloneDeep } from 'lodash'
 import showdown from 'showdown'
@@ -166,6 +166,14 @@ const NodeInputHandler = ({
 
     const [promptGeneratorDialogOpen, setPromptGeneratorDialogOpen] = useState(false)
     const [promptGeneratorDialogProps, setPromptGeneratorDialogProps] = useState({})
+
+    // State for Google Drive/Gmail credential handling
+    const [selectedCredential, setSelectedCredential] = useState(data.credential || null)
+    const [selectedCredentialData, setSelectedCredentialData] = useState(null)
+
+    const handleCredentialDataChange = useCallback((credData) => {
+        setSelectedCredentialData(credData)
+    }, [])
 
     const handleDataChange = ({ inputParam, newValue }) => {
         data.inputs[inputParam.name] = newValue
@@ -983,6 +991,8 @@ const NodeInputHandler = ({
                                 onSelect={(newValue) => {
                                     data.credential = newValue
                                     data.inputs[FLOWISE_CREDENTIAL_ID] = newValue // in case data.credential is not updated
+                                    setSelectedCredential(newValue)
+                                    setSelectedCredentialData(null) // Reset credential data when credential changes
                                 }}
                             />
                         )}

--- a/packages/ui/src/views/docstore/DocStoreInputHandler.jsx
+++ b/packages/ui/src/views/docstore/DocStoreInputHandler.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useState, useContext } from 'react'
+import { useState, useContext, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 
 // material-ui
@@ -42,6 +42,12 @@ const DocStoreInputHandler = ({ inputParam, data, disabled = false, onNodeDataCh
     const [showManageScrapedLinksDialog, setShowManageScrapedLinksDialog] = useState(false)
     const [manageScrapedLinksDialogProps, setManageScrapedLinksDialogProps] = useState({})
     const [reloadTimestamp, setReloadTimestamp] = useState(Date.now().toString())
+    const [selectedCredential, setSelectedCredential] = useState(null)
+    const [selectedCredentialData, setSelectedCredentialData] = useState(null)
+
+    const handleCredentialDataChange = useCallback((credData) => {
+        setSelectedCredentialData(credData)
+    }, [])
 
     const handleDataChange = ({ inputParam, newValue }) => {
         data.inputs[inputParam.name] = newValue
@@ -150,9 +156,8 @@ const DocStoreInputHandler = ({ inputParam, data, disabled = false, onNodeDataCh
                                 onSelect={(newValue) => {
                                     data.credential = newValue
                                     data.inputs[FLOWISE_CREDENTIAL_ID] = newValue // in case data.credential is not updated
-                                    if (handleCredentialChange) {
-                                        handleCredentialChange(newValue)
-                                    }
+                                    setSelectedCredential(newValue)
+                                    setSelectedCredentialData(null) // Reset credential data when credential changes
                                 }}
                             />
                         )}

--- a/packages/ui/src/views/docstore/DocStoreInputHandler.jsx
+++ b/packages/ui/src/views/docstore/DocStoreInputHandler.jsx
@@ -42,7 +42,7 @@ const DocStoreInputHandler = ({ inputParam, data, disabled = false, onNodeDataCh
     const [showManageScrapedLinksDialog, setShowManageScrapedLinksDialog] = useState(false)
     const [manageScrapedLinksDialogProps, setManageScrapedLinksDialogProps] = useState({})
     const [reloadTimestamp, setReloadTimestamp] = useState(Date.now().toString())
-    const [selectedCredential, setSelectedCredential] = useState(null)
+    const [selectedCredential, setSelectedCredential] = useState(data.credential || null)
     const [selectedCredentialData, setSelectedCredentialData] = useState(null)
 
     const handleCredentialDataChange = useCallback((credData) => {


### PR DESCRIPTION
## Summary

Fixes `ReferenceError: selectedCredential is not defined` error that occurs when adding Google Drive as a document loader in the DocStore.

## Problem

The `DocStoreInputHandler.jsx` component was referencing undefined variables:
- `selectedCredential` - used by GoogleDrivePicker and GmailLabelPicker
- `selectedCredentialData` - used by both pickers
- `handleCredentialDataChange` - callback function for credential data updates
- `handleCredentialChange` - undefined function reference in onSelect callback

## Solution

1. Added missing state variables:
   - `selectedCredential` - tracks the selected credential ID
   - `selectedCredentialData` - tracks the credential data object

2. Added `handleCredentialDataChange` callback using `useCallback` to update credential data

3. Fixed the credential `onSelect` callback to:
   - Set `selectedCredential` state when credential changes
   - Reset `selectedCredentialData` to null when a new credential is selected

## Test Plan

- [ ] Select Google Drive as document loader - should not throw ReferenceError
- [ ] Select a credential for Google Drive - state should update properly
- [ ] Select Gmail as document loader - same fix applies
- [ ] Verify file picker opens after credential selection

## Linear Ticket

[AGENT-617](https://linear.app/answerai/issue/AGENT-617)