### PR TITLE
fix(AGENT-589): add user ownership filter to chat queries

### DIFF
--- a/packages/server/src/services/chats/index.ts
+++ b/packages/server/src/services/chats/index.ts
@@ -33,9 +33,11 @@ const getAllChats = async (user: IUser, options: PaginationOptions = {}) => {
             .where('chat.chatflowChatId IS NOT NULL')
             .andWhere('chat.organizationId = :organizationId', { organizationId: user.organizationId })
 
-        // SECURITY FIX (AGENT-589): Filter by ACTIVE workspace ONLY
-        // All users (including admins) see only chats from the current workspace
-        // This prevents cross-workspace data leakage
+        // SECURITY FIX (AGENT-589): Filter by user ownership AND active workspace
+        // Users only see their own chats in the current workspace
+        // This prevents cross-user and cross-workspace data leakage
+        queryBuilder.andWhere('chat.ownerId = :userId', { userId: user.id })
+
         if (user.activeWorkspaceId) {
             queryBuilder.andWhere('chatflow.workspaceId = :activeWorkspaceId', {
                 activeWorkspaceId: user.activeWorkspaceId
@@ -71,9 +73,11 @@ const getChatById = async (chatId: string, user: IUser) => {
             .where('chat.id = :chatId', { chatId })
             .andWhere('chat.organizationId = :organizationId', { organizationId: user.organizationId })
 
-        // SECURITY FIX (AGENT-589): Filter by ACTIVE workspace ONLY
-        // All users (including admins) can only access chats from the current workspace
-        // This prevents cross-workspace data leakage
+        // SECURITY FIX (AGENT-589): Filter by user ownership AND active workspace
+        // Users can only access their own chats in the current workspace
+        // This prevents cross-user and cross-workspace data leakage
+        queryBuilder.andWhere('chat.ownerId = :userId', { userId: user.id })
+
         if (user.activeWorkspaceId) {
             queryBuilder.andWhere('chatflow.workspaceId = :activeWorkspaceId', {
                 activeWorkspaceId: user.activeWorkspaceId


### PR DESCRIPTION
## Summary
- Added `ownerId` filter to `getAllChats` and `getChatById` queries
- Users now only see their own chats within their active workspace
- Prevents cross-user data leakage in shared workspaces (e.g., Default Workspace)

## Problem
After switching workspaces, users could see ALL chats in that workspace, including chats belonging to other users. This was especially visible in the Default Workspace where multiple users have chats.

## Solution
Added `chat.ownerId = :userId` filter to both chat query methods:
- `getAllChats()` - Used by chat drawer/sidebar
- `getChatById()` - Used when accessing individual chats

## Test plan
- [ ] Switch to Default Workspace with multiple users
- [ ] Verify chat drawer only shows current user's chats
- [ ] Verify other users' chats are not visible
- [ ] Verify chat access by ID is also restricted to owner