### PR TITLE
fix(AGENT-593): preserve chatflow configuration during import/export

### DIFF
--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -162,6 +162,31 @@ const AgentflowCanvas = ({ chatflowid: chatflowId }) => {
 
             setNodes(nodes)
             setEdges(flowData.edges || [])
+
+            // Preserve chatflow configuration settings from imported file
+            // These include: chatbotConfig, speechToText, textToSpeech, followUpPrompts, apiConfig, analytic
+            const configFields = {
+                name: flowData.name,
+                description: flowData.description,
+                category: flowData.category,
+                chatbotConfig: flowData.chatbotConfig,
+                speechToText: flowData.speechToText,
+                textToSpeech: flowData.textToSpeech,
+                followUpPrompts: flowData.followUpPrompts,
+                apiConfig: flowData.apiConfig,
+                analytic: flowData.analytic,
+                type: flowData.type
+            }
+
+            // Update chatflow in redux store with configuration from imported file
+            dispatch({
+                type: SET_CHATFLOW,
+                chatflow: {
+                    ...chatflow,
+                    ...configFields
+                }
+            })
+
             setTimeout(() => setDirty(), 0)
         } catch (e) {
             console.error(e)

--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -164,19 +164,17 @@ const AgentflowCanvas = ({ chatflowid: chatflowId }) => {
             setEdges(flowData.edges || [])
 
             // Preserve chatflow configuration settings from imported file
-            // These include: chatbotConfig, speechToText, textToSpeech, followUpPrompts, apiConfig, analytic
-            const configFields = {
-                name: flowData.name,
-                description: flowData.description,
-                category: flowData.category,
-                chatbotConfig: flowData.chatbotConfig,
-                speechToText: flowData.speechToText,
-                textToSpeech: flowData.textToSpeech,
-                followUpPrompts: flowData.followUpPrompts,
-                apiConfig: flowData.apiConfig,
-                analytic: flowData.analytic,
-                type: flowData.type
-            }
+            // Only include fields that are actually defined to avoid overwriting existing values with undefined
+            const configFieldKeys = [
+                'name', 'description', 'category', 'chatbotConfig', 'visibility',
+                'speechToText', 'textToSpeech', 'followUpPrompts', 'apiConfig', 'analytic', 'type'
+            ]
+            const configFields = configFieldKeys.reduce((acc, key) => {
+                if (flowData[key] !== undefined) {
+                    acc[key] = flowData[key]
+                }
+                return acc
+            }, {})
 
             // Update chatflow in redux store with configuration from imported file
             dispatch({

--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -167,7 +167,8 @@ const AgentflowCanvas = ({ chatflowid: chatflowId }) => {
             // Only include fields that are actually defined to avoid overwriting existing values with undefined
             const configFieldKeys = [
                 'name', 'description', 'category', 'chatbotConfig', 'visibility',
-                'speechToText', 'textToSpeech', 'followUpPrompts', 'apiConfig', 'analytic', 'type'
+                'speechToText', 'textToSpeech', 'followUpPrompts', 'apiConfig', 'analytic', 'type',
+                'answersConfig', 'browserExtConfig'
             ]
             const configFields = configFieldKeys.reduce((acc, key) => {
                 if (flowData[key] !== undefined) {

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -172,6 +172,31 @@ const Canvas = ({ chatflowid: chatflowId }) => {
 
             setNodes(nodes)
             setEdges(flowData.edges || [])
+
+            // Preserve chatflow configuration settings from imported file
+            // These include: chatbotConfig, speechToText, textToSpeech, followUpPrompts, apiConfig, analytic
+            const configFields = {
+                name: flowData.name,
+                description: flowData.description,
+                category: flowData.category,
+                chatbotConfig: flowData.chatbotConfig,
+                speechToText: flowData.speechToText,
+                textToSpeech: flowData.textToSpeech,
+                followUpPrompts: flowData.followUpPrompts,
+                apiConfig: flowData.apiConfig,
+                analytic: flowData.analytic,
+                type: flowData.type
+            }
+
+            // Update chatflow in redux store with configuration from imported file
+            dispatch({
+                type: SET_CHATFLOW,
+                chatflow: {
+                    ...chatflow,
+                    ...configFields
+                }
+            })
+
             setTimeout(() => setDirty(), 0)
         } catch (e) {
             console.error(e)

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -174,19 +174,17 @@ const Canvas = ({ chatflowid: chatflowId }) => {
             setEdges(flowData.edges || [])
 
             // Preserve chatflow configuration settings from imported file
-            // These include: chatbotConfig, speechToText, textToSpeech, followUpPrompts, apiConfig, analytic
-            const configFields = {
-                name: flowData.name,
-                description: flowData.description,
-                category: flowData.category,
-                chatbotConfig: flowData.chatbotConfig,
-                speechToText: flowData.speechToText,
-                textToSpeech: flowData.textToSpeech,
-                followUpPrompts: flowData.followUpPrompts,
-                apiConfig: flowData.apiConfig,
-                analytic: flowData.analytic,
-                type: flowData.type
-            }
+            // Only include fields that are actually defined to avoid overwriting existing values with undefined
+            const configFieldKeys = [
+                'name', 'description', 'category', 'chatbotConfig', 'visibility',
+                'speechToText', 'textToSpeech', 'followUpPrompts', 'apiConfig', 'analytic', 'type'
+            ]
+            const configFields = configFieldKeys.reduce((acc, key) => {
+                if (flowData[key] !== undefined) {
+                    acc[key] = flowData[key]
+                }
+                return acc
+            }, {})
 
             // Update chatflow in redux store with configuration from imported file
             dispatch({

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -177,7 +177,8 @@ const Canvas = ({ chatflowid: chatflowId }) => {
             // Only include fields that are actually defined to avoid overwriting existing values with undefined
             const configFieldKeys = [
                 'name', 'description', 'category', 'chatbotConfig', 'visibility',
-                'speechToText', 'textToSpeech', 'followUpPrompts', 'apiConfig', 'analytic', 'type'
+                'speechToText', 'textToSpeech', 'followUpPrompts', 'apiConfig', 'analytic', 'type',
+                'answersConfig', 'browserExtConfig'
             ]
             const configFields = configFieldKeys.reduce((acc, key) => {
                 if (flowData[key] !== undefined) {


### PR DESCRIPTION
## Summary
- Fixed chatflow import to preserve configuration settings that were being lost
- Configuration fields now restored: chatbotConfig, speechToText, textToSpeech, followUpPrompts, apiConfig, analytic
- Applied fix to both regular canvas and agentflowsv2 Canvas

## Problem
When users export a chatflow and import it via Settings > Load Chatflow, the chatflow configuration settings were NOT preserved. Users would lose:
- Follow-up prompts
- Speech-to-text settings
- Text-to-speech settings
- Analytics configuration
- API configuration
- AnswerAI-specific configuration

## Solution
Updated the `handleLoadFlow` function in both canvas components to:
1. Extract configuration fields from the imported JSON
2. Dispatch these fields to the Redux store along with nodes/edges

## Test plan
- [ ] Export a chatflow with configuration settings (follow-up prompts, speech-to-text, etc.)
- [ ] Create a new chatflow and import the exported JSON
- [ ] Verify configuration settings are preserved after import
- [ ] Test with agentflowsv2 canvas as well