### PR TITLE
fix(AGENT-612): fix broken agent avatar images in canvas chat

### DIFF
--- a/packages/ui/src/views/chatmessage/AgentReasoningCard.jsx
+++ b/packages/ui/src/views/chatmessage/AgentReasoningCard.jsx
@@ -1,7 +1,10 @@
+import { useState, useCallback } from 'react'
 import { Box, Card, CardContent, Chip, Stack } from '@mui/material'
 import { IconTool, IconDeviceSdCard } from '@tabler/icons-react'
 import { MemoizedReactMarkdown } from '@/ui-component/markdown/MemoizedReactMarkdown'
 import nextAgentGIF from '@/assets/images/next-agent.gif'
+import multiagent_supervisorPNG from '@/assets/images/multiagent_supervisor.png'
+import multiagent_workerPNG from '@/assets/images/multiagent_worker.png'
 import PropTypes from 'prop-types'
 
 const AgentReasoningCard = ({
@@ -19,6 +22,18 @@ const AgentReasoningCard = ({
     onURLClick,
     getLabel
 }) => {
+    // Fallback image based on agent type (supervisor has instructions)
+    const fallbackIcon = agent.instructions ? multiagent_supervisorPNG : multiagent_workerPNG
+    const [iconSrc, setIconSrc] = useState(getAgentIcon(agent.nodeName, agent.instructions))
+    const [hasError, setHasError] = useState(false)
+
+    const handleImageError = useCallback(() => {
+        if (!hasError) {
+            setHasError(true)
+            setIconSrc(fallbackIcon)
+        }
+    }, [hasError, fallbackIcon])
+
     if (agent.nextAgent) {
         return (
             <Card
@@ -77,8 +92,9 @@ const AgentReasoningCard = ({
                                 height: '25px',
                                 width: 'auto'
                             }}
-                            src={getAgentIcon(agent.nodeName, agent.instructions)}
+                            src={iconSrc}
                             alt='agentPNG'
+                            onError={handleImageError}
                         />
                     </Box>
                     <div>{agent.agentName}</div>


### PR DESCRIPTION
## Summary

**Problem:** Agent avatar images were not displaying properly in the `AgentReasoningCard` component when agents responded in canvas chat. The `getAgentIcon()` function was returning API URLs that could fail to load (404 or network errors), causing broken images.

**Solution:** Added fallback handling in `AgentReasoningCard.jsx`:

1. **Imported fallback images:** Added imports for `multiagent_supervisorPNG` and `multiagent_workerPNG` static assets
2. **Added state management:** Used `useState` to track the icon source and error state
3. **Created error handler:** Added `handleImageError` callback using `useCallback` that:
   - Detects when the API-provided icon fails to load
   - Switches to appropriate fallback based on agent type (supervisor vs worker)
   - Prevents infinite loops with the `hasError` flag
4. **Updated img element:** Added `onError={handleImageError}` to the image element

### Key Changes
```jsx
const fallbackIcon = agent.instructions ? multiagent_supervisorPNG : multiagent_workerPNG
const [iconSrc, setIconSrc] = useState(getAgentIcon(agent.nodeName, agent.instructions))
const [hasError, setHasError] = useState(false)

const handleImageError = useCallback(() => {
    if (!hasError) {
        setHasError(true)
        setIconSrc(fallbackIcon)
    }
}, [hasError, fallbackIcon])

<img src={iconSrc} alt='agentPNG' onError={handleImageError} />
```

### Test Plan
- [ ] Open a chatflow with agents
- [ ] Trigger agent response
- [ ] Verify avatar images display correctly
- [ ] Test with network throttling to verify fallback works

Fixes AGENT-612