### PR TITLE
fix: prevent config tabs errors on unsaved/imported chatflows

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -175,6 +175,7 @@ const saveChatflow = async (req: Request, res: Response, next: NextFunction) => 
         const newChatFlow = new ChatFlow()
         Object.assign(newChatFlow, body)
         newChatFlow.workspaceId = workspaceId
+        newChatFlow.organizationId = orgId
         const apiResponse = await chatflowsService.saveChatflow(
             newChatFlow,
             orgId,

--- a/packages/ui/src/ui-component/extended/ChatflowGuardrails.jsx
+++ b/packages/ui/src/ui-component/extended/ChatflowGuardrails.jsx
@@ -37,7 +37,10 @@ const ChatflowGuardrails = ({ dialogProps }) => {
     // Load organization config
     useEffect(() => {
         const loadOrgConfig = async () => {
-            if (!dialogProps.chatflow?.organizationId) return
+            if (!dialogProps.chatflow?.organizationId) {
+                setLoadingOrgConfig(false)
+                return
+            }
 
             try {
                 setLoadingOrgConfig(true)

--- a/packages/ui/src/ui-component/extended/OverrideConfig.jsx
+++ b/packages/ui/src/ui-component/extended/OverrideConfig.jsx
@@ -335,7 +335,7 @@ const OverrideConfig = ({ dialogProps }) => {
     }
 
     useEffect(() => {
-        if (dialogProps.chatflow) {
+        if (dialogProps.chatflow?.id) {
             getConfigApi.request(dialogProps.chatflow.id)
             getAllVariablesApi.request()
         }


### PR DESCRIPTION
## Summary
Fixes configuration dialog errors when opening tabs on unsaved or imported chatflows.

## Issues Fixed

### 1. organizationId not set when saving chatflows
- **File:** `packages/server/src/controllers/chatflows/index.ts`
- **Issue:** Backend receives `orgId` but wasn't setting it on the ChatFlow entity
- **Fix:** Added `newChatFlow.organizationId = orgId` when creating chatflows
- **Impact:** Guardrails tab can now load org config correctly

### 2. Guardrails tab infinite loading
- **File:** `ChatflowGuardrails.jsx`
- **Issue:** When `organizationId` is undefined, `loadOrgConfig` returned early without setting `loadingOrgConfig` to `false`
- **Fix:** Added `setLoadingOrgConfig(false)` before early return

### 3. Security tab 500 error (`/flow-config/undefined`)
- **File:** `OverrideConfig.jsx`
- **Issue:** Called `getConfigApi.request(dialogProps.chatflow.id)` when `id` is undefined
- **Fix:** Changed condition from `if (dialogProps.chatflow)` to `if (dialogProps.chatflow?.id)`
- **Note:** This bug also exists in upstream Flowise

## Test plan
- [ ] Import a chatflow file
- [ ] Save the chatflow
- [ ] Open Settings → Guardrails tab - should load org config correctly
- [ ] Open Settings → Security tab - should not throw 500 error