### PR TITLE
fix(AGENT-620): remove email unique constraint from user table

### DIFF
--- a/packages/server/src/enterprise/database/entities/user.entity.ts
+++ b/packages/server/src/enterprise/database/entities/user.entity.ts
@@ -21,7 +21,7 @@ export class User {
     @Column({ type: 'varchar', length: 100 })
     name: string
 
-    @Column({ type: 'varchar', length: 255, unique: true })
+    @Column({ type: 'varchar', length: 255 })
     email: string
 
     @Column({ type: 'text', nullable: true })

--- a/packages/server/src/enterprise/database/migrations/postgres/1737076223692-RefactorEnterpriseDatabase.ts
+++ b/packages/server/src/enterprise/database/migrations/postgres/1737076223692-RefactorEnterpriseDatabase.ts
@@ -22,7 +22,7 @@ export class RefactorEnterpriseDatabase1737076223692 implements MigrationInterfa
             create table "user" (
                 "id" uuid default uuid_generate_v4() primary key,
                 "name" varchar(100) not null,
-                "email" varchar(255) not null unique,
+                "email" varchar(255) not null,
                 "credential" text null,
                 "tempToken" text null,
                 "tokenExpiry" timestamp null,


### PR DESCRIPTION
## Summary
- Remove email unique constraint from user table migration
- AAI allows multiple user accounts with same email from different auth providers

## Linear
Closes AGENT-620

## Changes
- Migration: removed `unique` from email column definition
- Entity: removed `unique: true` from `@Column` decorator

## Impact
- **Production:** Migration hasn't run - will work correctly
- **Staging/Others:** Already ran - no impact