### PR TITLE
fix(SUPPORT-8): force Organization visibility for Fiddler credentials

### DIFF
--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -80,12 +80,13 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                 throw new Error('Failed to load Fiddler credential component')
             }
 
-            // Configure modal for ADD mode
+            // Configure modal for ADD mode with org visibility for shared credentials
             const dialogProps = {
                 type: 'ADD',
                 cancelButtonName: 'Cancel',
                 confirmButtonName: 'Add',
-                credentialComponent: componentCredential
+                credentialComponent: componentCredential,
+                defaultVisibility: ['Organization'] // AAI enhancement: force org visibility for Fiddler
             }
 
             setCredentialDialogProps(dialogProps)

--- a/packages/server/src/database/migrations/postgres/aai/1768413137117-UpdateFiddlerCredentialsVisibility.ts
+++ b/packages/server/src/database/migrations/postgres/aai/1768413137117-UpdateFiddlerCredentialsVisibility.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class UpdateFiddlerCredentialsVisibility1768413137117 implements MigrationInterface {
+    name = 'UpdateFiddlerCredentialsVisibility1768413137117'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Update all fiddlerApi credentials to Organization visibility
+        // This ensures guardrails credentials are visible to all org members
+        // The UI still allows selection when multiple credentials exist per org
+        await queryRunner.query(`
+            UPDATE "credential"
+            SET "visibility" = 'Organization'
+            WHERE "credentialName" = 'fiddlerApi'
+            AND "visibility" = 'Private'
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Revert to Private visibility (original default)
+        await queryRunner.query(`
+            UPDATE "credential"
+            SET "visibility" = 'Private'
+            WHERE "credentialName" = 'fiddlerApi'
+            AND "visibility" = 'Organization'
+        `)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -94,6 +94,7 @@ import { AAIRestoreDataAndCreateWorkspaces1737076223693 } from './aai/1737076223
 import { AAIBackfillWorkspaceId1760000000002 } from './aai/1760000000002-AAIBackfillWorkspaceId'
 import { AddOrganizationConfig1753200000001 } from './aai/1753200000001-AddOrganizationConfig'
 import { AddGuardrailsMetadataToChatMessage1753200000002 } from './aai/1753200000002-AddGuardrailsMetadataToChatMessage'
+import { UpdateFiddlerCredentialsVisibility1768413137117 } from './aai/1768413137117-UpdateFiddlerCredentialsVisibility'
 
 export const postgresMigrations = [
     Init1693891895163,
@@ -187,6 +188,7 @@ export const postgresMigrations = [
     AddTextToSpeechToChatFlow1754986480347,
     ModifyChatflowType1755066758601,
     AddChatFlowNameIndex1759424903973,
+    UpdateFiddlerCredentialsVisibility1768413137117,
     // AAI: Backfill workspaceId - runs LAST after all feature migrations
     AAIBackfillWorkspaceId1760000000002
 ]

--- a/packages/ui/src/views/credentials/AddEditCredentialDialog.jsx
+++ b/packages/ui/src/views/credentials/AddEditCredentialDialog.jsx
@@ -136,6 +136,10 @@ const AddEditCredentialDialog = ({ show, dialogProps, onCancel, onConfirm, setEr
             const defaultCredentialData = initializeDefaultNodeData(dialogProps.credentialComponent.inputs || [])
             setCredentialData(defaultCredentialData)
             setComponentCredential(dialogProps.credentialComponent)
+            // Support defaultVisibility prop for pre-configured visibility (e.g., org-wide credentials)
+            if (dialogProps.defaultVisibility) {
+                setVisibility(dialogProps.defaultVisibility)
+            }
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
Port of SUPPORT-5 fix to latest staging branch. Forces Organization visibility for Fiddler credentials so all org members can access guardrails settings.

## Problem
Fiddler credentials created by User A were not visible to User B in the same organization because:
1. Default visibility was `Private`
2. UI credential list filters by `visibility LIKE '%Organization%'`

## Changes

| File | Change |
|------|--------|
| `packages/ui/src/views/credentials/AddEditCredentialDialog.jsx` | Add `defaultVisibility` prop support |
| `packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx` | Pass `defaultVisibility: ['Organization']` |
| `packages/server/src/database/migrations/postgres/aai/1768413137117-*` | Migration to fix existing credentials |

## How It Works
1. **New credentials**: MasterConfig passes `defaultVisibility: ['Organization']` to credential dialog
2. **Existing credentials**: Migration updates Private → Organization visibility

## Test Plan
- [ ] Admin opens Guardrails Settings → clicks "Connect Fiddler"
- [ ] Creates credential → DB shows `visibility = 'Organization'`
- [ ] Different user in same org → can see credential in guardrails dropdown
- [ ] Existing Private fiddlerApi credentials → updated to Organization after migration

## Related
- Original PR: #842
- Original Ticket: SUPPORT-5

Linear: SUPPORT-8