### PR TITLE
fix(AGENT-630): handle invalid organizationId in AAI migration

### DIFF
--- a/packages/server/src/database/migrations/postgres/aai/1737076223690-BackupAAIData.ts
+++ b/packages/server/src/database/migrations/postgres/aai/1737076223690-BackupAAIData.ts
@@ -78,14 +78,17 @@ export class BackupAAIData1737076223690 implements MigrationInterface {
                 orgColumns.push('"organizationConfig"')
             }
 
-            // Backup AAI organization columns that exist
+            // Backup ALL organizations that are either:
+            // 1. Have auth0Id (AAI organizations)
+            // 2. Are referenced by any user's organizationId (to preserve user-org relationships)
             await queryRunner.query(`
                 CREATE TABLE IF NOT EXISTS "aai_organization_backup" AS
                 SELECT ${orgColumns.join(', ')}
                 FROM "organization"
-                WHERE "auth0Id" IS NOT NULL;
+                WHERE "auth0Id" IS NOT NULL
+                   OR id IN (SELECT DISTINCT "organizationId" FROM "user" WHERE "organizationId" IS NOT NULL);
             `)
-            console.log(`AAI Organization backup created with columns: ${orgColumns.join(', ')}`)
+            console.log(`AAI Organization backup created with columns: ${orgColumns.join(', ')} (includes all user-referenced orgs)`)
         } else {
             console.log('No auth0Id column found in organization table - skipping organization backup')
         }

--- a/packages/server/src/database/migrations/postgres/aai/1737076223693-AAIRestoreDataAndCreateWorkspaces.ts
+++ b/packages/server/src/database/migrations/postgres/aai/1737076223693-AAIRestoreDataAndCreateWorkspaces.ts
@@ -153,8 +153,9 @@ export class AAIRestoreDataAndCreateWorkspaces1737076223693 implements Migration
 
     /**
      * Fix users whose organizationId references a non-existent organization.
-     * These users will be assigned to a fallback organization to ensure they
-     * get proper workspace access.
+     * With the updated backup migration, all user-referenced orgs should be captured.
+     * This method provides a fallback for edge cases while logging warnings
+     * so Auth0 sync issues can be investigated.
      */
     private async fixInvalidOrganizationIds(queryRunner: QueryRunner): Promise<void> {
         console.log('Checking for users with invalid organizationId...')
@@ -168,11 +169,11 @@ export class AAIRestoreDataAndCreateWorkspaces1737076223693 implements Migration
         `)
 
         if (orphanedUsers.length === 0) {
-            console.log('No users with invalid organizationId found')
+            console.log('All user organizationId references are valid')
             return
         }
 
-        console.log(`Found ${orphanedUsers.length} users with invalid organizationId`)
+        console.warn(`WARNING: Found ${orphanedUsers.length} users with organizationId referencing non-existent organizations`)
 
         // Get a fallback organization (first valid org)
         const fallbackOrg = await queryRunner.query(`
@@ -180,16 +181,19 @@ export class AAIRestoreDataAndCreateWorkspaces1737076223693 implements Migration
         `)
 
         if (fallbackOrg.length === 0) {
-            console.log('No fallback organization available - cannot fix orphaned users')
+            console.warn('No fallback organization available - skipping orphaned users')
+            for (const user of orphanedUsers) {
+                console.warn(`  - User ${user.id} (${user.email}) references non-existent org ${user.organizationId}`)
+            }
             return
         }
 
         const fallbackOrgId = fallbackOrg[0].id
-        console.log(`Using fallback organization: ${fallbackOrgId}`)
+        console.warn(`Using fallback organization: ${fallbackOrgId}. Review Auth0 sync for these users:`)
 
         // Update orphaned users to use fallback organization
         for (const user of orphanedUsers) {
-            console.log(`Fixing user ${user.id} (${user.email}): ${user.organizationId} -> ${fallbackOrgId}`)
+            console.warn(`  - Fixing user ${user.id} (${user.email}): ${user.organizationId} -> ${fallbackOrgId}`)
             await queryRunner.query(
                 `UPDATE "user" SET "organizationId" = $1 WHERE id = $2`,
                 [fallbackOrgId, user.id]
@@ -204,7 +208,7 @@ export class AAIRestoreDataAndCreateWorkspaces1737076223693 implements Migration
             `, [fallbackOrgId, user.id])
         }
 
-        console.log(`Fixed ${orphanedUsers.length} users with invalid organizationId`)
+        console.warn(`Fixed ${orphanedUsers.length} users with invalid organizationId. These may indicate Auth0 sync issues.`)
     }
 
     // =========================================================================

--- a/packages/server/src/database/migrations/postgres/aai/1737076223693-AAIRestoreDataAndCreateWorkspaces.ts
+++ b/packages/server/src/database/migrations/postgres/aai/1737076223693-AAIRestoreDataAndCreateWorkspaces.ts
@@ -146,6 +146,65 @@ export class AAIRestoreDataAndCreateWorkspaces1737076223693 implements Migration
         }
 
         console.log('AAI data restore completed')
+
+        // Fix users with invalid organizationId (orphaned references)
+        await this.fixInvalidOrganizationIds(queryRunner)
+    }
+
+    /**
+     * Fix users whose organizationId references a non-existent organization.
+     * These users will be assigned to a fallback organization to ensure they
+     * get proper workspace access.
+     */
+    private async fixInvalidOrganizationIds(queryRunner: QueryRunner): Promise<void> {
+        console.log('Checking for users with invalid organizationId...')
+
+        // Find users whose organizationId doesn't exist in the organization table
+        const orphanedUsers = await queryRunner.query(`
+            SELECT u.id, u."organizationId", u.email
+            FROM "user" u
+            WHERE u."organizationId" IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM organization o WHERE o.id = u."organizationId")
+        `)
+
+        if (orphanedUsers.length === 0) {
+            console.log('No users with invalid organizationId found')
+            return
+        }
+
+        console.log(`Found ${orphanedUsers.length} users with invalid organizationId`)
+
+        // Get a fallback organization (first valid org)
+        const fallbackOrg = await queryRunner.query(`
+            SELECT id FROM organization ORDER BY "createdDate" ASC LIMIT 1
+        `)
+
+        if (fallbackOrg.length === 0) {
+            console.log('No fallback organization available - cannot fix orphaned users')
+            return
+        }
+
+        const fallbackOrgId = fallbackOrg[0].id
+        console.log(`Using fallback organization: ${fallbackOrgId}`)
+
+        // Update orphaned users to use fallback organization
+        for (const user of orphanedUsers) {
+            console.log(`Fixing user ${user.id} (${user.email}): ${user.organizationId} -> ${fallbackOrgId}`)
+            await queryRunner.query(
+                `UPDATE "user" SET "organizationId" = $1 WHERE id = $2`,
+                [fallbackOrgId, user.id]
+            )
+
+            // Also ensure they have an organization_user entry
+            await queryRunner.query(`
+                INSERT INTO organization_user ("organizationId", "userId", "roleId", status, "createdBy", "updatedBy", "createdDate", "updatedDate")
+                SELECT $1, $2, r.id, 'active', $2, $2, NOW(), NOW()
+                FROM role r WHERE r.name = 'member'
+                ON CONFLICT ("organizationId", "userId") DO NOTHING
+            `, [fallbackOrgId, user.id])
+        }
+
+        console.log(`Fixed ${orphanedUsers.length} users with invalid organizationId`)
     }
 
     // =========================================================================

--- a/packages/server/src/enterprise/database/migrations/postgres/1737076223692-RefactorEnterpriseDatabase.ts
+++ b/packages/server/src/enterprise/database/migrations/postgres/1737076223692-RefactorEnterpriseDatabase.ts
@@ -545,10 +545,22 @@ export class RefactorEnterpriseDatabase1737076223692 implements MigrationInterfa
         const hasOrgIdColumn = tempUserColumns.some((col: { column_name: string }) => col.column_name === 'organizationId')
 
         if (hasOrgIdColumn && organizations.length > 0) {
+            // Get list of valid organization IDs that were actually migrated
+            const migratedOrgs = await queryRunner.query('select "id" from "organization";')
+            const validOrgIds = new Set(migratedOrgs.map((org: { id: string }) => org.id))
+            const fallbackOrgId = organizations[0].id
+
             for (let user of users) {
                 // First user is owner, others are members
                 const roleId = user.id === firstUserId ? ownerRoleId : memberRoleId
-                const orgId = user.organizationId || organizations[0].id
+
+                // Use user's orgId only if it exists in the migrated organizations
+                // Otherwise fall back to first organization
+                let orgId = user.organizationId
+                if (!orgId || !validOrgIds.has(orgId)) {
+                    console.log(`User ${user.id} has invalid organizationId ${orgId}, using fallback ${fallbackOrgId}`)
+                    orgId = fallbackOrgId
+                }
 
                 await queryRunner.query(`
                     insert into "organization_user" ("organizationId", "userId", "roleId", "status", "createdBy", "updatedBy")

--- a/packages/server/src/enterprise/database/migrations/postgres/1737076223692-RefactorEnterpriseDatabase.ts
+++ b/packages/server/src/enterprise/database/migrations/postgres/1737076223692-RefactorEnterpriseDatabase.ts
@@ -548,18 +548,21 @@ export class RefactorEnterpriseDatabase1737076223692 implements MigrationInterfa
             // Get list of valid organization IDs that were actually migrated
             const migratedOrgs = await queryRunner.query('select "id" from "organization";')
             const validOrgIds = new Set(migratedOrgs.map((org: { id: string }) => org.id))
-            const fallbackOrgId = organizations[0].id
+            const fallbackOrgId = migratedOrgs[0]?.id || organizations[0].id
 
+            let usersWithFallback = 0
             for (let user of users) {
                 // First user is owner, others are members
                 const roleId = user.id === firstUserId ? ownerRoleId : memberRoleId
 
-                // Use user's orgId only if it exists in the migrated organizations
-                // Otherwise fall back to first organization
+                // Use user's orgId if valid, otherwise fall back to first org
+                // The backup migration should capture all user-referenced orgs,
+                // but fallback ensures migration doesn't fail for edge cases
                 let orgId = user.organizationId
                 if (!orgId || !validOrgIds.has(orgId)) {
-                    console.log(`User ${user.id} has invalid organizationId ${orgId}, using fallback ${fallbackOrgId}`)
+                    console.warn(`WARNING: User ${user.id} (email: ${user.email}) has organizationId ${orgId} which doesn't exist - using fallback ${fallbackOrgId}. This may indicate Auth0 sync issue.`)
                     orgId = fallbackOrgId
+                    usersWithFallback++
                 }
 
                 await queryRunner.query(`
@@ -567,6 +570,9 @@ export class RefactorEnterpriseDatabase1737076223692 implements MigrationInterfa
                     values ('${orgId}','${user.id}','${roleId}','${OrganizationUserStatus.ACTIVE}','${firstUserId}','${firstUserId}')
                     on conflict ("organizationId", "userId") do nothing;
                 `)
+            }
+            if (usersWithFallback > 0) {
+                console.warn(`WARNING: ${usersWithFallback} users were assigned to fallback organization due to invalid organizationId. Review Auth0 sync for these users.`)
             }
             console.log('AAI organization_user relationships created')
         }


### PR DESCRIPTION
## Summary
Fixes production deployment failure caused by foreign key constraint violation and ensures all users get proper workspaces.

### Commit 1: Handle invalid organizationId in RefactorEnterprise migration
- Validates `user.organizationId` exists in migrated organizations before inserting into `organization_user`
- Falls back to first organization if user references a non-existent org
- Prevents FK constraint violation: `fk_organizationId`

### Commit 2: Fix orphaned users before workspace creation
- After restoring AAI data from backup, finds users with invalid `organizationId`
- Updates their `organizationId` to fallback org
- Ensures `organization_user` entry exists
- Enables workspace creation to find and process all users properly

## Problem
Production deploy fails with:
```
error: insert or update on table "organization_user" violates foreign key constraint "fk_organizationId"
Migration "RefactorEnterpriseDatabase1737076223692" failed
```

And without the second fix, users with orphaned organizationId would not get workspaces created.

## Root Cause
Some AAI users have `organizationId` values referencing organizations that don't exist in `temp_organization` (orphaned references). The migrations assumed all user organization IDs were valid.

## Test plan
- [ ] Deploy to staging - verify migration completes without FK errors
- [ ] Verify users with orphaned orgs are assigned to fallback org
- [ ] Verify all users have Default Workspace + Personal Workspace created
- [ ] Deploy to production

## Linear
Fixes AGENT-630