### PR TITLE
fix(SUPPORT-12): Restore AAI credential refresh routes lost in Flowise merge

### DIFF
--- a/packages/server/AUTHORIZATION.md
+++ b/packages/server/AUTHORIZATION.md
@@ -365,3 +365,137 @@ Permissions are resolved in order:
     - Verify organization isolation
     - Check user context
     - Validate error responses
+
+## OAuth Token Refresh
+
+TheAnswer provides dedicated routes for refreshing OAuth tokens for integrated services.
+
+### Routes Overview
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/api/v1/credentials/refresh-token` | POST | `credentials:update` | Refresh Google OAuth tokens |
+| `/api/v1/credentials/refresh-atlassian-token` | POST | `credentials:update` | Refresh Atlassian OAuth tokens |
+| `/api/v1/oauth2-credential/refresh/:credentialId` | POST | None | Generic OAuth2 refresh (Flowise) |
+
+### Architecture
+
+These routes are implemented in `packages/server/src/aai/routes/credentials-refresh.ts` as AAI-specific routes, separate from Flowise core code. This design:
+
+1. **Survives Flowise upgrades** - No merge conflicts
+2. **Clear separation** - AAI code in `aai/` directory
+3. **Router ordering** - Mounted before Flowise credentials router
+
+```
+Request: POST /api/v1/credentials/refresh-token
+
+1. Express checks routers in order
+2. AAI credentials router → Has /refresh-token → Handles request
+3. Flowise credentials router → Never reached for this path
+```
+
+### Google OAuth Refresh
+
+Used by Google Drive Picker and Gmail Label Picker UI components.
+
+**Why Google needs a dedicated route:**
+
+| Generic OAuth2 | Google OAuth |
+|----------------|--------------|
+| Uses `refresh_token` field | Uses `googleRefreshToken` field |
+| Direct HTTP POST to token URL | Uses `googleapis` library |
+| Standard OAuth2 fields | Custom field names |
+
+**Request:**
+
+```typescript
+POST /api/v1/credentials/refresh-token
+Content-Type: application/json
+Authorization: Bearer <api-key>
+
+{
+    "credentialId": "credential-uuid"
+}
+```
+
+**Success Response:**
+
+```typescript
+{
+    "success": true,
+    "message": "Token refreshed successfully",
+    "data": {
+        "id": "credential-uuid",
+        "name": "My Google Drive",
+        // ... updated credential
+    }
+}
+```
+
+**Error Response (Token Expired/Revoked):**
+
+```typescript
+HTTP 401 Unauthorized
+{
+    "success": false,
+    "message": "Error: credentialsService.updateRefreshToken - Google authorization has expired or been revoked. Please re-authenticate your Google account in Credentials settings."
+}
+```
+
+### Atlassian OAuth Refresh
+
+Used by Atlassian MCP integrations.
+
+**Request:**
+
+```typescript
+POST /api/v1/credentials/refresh-atlassian-token
+Content-Type: application/json
+Authorization: Bearer <api-key>
+
+{
+    "credentialId": "credential-uuid"
+}
+```
+
+### Error Handling
+
+| Error | HTTP Status | Message |
+|-------|-------------|---------|
+| `invalid_grant` | 401 | Re-authentication required |
+| Credential not found | 404 | Credential not found |
+| Other errors | 500 | Internal server error |
+
+### Code Flow
+
+```
+UI (GoogleDrivePicker)
+    ↓
+POST /credentials/refresh-token
+    ↓
+credentialsController.updateAndRefreshToken()
+    ↓
+credentialsService.updateAndRefreshToken()
+    ↓
+GoogleOauth2Client.refreshToken()
+    ↓
+googleapis oauth2Client.refreshToken()
+    ↓
+Update credential in database
+    ↓
+Return updated credential
+```
+
+### Related Files
+
+| File | Purpose |
+|------|---------|
+| `src/aai/routes/credentials-refresh.ts` | Route definitions |
+| `src/controllers/credentials/index.ts` | Controller (lines 113-163) |
+| `src/services/credentials/index.ts` | Service (lines 200-263) |
+| `src/utils/refreshGoogleAccessToken.ts` | Google OAuth client |
+
+### UI Components
+
+-   `packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx` - "Refresh Access Token" button
+-   `packages/ui/src/ui-component/gmail/GmailLabelPicker.jsx` - Gmail token refresh

--- a/packages/server/src/aai/routes/credentials-refresh.ts
+++ b/packages/server/src/aai/routes/credentials-refresh.ts
@@ -1,5 +1,6 @@
 import express, { Router } from 'express'
 import credentialsController from '../../controllers/credentials'
+import enforceAbility from '../../middlewares/authentication/enforceAbility'
 import { checkPermission } from '../../enterprise/rbac/PermissionCheck'
 
 /**
@@ -19,11 +20,17 @@ export function createCredentialsRefreshRouter(): Router {
     const router = express.Router()
 
     // Google OAuth refresh (used by GoogleDrivePicker, GmailLabelPicker)
-    router.post('/refresh-token', checkPermission('credentials:update'), credentialsController.updateAndRefreshToken)
+    router.post(
+        '/refresh-token',
+        enforceAbility('Credential'),
+        checkPermission('credentials:update'),
+        credentialsController.updateAndRefreshToken
+    )
 
     // Atlassian OAuth refresh
     router.post(
         '/refresh-atlassian-token',
+        enforceAbility('Credential'),
         checkPermission('credentials:update'),
         credentialsController.updateAndRefreshAtlassianToken
     )

--- a/packages/server/src/aai/routes/credentials-refresh.ts
+++ b/packages/server/src/aai/routes/credentials-refresh.ts
@@ -1,0 +1,32 @@
+import express, { Router } from 'express'
+import credentialsController from '../../controllers/credentials'
+import { checkPermission } from '../../enterprise/rbac/PermissionCheck'
+
+/**
+ * Creates AAI-specific credential refresh routes
+ *
+ * These routes handle Google OAuth and Atlassian token refresh.
+ * They are mounted BEFORE the Flowise credentials router to intercept refresh requests.
+ *
+ * This is TheAnswer-specific code that was accidentally removed during a Flowise upstream merge.
+ * By keeping it in the aai/routes/ directory, we avoid merge conflicts on future upgrades.
+ *
+ * Routes:
+ * - POST /credentials/refresh-token - Google OAuth refresh (used by GoogleDrivePicker, GmailLabelPicker)
+ * - POST /credentials/refresh-atlassian-token - Atlassian OAuth refresh
+ */
+export function createCredentialsRefreshRouter(): Router {
+    const router = express.Router()
+
+    // Google OAuth refresh (used by GoogleDrivePicker, GmailLabelPicker)
+    router.post('/refresh-token', checkPermission('credentials:update'), credentialsController.updateAndRefreshToken)
+
+    // Atlassian OAuth refresh
+    router.post(
+        '/refresh-atlassian-token',
+        checkPermission('credentials:update'),
+        credentialsController.updateAndRefreshAtlassianToken
+    )
+
+    return router
+}

--- a/packages/server/src/controllers/credentials/index.ts
+++ b/packages/server/src/controllers/credentials/index.ts
@@ -113,20 +113,25 @@ const updateCredential = async (req: Request, res: Response, next: NextFunction)
 const updateAndRefreshToken = async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (!req.body.credentialId) {
-            return res.status(400).json({
-                success: false,
-                message: 'Credential ID is required'
-            })
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                'Error: credentialsController.updateAndRefreshToken - credentialId not provided!'
+            )
         }
-
-        const apiResponse = await credentialsService.updateAndRefreshToken(req.body.credentialId, req.user?.id)
+        const workspaceId = req.user?.activeWorkspaceId
+        if (!workspaceId) {
+            throw new InternalFlowiseError(
+                StatusCodes.NOT_FOUND,
+                'Error: credentialsController.updateAndRefreshToken - workspace not found!'
+            )
+        }
+        const apiResponse = await credentialsService.updateAndRefreshToken(req.body.credentialId, workspaceId)
         return res.json({
             success: true,
             message: 'Token refreshed successfully',
             data: apiResponse
         })
     } catch (error) {
-        console.error('Error refreshing token:', error)
         next(error)
     }
 }
@@ -134,20 +139,25 @@ const updateAndRefreshToken = async (req: Request, res: Response, next: NextFunc
 const updateAndRefreshAtlassianToken = async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (!req.body.credentialId) {
-            return res.status(400).json({
-                success: false,
-                message: 'Credential ID is required'
-            })
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                'Error: credentialsController.updateAndRefreshAtlassianToken - credentialId not provided!'
+            )
         }
-
-        const apiResponse = await credentialsService.updateAndRefreshAtlassianToken(req.body.credentialId, (req.user as any)?.id)
+        const workspaceId = req.user?.activeWorkspaceId
+        if (!workspaceId) {
+            throw new InternalFlowiseError(
+                StatusCodes.NOT_FOUND,
+                'Error: credentialsController.updateAndRefreshAtlassianToken - workspace not found!'
+            )
+        }
+        const apiResponse = await credentialsService.updateAndRefreshAtlassianToken(req.body.credentialId, workspaceId)
         return res.json({
             success: true,
             message: 'Atlassian token refreshed successfully',
             data: apiResponse
         })
     } catch (error) {
-        console.error('Error refreshing Atlassian token:', error)
         next(error)
     }
 }

--- a/packages/server/src/controllers/credentials/index.ts
+++ b/packages/server/src/controllers/credentials/index.ts
@@ -126,11 +126,7 @@ const updateAndRefreshToken = async (req: Request, res: Response, next: NextFunc
             )
         }
         const apiResponse = await credentialsService.updateAndRefreshToken(req.body.credentialId, workspaceId)
-        return res.json({
-            success: true,
-            message: 'Token refreshed successfully',
-            data: apiResponse
-        })
+        return res.json(apiResponse)
     } catch (error) {
         next(error)
     }
@@ -152,11 +148,7 @@ const updateAndRefreshAtlassianToken = async (req: Request, res: Response, next:
             )
         }
         const apiResponse = await credentialsService.updateAndRefreshAtlassianToken(req.body.credentialId, workspaceId)
-        return res.json({
-            success: true,
-            message: 'Atlassian token refreshed successfully',
-            data: apiResponse
-        })
+        return res.json(apiResponse)
     } catch (error) {
         next(error)
     }

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -88,6 +88,7 @@ import adminRouter from './admin'
 import pricingRouter from './pricing'
 import { createAuth0Router } from '../aai/routes/auth0'
 import { createAuthMeRouter } from '../aai/routes/auth-me'
+import { createCredentialsRefreshRouter } from '../aai/routes/credentials-refresh'
 
 import organizationsRouter from './organizations'
 
@@ -103,6 +104,8 @@ router.use('/chatmessage', chatMessageRouter)
 router.use('/chatflows-uploads', chatflowsUploadsRouter)
 router.use('/components-credentials', componentsCredentialsRouter)
 router.use('/components-credentials-icon', componentsCredentialsIconRouter)
+// AAI: Credential refresh routes (must be BEFORE Flowise credentials router to intercept refresh requests)
+router.use('/credentials', createCredentialsRefreshRouter())
 router.use('/credentials', credentialsRouter)
 router.use('/datasets', IdentityManager.checkFeatureByPlan('feat:datasets'), datasetRouter)
 router.use('/document-store', documentStoreRouter)
@@ -185,5 +188,5 @@ router.use('/organizations', organizationsRouter)
 
 export default router
 
-// Export Auth0 and AuthMe router factories for use in index.ts where AppDataSource is available
-export { createAuth0Router, createAuthMeRouter }
+// Export router factories for use in index.ts where AppDataSource is available
+export { createAuth0Router, createAuthMeRouter, createCredentialsRefreshRouter }

--- a/packages/server/src/services/credentials/index.ts
+++ b/packages/server/src/services/credentials/index.ts
@@ -197,10 +197,13 @@ const updateCredential = async (credentialId: string, requestBody: any, workspac
     }
 }
 
-const updateAndRefreshToken = async (credentialId: string, userId?: string): Promise<any> => {
+const updateAndRefreshToken = async (credentialId: string, workspaceId: string): Promise<any> => {
     try {
         const appServer = getRunningExpressApp()
-        const credential = await appServer.AppDataSource.getRepository(Credential).findOneBy({ id: credentialId })
+        const credential = await appServer.AppDataSource.getRepository(Credential).findOneBy({
+            id: credentialId,
+            workspaceId: workspaceId
+        })
         if (!credential) {
             throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Credential ${credentialId} not found`)
         }
@@ -216,9 +219,8 @@ const updateAndRefreshToken = async (credentialId: string, userId?: string): Pro
             credentialName: credential.credentialName,
             plainDataObj: {
                 ...decryptedCredentialData,
-                googleAccessToken: access_token, // ✅ ACTUALIZA el nuevo access token
-                expiresAt: new Date(expiry_date) // ✅ ACTUALIZA la fecha de expiración
-                // expiresAt: new Date(Date.now() + 1 * 60 * 1000)
+                googleAccessToken: access_token,
+                expiresAt: new Date(expiry_date)
             },
             userId: credential.userId,
             organizationId: credential.organizationId,
@@ -240,12 +242,20 @@ const updateAndRefreshToken = async (credentialId: string, userId?: string): Pro
     }
 }
 
-const updateAndRefreshAtlassianToken = async (credentialId: string, userId?: string): Promise<any> => {
+const updateAndRefreshAtlassianToken = async (credentialId: string, workspaceId: string): Promise<any> => {
     try {
-        // Use centralized OAuth utility
-
         const appServer = getRunningExpressApp()
 
+        // Verify credential belongs to workspace before refresh
+        const existingCredential = await appServer.AppDataSource.getRepository(Credential).findOneBy({
+            id: credentialId,
+            workspaceId: workspaceId
+        })
+        if (!existingCredential) {
+            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Credential ${credentialId} not found in workspace`)
+        }
+
+        // Use centralized OAuth utility
         const success = await refreshStoredCredentialTokens(credentialId, appServer.AppDataSource)
 
         if (!success) {
@@ -253,7 +263,10 @@ const updateAndRefreshAtlassianToken = async (credentialId: string, userId?: str
         }
 
         // Return the updated credential
-        const credential = await appServer.AppDataSource.getRepository(Credential).findOneBy({ id: credentialId })
+        const credential = await appServer.AppDataSource.getRepository(Credential).findOneBy({
+            id: credentialId,
+            workspaceId: workspaceId
+        })
         return credential
     } catch (error) {
         throw new InternalFlowiseError(

--- a/packages/server/src/services/credentials/index.ts
+++ b/packages/server/src/services/credentials/index.ts
@@ -228,7 +228,11 @@ const updateAndRefreshToken = async (credentialId: string, userId?: string): Pro
         await appServer.AppDataSource.getRepository(Credential).merge(credential, updateCredentialEntity)
         const dbResponse = await appServer.AppDataSource.getRepository(Credential).save(credential)
         return dbResponse
-    } catch (error) {
+    } catch (error: any) {
+        // Return 401 for re-authentication required errors (e.g., invalid_grant)
+        if (error.code === 'REAUTH_REQUIRED' || error.message?.includes('re-authenticate')) {
+            throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `Error: credentialsService.updateRefreshToken - ${error.message}`)
+        }
         throw new InternalFlowiseError(
             StatusCodes.INTERNAL_SERVER_ERROR,
             `Error: credentialsService.updateRefreshToken - ${getErrorMessage(error)}`

--- a/packages/server/src/utils/refreshGoogleAccessToken.ts
+++ b/packages/server/src/utils/refreshGoogleAccessToken.ts
@@ -25,7 +25,24 @@ export class GoogleOauth2Client {
     }
 
     async refreshToken() {
-        const { tokens } = await this.oauth2Client.refreshToken(this.oauth2Client.credentials.refresh_token)
-        return tokens
+        try {
+            const { tokens } = await this.oauth2Client.refreshToken(this.oauth2Client.credentials.refresh_token)
+            return tokens
+        } catch (error: any) {
+            const errorMessage = error.message || ''
+            const errorResponse = error.response?.data?.error || ''
+
+            // Handle invalid_grant error with user-friendly message
+            if (errorMessage.includes('invalid_grant') || errorResponse === 'invalid_grant') {
+                const customError = new Error(
+                    'Google authorization has expired or been revoked. ' +
+                        'Please re-authenticate your Google account in Credentials settings.'
+                )
+                ;(customError as any).code = 'REAUTH_REQUIRED'
+                ;(customError as any).requiresReauth = true
+                throw customError
+            }
+            throw error
+        }
     }
 }


### PR DESCRIPTION
## Summary

Restores the Google OAuth and Atlassian OAuth token refresh routes that were accidentally removed during the Flowise 3.0.11 upstream merge (PR #726).

- **Root Cause**: Routes `/credentials/refresh-token` and `/credentials/refresh-atlassian-token` were lost when the Flowise credentials router was replaced
- **Impact**: Users couldn't manually refresh Google Drive/Gmail OAuth tokens, causing "0 chunks" issue in document stores with expired credentials
- **Solution**: Create AAI-specific routes that survive future Flowise upgrades

## Changes

### New File: `packages/server/src/aai/routes/credentials-refresh.ts`
- Google OAuth refresh route: `POST /credentials/refresh-token`
- Atlassian OAuth refresh route: `POST /credentials/refresh-atlassian-token`
- Uses `checkPermission('credentials:update')` middleware

### Modified: `packages/server/src/routes/index.ts`
- Import and mount AAI credentials router **before** Flowise router
- Express router ordering ensures AAI routes intercept refresh requests

### Modified: `packages/server/src/utils/refreshGoogleAccessToken.ts`
- Add `invalid_grant` error handling with user-friendly message
- Sets `code: 'REAUTH_REQUIRED'` for proper HTTP status mapping

### Modified: `packages/server/src/services/credentials/index.ts`
- Return HTTP 401 (not 500) when re-authentication is required

### Documentation: `packages/server/AUTHORIZATION.md`
- Add "OAuth Token Refresh" section explaining routes, architecture, and usage

## Architecture Decision

Routes are in `aai/routes/` directory (not Flowise `routes/credentials/`) because:
- ✅ Survives Flowise upgrades - no merge conflicts
- ✅ Follows existing pattern (`aai/routes/auth0.ts`, `aai/routes/auth-me.ts`)
- ✅ Clear separation of TheAnswer-specific code

## Test Plan

- [ ] Route exists: `POST /credentials/refresh-token` returns JSON (not 404)
- [ ] Valid token refresh works with Google Drive credential
- [ ] Expired token shows user-friendly "re-authenticate" message
- [ ] Atlassian token refresh still works (regression)
- [ ] Document Store can create chunks after credential re-auth

## Related

- Ticket: SUPPORT-12 (Moonstruck Document Store Chunks Missing)
- Previous fix attempt: Commit `6a04beb7` (feat: manual refresh google access token)

🤖 Generated with [Claude Code](https://claude.ai/code)