### PR TITLE
fix(components): remove userId override in dropdowns to respect workspace filtering

### DIFF
--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -129,10 +129,6 @@ class ExecuteFlow_Agentflow implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                userId: options.userId
-            }
             const chatflows = await appDataSource.getRepository(databaseEntities['ChatFlow']).findBy(searchOptions)
 
             for (let i = 0; i < chatflows.length; i += 1) {

--- a/packages/components/nodes/agentflow/Retriever/Retriever.ts
+++ b/packages/components/nodes/agentflow/Retriever/Retriever.ts
@@ -121,10 +121,6 @@ class Retriever_Agentflow implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                userId: options.userId
-            }
             const stores = await appDataSource.getRepository(databaseEntities['DocumentStore']).findBy(searchOptions)
             for (const store of stores) {
                 if (store.status === 'UPSERTED') {

--- a/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
+++ b/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
@@ -110,10 +110,6 @@ class OpenAIAssistant_Agents implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                userId: options.userId
-            }
             const assistants = await appDataSource.getRepository(databaseEntities['Assistant']).findBy({
                 ...searchOptions,
                 type: 'OPENAI'

--- a/packages/components/nodes/documentloaders/DocumentStore/DocStoreLoader.ts
+++ b/packages/components/nodes/documentloaders/DocumentStore/DocStoreLoader.ts
@@ -65,10 +65,6 @@ class DocStore_DocumentLoaders implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                userId: options.userId
-            }
             const stores = await appDataSource.getRepository(databaseEntities['DocumentStore']).findBy(searchOptions)
             for (const store of stores) {
                 if (store.status === 'SYNC') {

--- a/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
@@ -135,10 +135,6 @@ class ExecuteFlow_SeqAgents implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                userId: options.userId
-            }
             const chatflows = await appDataSource.getRepository(databaseEntities['ChatFlow']).findBy(searchOptions)
 
             for (let i = 0; i < chatflows.length; i += 1) {

--- a/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
+++ b/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
@@ -135,10 +135,6 @@ class ChatflowTool_Tools implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                userId: options.userId
-            }
             const chatflows = await appDataSource.getRepository(databaseEntities['ChatFlow']).findBy(searchOptions)
 
             for (let i = 0; i < chatflows.length; i += 1) {

--- a/packages/components/nodes/vectorstores/DocumentStoreVS/DocStoreVector.ts
+++ b/packages/components/nodes/vectorstores/DocumentStoreVS/DocStoreVector.ts
@@ -57,10 +57,6 @@ class DocStore_VectorStores implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                userId: options.userId
-            }
             const stores = await appDataSource.getRepository(databaseEntities['DocumentStore']).findBy(searchOptions)
             for (const store of stores) {
                 if (store.status === 'UPSERTED') {


### PR DESCRIPTION
## Summary
- Fixes component dropdowns not showing workspace-shared resources
- Removes incorrect `userId` filter override that was ignoring `workspaceId`

## Problem
Component loadMethods were overriding `searchOptions.where` with `userId: options.userId`, which:
1. Ignored the `workspaceId` filter passed from the server
2. Created an AND condition requiring both workspace AND user ownership
3. Prevented workspace members from seeing shared Document Stores, Chatflows, and Assistants in dropdowns

## Changes
Removed the `userId` override from 7 components:
- `agentflow/Retriever/Retriever.ts`
- `agentflow/ExecuteFlow/ExecuteFlow.ts`
- `sequentialagents/ExecuteFlow/ExecuteFlow.ts`
- `vectorstores/DocumentStoreVS/DocStoreVector.ts`
- `documentloaders/DocumentStore/DocStoreLoader.ts`
- `tools/ChatflowTool/ChatflowTool.ts`
- `agents/OpenAIAssistant/OpenAIAssistant.ts`

## Test plan
- [ ] Verify Document Store dropdown shows workspace stores (not just user's own)
- [ ] Verify Chatflow dropdown in ExecuteFlow shows workspace chatflows
- [ ] Verify Assistant dropdown shows workspace assistants

Closes #853