### PR TITLE
fix(AGENT-617): forward credential props in recursive NodeInputHandler tab calls

### DIFF
--- a/packages/ui/src/views/canvas/NodeInputHandler.jsx
+++ b/packages/ui/src/views/canvas/NodeInputHandler.jsx
@@ -124,7 +124,11 @@ const NodeInputHandler = ({
     parentParamForArray = null,
     arrayIndex = null,
     onHideNodeInfoDialog,
-    onCustomDataChange
+    onCustomDataChange,
+    // Credential props for Google Drive/Gmail pickers (forwarded in recursive calls)
+    selectedCredential: selectedCredentialProp,
+    selectedCredentialData: selectedCredentialDataProp,
+    handleCredentialDataChange: handleCredentialDataChangeProp
 }) => {
     const theme = useTheme()
     const customization = useSelector((state) => state.customization)
@@ -168,12 +172,18 @@ const NodeInputHandler = ({
     const [promptGeneratorDialogProps, setPromptGeneratorDialogProps] = useState({})
 
     // State for Google Drive/Gmail credential handling
-    const [selectedCredential, setSelectedCredential] = useState(data.credential || null)
-    const [selectedCredentialData, setSelectedCredentialData] = useState(null)
+    // Use props if provided (for recursive/nested calls), otherwise use local state
+    const [selectedCredential, setSelectedCredential] = useState(selectedCredentialProp ?? data.credential ?? null)
+    const [selectedCredentialData, setSelectedCredentialData] = useState(selectedCredentialDataProp ?? null)
 
-    const handleCredentialDataChange = useCallback((credData) => {
-        setSelectedCredentialData(credData)
-    }, [])
+    const handleCredentialDataChange = useCallback(
+        (credData) => {
+            setSelectedCredentialData(credData)
+            // Also notify parent if callback prop is provided
+            handleCredentialDataChangeProp?.(credData)
+        },
+        [handleCredentialDataChangeProp]
+    )
 
     const handleDataChange = ({ inputParam, newValue }) => {
         data.inputs[inputParam.name] = newValue
@@ -1024,6 +1034,9 @@ const NodeInputHandler = ({
                                                 data={data}
                                                 isAdditionalParams={true}
                                                 disablePadding={true}
+                                                selectedCredential={selectedCredential}
+                                                selectedCredentialData={selectedCredentialData}
+                                                handleCredentialDataChange={handleCredentialDataChange}
                                             />
                                         </TabPanel>
                                     ))}
@@ -1475,7 +1488,11 @@ NodeInputHandler.propTypes = {
     parentParamForArray: PropTypes.object,
     arrayIndex: PropTypes.number,
     onCustomDataChange: PropTypes.func,
-    onHideNodeInfoDialog: PropTypes.func
+    onHideNodeInfoDialog: PropTypes.func,
+    // Credential props for Google Drive/Gmail pickers (forwarded in recursive calls)
+    selectedCredential: PropTypes.string,
+    selectedCredentialData: PropTypes.object,
+    handleCredentialDataChange: PropTypes.func
 }
 
 export default NodeInputHandler


### PR DESCRIPTION
## Summary

- Fixes recursive tab rendering issue for GoogleDrivePicker in NodeInputHandler.jsx
- Addresses PR #824 review feedback about missing credential prop forwarding in nested tabs

## Changes

- Accept credential props (`selectedCredential`, `selectedCredentialData`, `handleCredentialDataChange`) in component signature
- Use props with fallback to local state for nested component support
- Forward credential props in recursive tab rendering call
- Add PropTypes for new credential props
- Notify parent via callback when credential data changes

## Test Plan

- [ ] Test Google Drive picker in **Canvas/Chatflow** context (direct usage)
- [ ] Test Google Drive picker when nested inside **tabs** in Canvas
- [ ] Test Google Drive picker in **DocStore** context (regression check)
- [ ] Verify no `ReferenceError` in browser console
- [ ] Verify credential selection updates state correctly

## Related

- **Linear:** [AGENT-617](https://linear.app/answeragent/issue/AGENT-617)
- **Previous PR:** #824 (original fix for DocStoreInputHandler)
- **Review comment:** This addresses Max's feedback about NodeInputHandler recursive tab calls

🤖 Generated with [Claude Code](https://claude.ai/code)