### PR TITLE
fix(AGENT-626): redirect to Auth0 login instead of non-existent /login route

### DIFF
--- a/packages-answers/ui/src/getCachedSession.ts
+++ b/packages-answers/ui/src/getCachedSession.ts
@@ -111,6 +111,10 @@ const getCachedSession = cache(async (req?: any, res: any = new Response()): Pro
                     // Merge enriched data into session.user (Flowise data takes priority)
                     session.user = { ...session.user, ...enrichedUser }
                 }
+            } else if (response.status === 401) {
+                console.warn('[getCachedSession] Auth token expired or invalid for /auth/me enrichment')
+            } else {
+                console.warn(`[getCachedSession] Unexpected status ${response.status} from /auth/me`)
             }
         }
     } catch (err: any) {

--- a/packages/ui/src/api/client.js
+++ b/packages/ui/src/api/client.js
@@ -44,12 +44,9 @@ apiClient.interceptors.response.use(
             localStorage.removeItem('password')
             AuthUtils.removeCurrentUser()
 
-            // Redirect to login page
-            // Check if we're in a browser environment
+            // Redirect to Auth0 login page
             if (typeof window !== 'undefined') {
-                // Use Auth0 login for AAI, fallback to /login for enterprise
-                const loginUrl = window.location.pathname.includes('/sidekick') ? '/api/auth/login' : '/login'
-                window.location.href = loginUrl
+                window.location.href = '/api/auth/login'
             }
         }
 

--- a/packages/ui/src/views/account/index.jsx
+++ b/packages/ui/src/views/account/index.jsx
@@ -108,7 +108,7 @@ const AccountSettings = () => {
         if (currentUser) {
             getUserByIdApi.request(currentUser.id)
         } else {
-            window.location.href = '/login'
+            window.location.href = '/api/auth/login'
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentUser])


### PR DESCRIPTION
## Summary

Fixes critical authentication flow issue where unauthenticated users see a 404 error on `/login` instead of being redirected to Auth0 login.

**Root Cause:** Legacy Flowise UI code conditionally redirected to `/login` (which doesn't exist in the Next.js app) instead of `/api/auth/login` (Auth0).

**Changes:**
- `packages/ui/src/api/client.js` - Always redirect to `/api/auth/login` on 401
- `packages/ui/src/views/account/index.jsx` - Use Auth0 login path
- `packages-answers/ui/src/getCachedSession.ts` - Add logging for 401 responses

## Test plan

- [ ] Clear cookies and access staging URL → should redirect to Auth0 login (not 404)
- [ ] Verify existing authenticated sessions work normally
- [ ] Check console logs for proper 401 error messages

## Linear Ticket

[AGENT-626: Critical: Login page returns 404 after auth/me fetch fails on staging/prod](https://linear.app/answeragent/issue/AGENT-626/critical-login-page-returns-404-after-authme-fetch-fails-on)

🤖 Generated with [Claude Code](https://claude.ai/code)