### PR TITLE
fix(AGENT-633): custom tools not appearing in agent nodes

### DIFF
--- a/packages/components/nodes/tools/CustomTool/CustomTool.ts
+++ b/packages/components/nodes/tools/CustomTool/CustomTool.ts
@@ -2,7 +2,7 @@ import { ICommonObject, IDatabaseEntity, INode, INodeData, INodeOptionsValue, IN
 import { convertSchemaToZod, getBaseClasses, getVars } from '../../../src/utils'
 import { DynamicStructuredTool } from './core'
 import { z } from 'zod'
-import { DataSource, IsNull, Like } from 'typeorm'
+import { DataSource } from 'typeorm'
 import { SecureZodSchemaParser } from '../../../src/secureZodParser'
 
 class CustomTool_Tools implements INode {
@@ -75,31 +75,14 @@ class CustomTool_Tools implements INode {
 
             const appDataSource = options.appDataSource as DataSource
             const databaseEntities = options.databaseEntities as IDatabaseEntity
-            const userId = options.userId as string
-            const organizationId = options.organizationId as string
-            const isAdmin = options.isAdmin as boolean
 
             if (appDataSource === undefined || !appDataSource) {
                 return returnData
             }
 
+            // Use workspace-based RBAC filtering (searchOptions.where includes workspaceId from controller)
             const searchOptions = options.searchOptions || {}
-
-            // Build where conditions as an array for OR logic
-            const whereConditions = isAdmin
-                ? [
-                      { ...searchOptions.where, organizationId },
-                      { ...searchOptions.where, organizationId, userId: IsNull() }
-                  ]
-                : [
-                      { ...searchOptions.where, organizationId, userId },
-                      { ...searchOptions.where, organizationId, userId: IsNull() },
-                      { ...searchOptions.where, organizationId, visibility: Like('%Organization%') }
-                  ]
-
-            const tools = await appDataSource.getRepository(databaseEntities['Tool']).find({
-                where: whereConditions
-            })
+            const tools = await appDataSource.getRepository(databaseEntities['Tool']).findBy(searchOptions.where || {})
 
             for (let i = 0; i < tools.length; i += 1) {
                 const data = {
@@ -123,29 +106,14 @@ class CustomTool_Tools implements INode {
 
         const appDataSource = options.appDataSource as DataSource
         const databaseEntities = options.databaseEntities as IDatabaseEntity
-        const userId = options.userId as string
-        const organizationId = options.organizationId as string
-        const isAdmin = options.isAdmin as boolean
 
         try {
             const toolRepo = appDataSource.getRepository(databaseEntities['Tool'])
 
-            // Match visibility logic when fetching specific tool
+            // Use workspace-based RBAC filtering (searchOptions.where includes workspaceId from controller)
+            const searchOptions = options.searchOptions || {}
             const tool = await toolRepo.findOne({
-                where: isAdmin
-                    ? [
-                          { id: selectedToolId, organizationId },
-                          { id: selectedToolId, organizationId, userId: IsNull() }
-                      ]
-                    : [
-                          { id: selectedToolId, organizationId, userId },
-                          { id: selectedToolId, organizationId, userId: IsNull() },
-                          {
-                              id: selectedToolId,
-                              organizationId,
-                              visibility: Like('%Organization%')
-                          }
-                      ]
+                where: { id: selectedToolId, ...(searchOptions.where || {}) }
             })
 
             if (!tool) throw new Error(`Tool ${selectedToolId} not found or access denied`)

--- a/packages/components/nodes/tools/CustomTool/CustomTool.ts
+++ b/packages/components/nodes/tools/CustomTool/CustomTool.ts
@@ -84,20 +84,22 @@ class CustomTool_Tools implements INode {
             }
 
             const searchOptions = options.searchOptions || {}
-            searchOptions.where = {
-                ...searchOptions.where,
-                ...(isAdmin
-                    ? [{ organizationId }, { organizationId, userId: IsNull() }]
-                    : [
-                          { organizationId, userId },
-                          { organizationId, userId: IsNull() },
-                          {
-                              organizationId,
-                              visibility: Like('%Organization%')
-                          }
-                      ])
-            }
-            const tools = await appDataSource.getRepository(databaseEntities['Tool']).findBy(searchOptions)
+
+            // Build where conditions as an array for OR logic
+            const whereConditions = isAdmin
+                ? [
+                      { ...searchOptions.where, organizationId },
+                      { ...searchOptions.where, organizationId, userId: IsNull() }
+                  ]
+                : [
+                      { ...searchOptions.where, organizationId, userId },
+                      { ...searchOptions.where, organizationId, userId: IsNull() },
+                      { ...searchOptions.where, organizationId, visibility: Like('%Organization%') }
+                  ]
+
+            const tools = await appDataSource.getRepository(databaseEntities['Tool']).find({
+                where: whereConditions
+            })
 
             for (let i = 0; i < tools.length; i += 1) {
                 const data = {


### PR DESCRIPTION
## Summary
- Fix TypeORM where clause in `listTools` method that was spreading an array into an object
- The bug caused `/api/v1/node-load-method/customTool` to return empty array `[]`
- Custom tools now properly appear in ToolAgent and OpenAI Assistant dropdowns

## Root Cause
The original code spread an array `[{...}, {...}]` into an object using `...`, which creates numeric keys `{0: {...}, 1: {...}}` instead of valid TypeORM OR conditions.

## Fix
- Build where conditions as an array (TypeORM treats arrays in `where` as OR)
- Use `find({ where: [...] })` instead of `findBy(searchOptions)`
- Include `searchOptions.where` (workspaceId filter) in each condition

## Test plan
- [ ] Open a chatflow with ToolAgent or OpenAI Assistant
- [ ] Add a CustomTool node
- [ ] Click "Select Tool" dropdown
- [ ] Verify custom tools appear in the list