### PR TITLE
fix(AGENT-634): populate workspace data for API key auth users

### DIFF
--- a/packages/server/src/middlewares/authentication/index.ts
+++ b/packages/server/src/middlewares/authentication/index.ts
@@ -124,9 +124,17 @@ export const authenticationHandlerMiddleware =
                 return res.status(401).send("Unauthorized: API key organization doesn't match")
             }
 
-            // Store API key user with additional auth0 org info
-            req.user = apiKeyUser as any
-            ;(req.user as any).auth0OrgId = organization?.auth0Id
+            // Populate workspace data for API key users (same as JWT users)
+            const workspaceData = organization
+                ? await populateWorkspaceData(AppDataSource, apiKeyUser, organization.id)
+                : {}
+
+            // Store API key user with workspace data and additional auth0 org info
+            req.user = {
+                ...apiKeyUser,
+                ...workspaceData,
+                auth0OrgId: organization?.auth0Id
+            } as any
 
             // Apply billing customer override for organizational billing consolidation
             if (OVERRIDE_CUSTOMER_ID && DEFAULT_CUSTOMER_ID && req.user) {


### PR DESCRIPTION
## Summary
- API key authentication was not calling `populateWorkspaceData`, leaving `activeOrganizationId` and `activeWorkspaceId` unset
- This caused API key creation to fail since the controller relies on `activeOrganizationId`
- Now API key auth users get the same workspace data population as JWT users

## Changes
- Updated `authenticationHandlerMiddleware` to call `populateWorkspaceData` for API key authenticated users
- Spreads workspace data (`activeWorkspaceId`, `activeOrganizationId`, etc.) into `req.user`

## Test plan
- [ ] Create API key via UI (JWT auth) - should work as before
- [ ] Create API key via API using existing API key - should now work (was failing)
- [ ] Verify `organizationId` is populated in new API key records

Fixes AGENT-634