### PR TITLE
fix(AGENT-638): enable Langfuse tracing for agentflows via env vars

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -11,7 +11,8 @@ import {
     IMessage,
     IServerSideEventStreamer,
     convertChatHistoryToText,
-    generateFollowUpPrompts
+    generateFollowUpPrompts,
+    isAnalyticsEnabled
 } from 'flowise-components'
 import {
     IncomingAgentflowInput,
@@ -1885,7 +1886,7 @@ export const executeAgentFlow = async ({
     let parentTraceIds: ICommonObject | undefined
 
     try {
-        if (chatflow.analytic) {
+        if (isAnalyticsEnabled(chatflow.analytic)) {
             // Override config analytics
             let analyticInputs: ICommonObject = {}
             if (overrideConfig?.analytics && Object.keys(overrideConfig.analytics).length > 0) {


### PR DESCRIPTION
## Summary
- Agentflows were not sending traces to Langfuse even when `LANGFUSE_SECRET_KEY` env var was set
- Root cause: `buildAgentflow.ts` checked `chatflow.analytic` directly, which is only truthy if analytics is configured in UI
- Fix: Use `isAnalyticsEnabled()` which properly checks both UI config AND env vars

## Changes
- Import `isAnalyticsEnabled` from `flowise-components`
- Replace `if (chatflow.analytic)` with `if (isAnalyticsEnabled(chatflow.analytic))`

## Test plan
- [ ] Set `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST` env vars
- [ ] Run an agentflow (without UI analytics config)
- [ ] Verify traces appear in Langfuse dashboard
- [ ] Verify chatflows still work (no regression)

Fixes AGENT-638