### PR TITLE
fix(AGENT-635): make AddOrganizationConfig migration idempotent

### DIFF
--- a/packages/server/src/database/migrations/postgres/aai/1753200000001-AddOrganizationConfig.ts
+++ b/packages/server/src/database/migrations/postgres/aai/1753200000001-AddOrganizationConfig.ts
@@ -4,7 +4,7 @@ export class AddOrganizationConfig1753200000001 implements MigrationInterface {
     name = 'AddOrganizationConfig1753200000001'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "organization" ADD "organizationConfig" jsonb`)
+        await queryRunner.query(`ALTER TABLE "organization" ADD COLUMN IF NOT EXISTS "organizationConfig" jsonb`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Summary
- Use `ADD COLUMN IF NOT EXISTS` instead of `ADD` in migration
- Prevents failure when column already exists on fresh DB setup

## Test plan
- [ ] Run migration twice - should succeed both times
- [ ] Fresh DB: drop and recreate, run all migrations

Fixes AGENT-635