### PR TITLE
fix(AGENT-635): add IF EXISTS to migration down() for idempotency

### DIFF
--- a/packages/server/src/database/migrations/postgres/aai/1753200000001-AddOrganizationConfig.ts
+++ b/packages/server/src/database/migrations/postgres/aai/1753200000001-AddOrganizationConfig.ts
@@ -8,6 +8,6 @@ export class AddOrganizationConfig1753200000001 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN "organizationConfig"`)
+        await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN IF EXISTS "organizationConfig"`)
     }
 }


### PR DESCRIPTION
## Summary
- Add `IF EXISTS` clause to `DROP COLUMN` in the `down()` method of `AddOrganizationConfig` migration
- Makes the migration fully idempotent for safe rollback scenarios

## Problem
The migration's `down()` method used `DROP COLUMN "organizationConfig"` without `IF EXISTS`. This could fail during rollback if:
- The column was already dropped manually
- The column was created by `AAIRestoreDataAndCreateWorkspaces` migration (which runs first due to earlier timestamp)

## Solution
Changed from:
```sql
ALTER TABLE "organization" DROP COLUMN "organizationConfig"
```

To:
```sql
ALTER TABLE "organization" DROP COLUMN IF EXISTS "organizationConfig"
```

## Changes
- `packages/server/src/database/migrations/postgres/aai/1753200000001-AddOrganizationConfig.ts`
  - Added `IF EXISTS` to `down()` method

## Test plan
- [ ] Run migration rollback: `pnpm migration:revert`
- [ ] Re-run migration: `pnpm migration:run`
- [ ] Verify idempotency works in both directions

## Related
- Follows up on PR #870 which added `IF NOT EXISTS` to the `up()` method
- Ticket: AGENT-635

🤖 Generated with [Claude Code](https://claude.ai/claude-code)