### PR TITLE
fix(AGENT-639): use workspaceId filter in queryVectorStore

### DIFF
--- a/packages/server/src/controllers/documentstore/index.ts
+++ b/packages/server/src/controllers/documentstore/index.ts
@@ -522,14 +522,20 @@ const insertIntoVectorStore = async (req: Request, res: Response, next: NextFunc
 const queryVectorStore = async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (typeof req.body === 'undefined') {
-            throw new Error('Error: documentStoreController.queryVectorStore - body not provided!')
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                'Error: documentStoreController.queryVectorStore - body not provided!'
+            )
+        }
+        const workspaceId = req.user?.activeWorkspaceId
+        if (!workspaceId) {
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                'Error: documentStoreController.queryVectorStore - workspaceId not provided!'
+            )
         }
         const body = req.body
-        const apiResponse = await documentStoreService.queryVectorStore(
-            { ...body, userId: req.user?.id!, organizationId: req.user?.organizationId! },
-            req.user?.id!,
-            req.user?.organizationId!
-        )
+        const apiResponse = await documentStoreService.queryVectorStore(body, workspaceId)
         return res.json(apiResponse)
     } catch (error) {
         next(error)

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1658,26 +1658,24 @@ const getRecordManagerProviders = async () => {
     }
 }
 
-const queryVectorStore = async (data: ICommonObject, userId: string, organizationId: string) => {
+const queryVectorStore = async (data: ICommonObject, workspaceId: string) => {
     try {
         const appServer = getRunningExpressApp()
         const componentNodes = appServer.nodesPool.componentNodes
 
         const entity = await appServer.AppDataSource.getRepository(DocumentStore).findOneBy({
             id: data.storeId,
-            userId,
-            organizationId
+            workspaceId
         })
         if (!entity) {
-            throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Document store ${data.storeId} not found`)
+            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Document store ${data.storeId} not found`)
         }
         const options: ICommonObject = {
             chatflowid: data.storeId ?? uuidv4(),
             appDataSource: appServer.AppDataSource,
             databaseEntities,
             logger,
-            organizationId,
-            userId
+            workspaceId
         }
 
         if (!entity.embeddingConfig) {


### PR DESCRIPTION
## Summary

- Fix `queryVectorStore` to filter by `workspaceId` instead of `userId`+`organizationId`
- Aligns with other document store methods like `getDocumentStoreById`
- Fixes "Document store not found" errors in Retrieval Playground

## Root Cause

The `queryVectorStore` method was using inconsistent filtering:

**Before (broken):**
```typescript
findOneBy({ id, userId, organizationId })
```

**After (fixed):**
```typescript
findOneBy({ id, workspaceId })
```

## Linear Ticket

https://linear.app/answeragent/issue/AGENT-639

## Test plan

- [ ] Test Retrieval Playground with document store created by another user in same workspace
- [ ] Verify document store queries still work for the creator