### PR TITLE
fix(AGENT-405): add /sidekick-studio prefix to agentflow URL after save

### DIFF
--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -566,7 +566,7 @@ const AgentflowCanvas = ({ chatflowid: chatflowId }) => {
             const chatflow = createNewChatflowApi.data
             dispatch({ type: SET_CHATFLOW, chatflow })
             saveChatflowSuccess()
-            window.history.replaceState(state, null, `/v2/agentcanvas/${chatflow.id}`)
+            window.history.replaceState(state, null, `/sidekick-studio/v2/agentcanvas/${chatflow.id}`)
         } else if (createNewChatflowApi.error) {
             errorFailed(`Failed to save ${canvasTitle}: ${createNewChatflowApi.error.response.data.message}`)
         }


### PR DESCRIPTION
## Summary
- Fix hardcoded URL path in Canvas.jsx that was missing the `/sidekick-studio` prefix
- Prevents 404 errors when refreshing page after saving a new agentflow
- Enables chat history to load correctly after page refresh

## Problem
When creating a new agentflow and saving it for the first time, the URL was incorrectly updated to `/v2/agentcanvas/{id}` instead of `/sidekick-studio/v2/agentcanvas/{id}`. This caused a 404 error on page refresh, preventing chat history from loading properly.

## Solution
Updated `window.history.replaceState()` in `packages/ui/src/views/agentflowsv2/Canvas.jsx` to include the `/sidekick-studio` prefix.

## Test plan
- [ ] Create a new agentflow v2
- [ ] Save the agentflow
- [ ] Verify URL shows `/sidekick-studio/v2/agentcanvas/{id}`
- [ ] Refresh the page - no 404 error
- [ ] Chat history loads correctly

## Linear Ticket
https://linear.app/answeragent/issue/AGENT-405

🤖 Generated with [Claude Code](https://claude.ai/code)