### PR TITLE
fix(AGENT-639): add organizationId to queryVectorStore for correct namespace

### DIFF
--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1675,7 +1675,8 @@ const queryVectorStore = async (data: ICommonObject, workspaceId: string) => {
             appDataSource: appServer.AppDataSource,
             databaseEntities,
             logger,
-            workspaceId
+            workspaceId,
+            organizationId: entity.organizationId
         }
 
         if (!entity.embeddingConfig) {


### PR DESCRIPTION
## Summary

Follow-up fix for AGENT-639. The previous fix changed filtering to use `workspaceId` for finding the document store, but inadvertently removed `organizationId` from the options object passed to the vector store.

This caused vector retrieval to fail because:
- **Upsert** stores documents in namespace: `org:XXX_chatflow:YYY_default`
- **Query** looked in namespace: `chatflow:YYY_default` (missing org prefix)

The fix adds `organizationId: entity.organizationId` to the options, ensuring the namespace matches during retrieval.

## Related Issues

- Fixes SUPPORT-17: Kumello document store found but vector retrieval returns 0 chunks
- Follow-up to AGENT-639 (PR #875)

## Test plan

- [ ] Test Retrieval Playground with Kumello document store
- [ ] Test agentflow retriever node returns chunks
- [ ] Verify namespace includes org prefix in vector queries