### PR TITLE
fix(AGENT-639): include workspaceData in JWT auth req.user

### DIFF
--- a/packages/server/src/middlewares/authentication/index.ts
+++ b/packages/server/src/middlewares/authentication/index.ts
@@ -250,7 +250,7 @@ export const authenticationHandlerMiddleware =
                             user.stripeCustomerId = DEFAULT_CUSTOMER_ID
                         }
 
-                        req.user = { ...authUser, ...user, roles, permissions } as any
+                        req.user = { ...authUser, ...user, ...workspaceData, roles, permissions } as any
                     } else {
                         // User authenticated but from unauthorized organization - treat as anonymous user
                         console.warn(`Auth: User ${email} from org '${userOrgId}' treated as anonymous - not in allowed orgs`)


### PR DESCRIPTION
## Summary
- Fixes `null value in column "organizationId"` error when creating API keys
- JWT auth path was missing `workspaceData` spread in `req.user`
- This caused `activeOrganizationId` to be undefined for JWT-authenticated users

## Root Cause
API key auth included `workspaceData`:
```typescript
req.user = { ...apiKeyUser, ...workspaceData, ... }
```

But JWT auth did NOT:
```typescript
req.user = { ...authUser, ...user, roles, permissions }  // missing workspaceData!
```

## Related
- Linear: AGENT-639
- Previous PRs: #875, #878, #880

## Test plan
- [ ] Login via JWT (UI)
- [ ] Create new API key - should succeed without organizationId error