### PR TITLE
fix(AGENT-612): use Next.js Image component for canvas chat avatars

### DIFF
--- a/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
@@ -34,6 +34,7 @@ import {
 import { useTheme, styled, alpha } from '@mui/material/styles'
 import DatePicker from 'react-datepicker'
 
+import Image from 'next/image'
 import robotPNG from '@/assets/images/robot.png'
 import userPNG from '@/assets/images/account.png'
 import msgEmptySVG from '@/assets/images/message_empty.svg'
@@ -1226,21 +1227,21 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
                                                         >
                                                             {/* Display the correct icon depending on the message type */}
                                                             {message.type === 'apiMessage' ? (
-                                                                <img
+                                                                <Image
                                                                     style={{ marginLeft: '10px' }}
                                                                     src={robotPNG}
                                                                     alt='AI'
-                                                                    width='25'
-                                                                    height='25'
+                                                                    width={25}
+                                                                    height={25}
                                                                     className='boticon'
                                                                 />
                                                             ) : (
-                                                                <img
+                                                                <Image
                                                                     style={{ marginLeft: '10px' }}
                                                                     src={userPNG}
                                                                     alt='Me'
-                                                                    width='25'
-                                                                    height='25'
+                                                                    width={25}
+                                                                    height={25}
                                                                     className='usericon'
                                                                 />
                                                             )}

--- a/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
@@ -34,12 +34,14 @@ import {
 import { useTheme, styled, alpha } from '@mui/material/styles'
 import DatePicker from 'react-datepicker'
 
-import Image from 'next/image'
 import robotPNG from '@/assets/images/robot.png'
 import userPNG from '@/assets/images/account.png'
 import msgEmptySVG from '@/assets/images/message_empty.svg'
 import multiagent_supervisorPNG from '@/assets/images/multiagent_supervisor.png'
 import multiagent_workerPNG from '@/assets/images/multiagent_worker.png'
+
+// Helper to extract src from Next.js StaticImageData or return string as-is
+const getImageSrc = (img) => img?.src || img || ''
 import { IconTool, IconDeviceSdCard, IconFileExport, IconEraser, IconX, IconDownload, IconPaperclip, IconBulb } from '@tabler/icons-react'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 
@@ -1227,21 +1229,21 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
                                                         >
                                                             {/* Display the correct icon depending on the message type */}
                                                             {message.type === 'apiMessage' ? (
-                                                                <Image
+                                                                <img
                                                                     style={{ marginLeft: '10px' }}
-                                                                    src={robotPNG}
+                                                                    src={getImageSrc(robotPNG)}
                                                                     alt='AI'
-                                                                    width={25}
-                                                                    height={25}
+                                                                    width='25'
+                                                                    height='25'
                                                                     className='boticon'
                                                                 />
                                                             ) : (
-                                                                <Image
+                                                                <img
                                                                     style={{ marginLeft: '10px' }}
-                                                                    src={userPNG}
+                                                                    src={getImageSrc(userPNG)}
                                                                     alt='Me'
-                                                                    width={25}
-                                                                    height={25}
+                                                                    width='25'
+                                                                    height='25'
                                                                     className='usericon'
                                                                 />
                                                             )}

--- a/packages/ui/src/views/chatmessage/AgentReasoningCard.jsx
+++ b/packages/ui/src/views/chatmessage/AgentReasoningCard.jsx
@@ -2,11 +2,13 @@ import { useState, useCallback } from 'react'
 import { Box, Card, CardContent, Chip, Stack } from '@mui/material'
 import { IconTool, IconDeviceSdCard } from '@tabler/icons-react'
 import { MemoizedReactMarkdown } from '@/ui-component/markdown/MemoizedReactMarkdown'
-import Image from 'next/image'
 import nextAgentGIF from '@/assets/images/next-agent.gif'
 import multiagent_supervisorPNG from '@/assets/images/multiagent_supervisor.png'
 import multiagent_workerPNG from '@/assets/images/multiagent_worker.png'
 import PropTypes from 'prop-types'
+
+// Helper to extract src from Next.js StaticImageData or return string as-is
+const getImageSrc = (img) => img?.src || img || ''
 
 const AgentReasoningCard = ({
     agent,
@@ -58,16 +60,14 @@ const AgentReasoningCard = ({
                         flexDirection='row'
                     >
                         <Box sx={{ height: 'auto', pr: 1 }}>
-                            <Image
+                            <img
                                 style={{
                                     objectFit: 'cover',
                                     height: '35px',
                                     width: 'auto'
                                 }}
-                                src={nextAgentGIF}
+                                src={getImageSrc(nextAgentGIF)}
                                 alt='agentPNG'
-                                width={35}
-                                height={35}
                             />
                         </Box>
                         <div>{agent.nextAgent}</div>
@@ -89,7 +89,7 @@ const AgentReasoningCard = ({
                     flexDirection='row'
                 >
                     <Box sx={{ height: 'auto', pr: 1 }}>
-                        <Image
+                        <img
                             style={{
                                 objectFit: 'cover',
                                 height: '25px',
@@ -97,8 +97,6 @@ const AgentReasoningCard = ({
                             }}
                             src={iconSrc}
                             alt='agentPNG'
-                            width={25}
-                            height={25}
                             onError={handleImageError}
                         />
                     </Box>

--- a/packages/ui/src/views/chatmessage/AgentReasoningCard.jsx
+++ b/packages/ui/src/views/chatmessage/AgentReasoningCard.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { Box, Card, CardContent, Chip, Stack } from '@mui/material'
 import { IconTool, IconDeviceSdCard } from '@tabler/icons-react'
 import { MemoizedReactMarkdown } from '@/ui-component/markdown/MemoizedReactMarkdown'
+import Image from 'next/image'
 import nextAgentGIF from '@/assets/images/next-agent.gif'
 import multiagent_supervisorPNG from '@/assets/images/multiagent_supervisor.png'
 import multiagent_workerPNG from '@/assets/images/multiagent_worker.png'
@@ -57,7 +58,7 @@ const AgentReasoningCard = ({
                         flexDirection='row'
                     >
                         <Box sx={{ height: 'auto', pr: 1 }}>
-                            <img
+                            <Image
                                 style={{
                                     objectFit: 'cover',
                                     height: '35px',
@@ -65,6 +66,8 @@ const AgentReasoningCard = ({
                                 }}
                                 src={nextAgentGIF}
                                 alt='agentPNG'
+                                width={35}
+                                height={35}
                             />
                         </Box>
                         <div>{agent.nextAgent}</div>
@@ -86,7 +89,7 @@ const AgentReasoningCard = ({
                     flexDirection='row'
                 >
                     <Box sx={{ height: 'auto', pr: 1 }}>
-                        <img
+                        <Image
                             style={{
                                 objectFit: 'cover',
                                 height: '25px',
@@ -94,6 +97,8 @@ const AgentReasoningCard = ({
                             }}
                             src={iconSrc}
                             alt='agentPNG'
+                            width={25}
+                            height={25}
                             onError={handleImageError}
                         />
                     </Box>

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -41,12 +41,14 @@ import {
     IconSparkles,
     IconVolume
 } from '@tabler/icons-react'
-import Image from 'next/image'
 import robotPNG from '@/assets/images/robot.png'
 import userPNG from '@/assets/images/account.png'
 import multiagent_supervisorPNG from '@/assets/images/multiagent_supervisor.png'
 import multiagent_workerPNG from '@/assets/images/multiagent_worker.png'
 import audioUploadSVG from '@/assets/images/wave-sound.jpg'
+
+// Helper to extract src from Next.js StaticImageData or return string as-is
+const getImageSrc = (img) => img?.src || img || ''
 
 // project import
 import NodeInputHandler from '@/views/canvas/NodeInputHandler'
@@ -1239,9 +1241,9 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
         if (nodeName) {
             return `${baseURL}/api/v1/node-icon/${nodeName}`
         } else if (instructions) {
-            return multiagent_supervisorPNG
+            return getImageSrc(multiagent_supervisorPNG)
         } else {
-            return multiagent_workerPNG
+            return getImageSrc(multiagent_workerPNG)
         }
     }
 
@@ -2423,9 +2425,9 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
                                 >
                                     {/* Display the correct icon depending on the message type */}
                                     {message.type === 'apiMessage' || message.type === 'leadCaptureMessage' ? (
-                                        <Image src={robotPNG} alt='AI' width={30} height={30} className='boticon' />
+                                        <img src={getImageSrc(robotPNG)} alt='AI' width='30' height='30' className='boticon' />
                                     ) : (
-                                        <Image src={userPNG} alt='Me' width={30} height={30} className='usericon' />
+                                        <img src={getImageSrc(userPNG)} alt='Me' width='30' height='30' className='usericon' />
                                     )}
                                     <div
                                         style={{

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -41,6 +41,7 @@ import {
     IconSparkles,
     IconVolume
 } from '@tabler/icons-react'
+import Image from 'next/image'
 import robotPNG from '@/assets/images/robot.png'
 import userPNG from '@/assets/images/account.png'
 import multiagent_supervisorPNG from '@/assets/images/multiagent_supervisor.png'
@@ -2422,9 +2423,9 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
                                 >
                                     {/* Display the correct icon depending on the message type */}
                                     {message.type === 'apiMessage' || message.type === 'leadCaptureMessage' ? (
-                                        <img src={robotPNG} alt='AI' width='30' height='30' className='boticon' />
+                                        <Image src={robotPNG} alt='AI' width={30} height={30} className='boticon' />
                                     ) : (
-                                        <img src={userPNG} alt='Me' width='30' height='30' className='usericon' />
+                                        <Image src={userPNG} alt='Me' width={30} height={30} className='usericon' />
                                     )}
                                     <div
                                         style={{


### PR DESCRIPTION
## Summary

- Fixed bot/user avatars in canvas chat showing as `[object Object]` instead of actual images
- Changed `<img>` to `<Image>` from `next/image` which handles Next.js image imports correctly

## Problem

PNG imports in Next.js return an object `{ src: 'url', width, height }` instead of a direct URL string. The existing code:
```jsx
<img src={robotPNG} ... />
```
Resulted in `src="[object Object]"` in the rendered HTML.

## Solution

Use Next.js `<Image>` component which handles the object import format automatically:
```jsx
<Image src={robotPNG} alt='AI' width={30} height={30} className='boticon' />
```

## Test plan

- [ ] Open any chatflow in canvas view
- [ ] Open the chat panel (right side)
- [ ] Verify bot avatar (robot icon) displays correctly
- [ ] Verify user avatar displays correctly

## Linear ticket

https://linear.app/answeragent/issue/AGENT-612

🤖 Generated with [Claude Code](https://claude.ai/code)