### PR TITLE
fix(ContentfulLoader): exclude archived entries from query results

### DIFF
--- a/packages/components/nodes/documentloaders/Contentful/Contentful.ts
+++ b/packages/components/nodes/documentloaders/Contentful/Contentful.ts
@@ -548,6 +548,9 @@ class ContentfulLoader extends BaseDocumentLoader {
     private async runQuery(): Promise<Document[]> {
         let query: any = this.metadata || {}
 
+        // Explicitly exclude archived entries
+        query['sys.archivedAt[exists]'] = false
+
         if (this.limit) {
             query.limit = this.limit
         }
@@ -569,15 +572,19 @@ class ContentfulLoader extends BaseDocumentLoader {
         let allEntries: ContentfulEntry[] = []
         let total: number
         let skip = 0
+        let itemsProcessed = 0
 
         try {
             do {
                 query.skip = skip
                 const response: ContentfulLoaderResponse = await client.getEntries(query)
-                allEntries = allEntries.concat(response.items)
+                // Filter out archived entries as a safety measure
+                const nonArchivedItems = response.items.filter((entry) => !entry.sys.archivedVersion)
+                allEntries = allEntries.concat(nonArchivedItems)
                 total = response.total || 0
+                itemsProcessed += response.items.length
                 skip += response.items.length
-            } while (this.includeAll && allEntries.length < total)
+            } while (this.includeAll && itemsProcessed < total)
 
             return allEntries.map((entry) => this.createDocumentFromEntry(entry))
         } catch (error) {


### PR DESCRIPTION
- Explicitly exclude archived entries in the query to ensure only active content is processed.
- Added a filter to remove archived items from the response, enhancing data integrity and performance.
- Updated the loop condition to track processed items accurately, ensuring all relevant entries are retrieved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances Contentful loader to return only active entries and ensures complete pagination.
> 
> - Adds `query['sys.archivedAt[exists]'] = false` to exclude archived entries at the API level
> - Filters fetched items to drop any with `sys.archivedVersion` before processing
> - Updates pagination loop to track `itemsProcessed` and continue while `includeAll` and `itemsProcessed < total`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee96b8cbfd357249a9ebd6fc66348be28623e983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->