### PR TITLE
fix(AGENT-639): pass entity organizationId/workspaceId in vector store options

### DIFF
--- a/packages/components/nodes/vectorstores/DocumentStoreVS/DocStoreVector.ts
+++ b/packages/components/nodes/vectorstores/DocumentStoreVS/DocStoreVector.ts
@@ -109,7 +109,9 @@ class DocStore_VectorStores implements INode {
         const vectorStoreObj = await _createVectorStoreObject(options.componentNodes, data)
         const retrieverOrVectorStore = await vectorStoreObj.init(vStoreNodeData, '', {
             ...options,
-            chatflowid: entity.id
+            chatflowid: entity.id,
+            organizationId: entity.organizationId,
+            workspaceId: entity.workspaceId
         })
         if (!retrieverOrVectorStore) {
             return { error: 'Failed to create vectorStore' }

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -597,8 +597,8 @@ const deleteVectorStoreFromStore = async (storeId: string, workspaceId: string) 
 
         const options: ICommonObject = {
             chatflowid: storeId,
-            // organizationId,
-            // userId,
+            organizationId: entity.organizationId,
+            workspaceId: entity.workspaceId,
             appDataSource: appServer.AppDataSource,
             databaseEntities,
             logger
@@ -1543,6 +1543,8 @@ const _insertIntoVectorStoreWorkerThread = async (
         const options: ICommonObject = {
             chatflowid,
             user,
+            organizationId: entity.organizationId,
+            workspaceId,
             appDataSource,
             databaseEntities,
             logger


### PR DESCRIPTION
## Summary
- Fixes Document Store Vector retrieval returning empty results when using API key auth
- Ensures consistent namespace generation across all Document Store vector store operations

## Changes
1. **DocStoreVector.ts** (component): Pass `organizationId` and `workspaceId` from the Document Store entity when initializing vector store for chatflow tool usage
2. **documentstore service (delete)**: Add `organizationId` and `workspaceId` to options for delete operations
3. **documentstore service (upsert)**: Add `organizationId` and `workspaceId` to options for upsert operations

## Root Cause
AAI Vector Store uses `generateSecureNamespace()` to create namespaces: `org:${organizationId}_chatflow:${chatflowid}_${namespace}`

When data was upserted, it used the Document Store's `entity.organizationId`. When querying via a chatflow tool, if `options.organizationId` was missing or different, the namespace wouldn't match → empty results.

## Test plan
- [ ] Deploy to staging
- [ ] Run: `./scripts/test-kumello-endpoint.sh`
- [ ] Verify `medtech_distributor` tool returns non-empty `toolOutput`