### PR TITLE
chore(ci): add caching and concurrency to GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
     workflow_dispatch:
 permissions:
     contents: read
+concurrency:
+    group: ci-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 jobs:
     build:
         strategy:
@@ -32,11 +35,25 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   cache: 'pnpm'
                   cache-dependency-path: 'pnpm-lock.yaml'
+            - name: Turbo cache
+              uses: actions/cache@v4
+              with:
+                  path: .turbo
+                  key: turbo-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
+                  restore-keys: |
+                      turbo-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
+                      turbo-${{ runner.os }}-
             - run: pnpm install
             - run: pnpm lint
             - run: pnpm build
               env:
                   NODE_OPTIONS: '--max_old_space_size=4096'
+            - name: Cache Cypress binary
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/Cypress
+                  key: cypress-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: cypress-${{ runner.os }}-
             - name: Cypress install
               run: pnpm cypress install
             - name: Install dependencies (Cypress Action)


### PR DESCRIPTION
## Summary
- Add Turbo cache to main.yml for faster builds (~3-5 min saved)
- Add Cypress binary cache to skip 200MB download (~30-60 sec saved)
- Add concurrency controls to cancel redundant CI runs on rapid pushes
- Add concurrency to claude.yml and claude-code-review.yml

## Changes
| File | Changes |
|------|---------|
| `main.yml` | +Turbo cache, +Cypress cache, +concurrency |
| `claude.yml` | +concurrency (cancel-in-progress: false) |
| `claude-code-review.yml` | +concurrency (cancel-in-progress: true) |

## Test plan
- [ ] Push branch → verify "Turbo cache" step shows in Actions
- [ ] Push again → verify cache hit in logs
- [ ] Push 2 commits quickly → verify first run gets cancelled