### PR TITLE
fix(ui): fix AppDrawer overlapping page content

### DIFF
--- a/packages-answers/ui/src/AppDrawer.tsx
+++ b/packages-answers/ui/src/AppDrawer.tsx
@@ -79,6 +79,7 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
     flexShrink: 0,
     whiteSpace: 'nowrap',
     boxSizing: 'border-box',
+    height: '100%',
     transition: theme.transitions.create('width', {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.enteringScreen
@@ -91,7 +92,9 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
         }),
         overflowX: 'hidden',
         overflowY: open ? 'auto' : 'hidden',
-        boxSizing: 'border-box'
+        boxSizing: 'border-box',
+        position: 'relative',
+        height: '100%'
     }
 }))
 


### PR DESCRIPTION
## Summary
Fixes the AppDrawer sidebar overlapping page content instead of pushing it aside.

## Changes
- `packages-answers/ui/src/AppDrawer.tsx`:
  - Added `height: '100%'` to root Drawer styled component
  - Added `position: 'relative'` to `.MuiDrawer-paper` - overrides MUI's default `position: fixed`
  - Added `height: '100%'` to `.MuiDrawer-paper`

## Root Cause
MUI's `permanent` drawer has default `position: fixed` on the drawer paper, causing it to float over content instead of participating in flex layout.

## Impact
- AppDrawer now properly pushes content to the right when open
- Content expands correctly when drawer is collapsed
- No overlap on any pages (canvas, chatflows, etc.)

## Test plan
- [ ] Verify AppDrawer open state (240px): content pushed right, no overlap
- [ ] Verify AppDrawer collapsed state (56px): content expands, icons visible
- [ ] Test canvas page (`/sidekick-studio/canvas/[id]`) - no overlap
- [ ] Test other pages like `/sidekick-studio/chatflows`
- [ ] Verify smooth transitions when toggling drawer state