### PR TITLE
fix(SUPPORT-5): Fiddler credentials read-only state for cross-workspace users

### DIFF
--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -13,7 +13,7 @@ import CircularProgress from '@mui/material/CircularProgress'
 import credentialsApi from 'flowise-ui/src/api/credentials'
 import { enqueueSnackbar as enqueueSnackbarAction, closeSnackbar as closeSnackbarAction } from 'flowise-ui/src/store/actions'
 import useConfirm from 'flowise-ui/src/hooks/useConfirm'
-import { IconX, IconUnlink, IconExternalLink, IconShieldCheck } from '@tabler/icons-react'
+import { IconX, IconUnlink, IconEdit, IconShieldCheck } from '@tabler/icons-react'
 
 // Use core Flowise dialog with defaultVisibility prop for org-wide credentials
 const AddEditCredentialDialog = dynamic(() => import('flowise-ui/src/views/credentials/AddEditCredentialDialog'), { ssr: false })
@@ -123,16 +123,33 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
         setShowCredentialDialog(false)
     }
 
-    const handleManageCredentials = () => {
-        window.open('/admin/org-credentials', '_blank')
+    const handleEditCredential = async () => {
+        if (!selectedCredentialObj) return
+        try {
+            const response = await credentialsApi.getSpecificComponentCredential('fiddlerApi')
+            const componentCredential = response.data
+            if (!componentCredential?.name) {
+                throw new Error('Failed to load Fiddler credential component')
+            }
+            setCredentialDialogProps({
+                type: 'EDIT',
+                cancelButtonName: 'Cancel',
+                confirmButtonName: 'Save',
+                credentialComponent: componentCredential,
+                credential: selectedCredentialObj
+            })
+            setShowCredentialDialog(true)
+        } catch (error) {
+            console.error('Error loading credential component:', error)
+        }
     }
 
     const handleDisconnect = async () => {
-        if (!selectedCredentialObj) return
+        const credName = selectedCredentialObj?.name || 'Fiddler credential'
 
         const isConfirmed = await confirm({
             title: 'Disconnect',
-            description: `Disconnect credential "${selectedCredentialObj.name}" from guardrails? The credential will not be deleted.`,
+            description: `Disconnect "${credName}" from guardrails? The credential will not be deleted.`,
             confirmButtonName: 'Disconnect',
             cancelButtonName: 'Cancel'
         })
@@ -167,7 +184,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
         <Box variant='outlined' sx={{ mb: 3 }}>
             {/* Enable/Disable Toggle */}
             <FormControlLabel
-                control={<Switch checked={enabled} onChange={handleEnabledChange} color='primary' disabled={isReadOnlyMode} />}
+                control={<Switch checked={enabled} onChange={handleEnabledChange} color='primary' />}
                 label='Enable Guardrails'
                 sx={{ mb: 2 }}
             />
@@ -191,16 +208,44 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                             borderRadius: 1.5,
                             bgcolor: 'action.hover',
                             border: '1px solid',
-                            borderColor: 'divider'
+                            borderColor: 'divider',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            gap: 2
                         }}
                     >
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <IconShieldCheck size={20} />
-                            <Typography variant='body2'>Guardrails are configured for your organization.</Typography>
+                        <Box sx={{ flex: 1 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                <IconShieldCheck size={20} />
+                                <Typography variant='body2'>
+                                    Fiddler guardrails are active and configured for your organization.
+                                </Typography>
+                            </Box>
+                            <Typography variant='caption' color='text.secondary' sx={{ mt: 0.5, display: 'block', ml: 3.5 }}>
+                                The connected credential is managed in another workspace.
+                            </Typography>
                         </Box>
-                        <Typography variant='caption' color='text.secondary' sx={{ mt: 1, display: 'block' }}>
-                            Contact an admin with access to manage the Fiddler credential.
-                        </Typography>
+                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                            <Button
+                                variant='outlined'
+                                size='small'
+                                color='error'
+                                onClick={handleDisconnect}
+                                startIcon={<IconUnlink size={16} />}
+                            >
+                                Disconnect
+                            </Button>
+                            {credentials.length > 0 && (
+                                <Button
+                                    variant='outlined'
+                                    size='small'
+                                    onClick={() => setShowCredentialDropdown(!showCredentialDropdown)}
+                                >
+                                    Change
+                                </Button>
+                            )}
+                        </Box>
                     </Card>
                 ) : selectedCredentialObj ? (
                     // Connected State - Show credential name with edit button
@@ -259,11 +304,10 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                                 variant='outlined'
                                 size='small'
                                 disabled={!enabled}
-                                onClick={handleManageCredentials}
-                                startIcon={<IconExternalLink size={16} />}
-                                title='Manage credentials'
+                                onClick={handleEditCredential}
+                                startIcon={<IconEdit size={16} />}
                             >
-                                Manage
+                                Edit
                             </Button>
                             <Button
                                 variant='outlined'

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -25,6 +25,15 @@ interface GuardrailConfig {
     credentialId?: string
 }
 
+interface CredentialDialogProps {
+    type: 'ADD' | 'EDIT'
+    cancelButtonName: string
+    confirmButtonName: string
+    credentialComponent: Record<string, unknown>
+    defaultVisibility?: string[]
+    data?: Credential
+}
+
 interface MasterConfigProps {
     config: GuardrailConfig
     onConfigChange: (updates: Partial<GuardrailConfig>) => void
@@ -44,7 +53,8 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
 
     // Credential modal state
     const [showCredentialDialog, setShowCredentialDialog] = useState(false)
-    const [credentialDialogProps, setCredentialDialogProps] = useState<any>({})
+    const [credentialDialogProps, setCredentialDialogProps] = useState<Partial<CredentialDialogProps>>({})
+    const [editLoading, setEditLoading] = useState(false)
     const [showCredentialDropdown, setShowCredentialDropdown] = useState(false)
 
     // Hooks for snackbar notifications and confirmation dialog
@@ -142,6 +152,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
 
     const handleEditCredential = async () => {
         if (!selectedCredentialObj) return
+        setEditLoading(true)
         try {
             const response = await credentialsApi.getSpecificComponentCredential(FIDDLER_CREDENTIAL_NAME)
             const componentCredential = response.data
@@ -159,10 +170,13 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
         } catch (error) {
             console.error('Error loading credential component:', error)
             showSnackbar('Failed to load credential editor', 'error')
+        } finally {
+            setEditLoading(false)
         }
     }
 
     const handleDisconnect = async () => {
+        if (!selectedCredential && !config?.credentialId) return
         const credName = selectedCredentialObj?.name || 'Fiddler credential'
 
         const isConfirmed = await confirm({
@@ -311,9 +325,9 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                             <Button
                                 variant='outlined'
                                 size='small'
-                                disabled={!enabled}
+                                disabled={!enabled || editLoading}
                                 onClick={handleEditCredential}
-                                startIcon={<IconEdit size={16} />}
+                                startIcon={editLoading ? <CircularProgress size={16} /> : <IconEdit size={16} />}
                             >
                                 Edit
                             </Button>

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -148,7 +148,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                 cancelButtonName: 'Cancel',
                 confirmButtonName: 'Save',
                 credentialComponent: componentCredential,
-                credential: selectedCredentialObj
+                data: selectedCredentialObj
             })
             setShowCredentialDialog(true)
         } catch (error) {

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -18,9 +18,16 @@ import { IconX, IconUnlink, IconEdit, IconShieldCheck } from '@tabler/icons-reac
 // Use core Flowise dialog with defaultVisibility prop for org-wide credentials
 const AddEditCredentialDialog = dynamic(() => import('flowise-ui/src/views/credentials/AddEditCredentialDialog'), { ssr: false })
 
+const FIDDLER_CREDENTIAL_NAME = 'fiddlerApi'
+
+interface GuardrailConfig {
+    enabled?: boolean
+    credentialId?: string
+}
+
 interface MasterConfigProps {
-    config: any
-    onConfigChange: (updates: Partial<any>) => void
+    config: GuardrailConfig
+    onConfigChange: (updates: Partial<GuardrailConfig>) => void
 }
 
 interface Credential {
@@ -46,6 +53,21 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
     const closeSnackbar = (...args: any[]) => dispatch(closeSnackbarAction(...args))
     const { confirm } = useConfirm()
 
+    const showSnackbar = (message: string, variant: 'success' | 'error') => {
+        enqueueSnackbar({
+            message,
+            options: {
+                key: new Date().getTime() + Math.random(),
+                variant,
+                action: (key: any) => (
+                    <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
+                        <IconX />
+                    </Button>
+                )
+            }
+        })
+    }
+
     // Load Fiddler credentials on mount
     useEffect(() => {
         loadCredentials()
@@ -60,7 +82,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
     const loadCredentials = async () => {
         try {
             setLoadingCredentials(true)
-            const response = await credentialsApi.getCredentialsByName('fiddlerApi')
+            const response = await credentialsApi.getCredentialsByName(FIDDLER_CREDENTIAL_NAME)
             setCredentials(response.data || [])
         } catch (error) {
             console.error('Failed to load Fiddler credentials:', error)
@@ -75,16 +97,10 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
         onConfigChange({ enabled: newEnabled })
     }
 
-    const handleCredentialChange = (event: any) => {
-        const newCredentialId = event.target.value
-        setSelectedCredential(newCredentialId)
-        onConfigChange({ credentialId: newCredentialId })
-    }
-
     const handleCreateCredential = async () => {
         try {
             // Load the Fiddler credential component schema
-            const response = await credentialsApi.getSpecificComponentCredential('fiddlerApi')
+            const response = await credentialsApi.getSpecificComponentCredential(FIDDLER_CREDENTIAL_NAME)
             const componentCredential = response.data
 
             if (!componentCredential?.name) {
@@ -102,18 +118,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
             setShowCredentialDialog(true)
         } catch (error) {
             console.error('Error loading credential component:', error)
-            enqueueSnackbar({
-                message: 'Failed to load credential component',
-                options: {
-                    key: new Date().getTime() + Math.random(),
-                    variant: 'error',
-                    action: (key: any) => (
-                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
-                            <IconX />
-                        </Button>
-                    )
-                }
-            })
+            showSnackbar('Failed to load credential component', 'error')
         }
     }
 
@@ -138,7 +143,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
     const handleEditCredential = async () => {
         if (!selectedCredentialObj) return
         try {
-            const response = await credentialsApi.getSpecificComponentCredential('fiddlerApi')
+            const response = await credentialsApi.getSpecificComponentCredential(FIDDLER_CREDENTIAL_NAME)
             const componentCredential = response.data
             if (!componentCredential?.name) {
                 throw new Error('Failed to load Fiddler credential component')
@@ -153,18 +158,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
             setShowCredentialDialog(true)
         } catch (error) {
             console.error('Error loading credential component:', error)
-            enqueueSnackbar({
-                message: 'Failed to load credential editor',
-                options: {
-                    key: new Date().getTime() + Math.random(),
-                    variant: 'error',
-                    action: (key: any) => (
-                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
-                            <IconX />
-                        </Button>
-                    )
-                }
-            })
+            showSnackbar('Failed to load credential editor', 'error')
         }
     }
 
@@ -181,18 +175,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
         if (isConfirmed) {
             setSelectedCredential('')
             onConfigChange({ credentialId: '', enabled: false })
-            enqueueSnackbar({
-                message: 'Credential disconnected from guardrails',
-                options: {
-                    key: new Date().getTime() + Math.random(),
-                    variant: 'success',
-                    action: (key: any) => (
-                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
-                            <IconX />
-                        </Button>
-                    )
-                }
-            })
+            showSnackbar('Credential disconnected from guardrails', 'success')
         }
     }
 
@@ -241,16 +224,17 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                     >
                         <Box sx={{ flex: 1 }}>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                <IconShieldCheck size={20} />
+                                <IconShieldCheck size={20} aria-label="Guardrails configured" />
                                 <Typography variant='body2'>
                                     Fiddler guardrails are active and configured for your organization.
                                 </Typography>
                             </Box>
                             <Typography variant='caption' color='text.secondary' sx={{ mt: 0.5, display: 'block', ml: 3.5 }}>
-                                The connected credential is managed in another workspace.
+                                This credential is managed by another member of your organization.
                             </Typography>
                         </Box>
                         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                            {/* Disconnect is intentionally always enabled in read-only mode so any org member can disconnect guardrails */}
                             <Button
                                 variant='outlined'
                                 size='small'

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -245,6 +245,9 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                             </Box>
                             <Typography variant='caption' color='text.secondary' sx={{ mt: 0.5, display: 'block', ml: 3.5 }}>
                                 This credential is managed by another member of your organization.
+                                {config?.credentialId && (
+                                    <> (ID: {config.credentialId.slice(0, 8)}…)</>
+                                )}
                             </Typography>
                         </Box>
                         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
@@ -258,6 +261,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                             >
                                 Disconnect
                             </Button>
+                            {/* Show Change when user owns any credentials they could switch to */}
                             {credentials.length > 0 && (
                                 <Button
                                     variant='outlined'
@@ -341,6 +345,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                             >
                                 Disconnect
                             </Button>
+                            {/* > 1 because the currently selected credential doesn't count as an alternative */}
                             {credentials.length > 1 && (
                                 <Button
                                     variant='outlined'

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -59,7 +59,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
 
     const loadCredentials = async () => {
         try {
-            setLoadingCredentials(false)
+            setLoadingCredentials(true)
             const response = await credentialsApi.getCredentialsByName('fiddlerApi')
             setCredentials(response.data || [])
         } catch (error) {
@@ -102,6 +102,18 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
             setShowCredentialDialog(true)
         } catch (error) {
             console.error('Error loading credential component:', error)
+            enqueueSnackbar({
+                message: 'Failed to load credential component',
+                options: {
+                    key: new Date().getTime() + Math.random(),
+                    variant: 'error',
+                    action: (key: any) => (
+                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
+                            <IconX />
+                        </Button>
+                    )
+                }
+            })
         }
     }
 
@@ -141,6 +153,18 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
             setShowCredentialDialog(true)
         } catch (error) {
             console.error('Error loading credential component:', error)
+            enqueueSnackbar({
+                message: 'Failed to load credential editor',
+                options: {
+                    key: new Date().getTime() + Math.random(),
+                    variant: 'error',
+                    action: (key: any) => (
+                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
+                            <IconX />
+                        </Button>
+                    )
+                }
+            })
         }
     }
 


### PR DESCRIPTION
## Summary
- Users who can't access the configured Fiddler credential now see a trust message ("Fiddler guardrails are active and configured for your organization") with Disconnect and Change buttons
- Users with credential access see Edit (opens credential modal), Disconnect, and Change buttons
- Enable Guardrails toggle always works regardless of credential access

## Test plan
- [ ] User A (Workspace 1): Create Fiddler credential, configure guardrails
- [ ] User B (Workspace 2, same org): See read-only trust message with Disconnect/Change
- [ ] User A: See Edit/Disconnect/Change buttons, Edit opens credential modal
- [ ] Toggle works in both states
- [ ] Disconnect works from both states
- [ ] Change credential dropdown works from both states