### PR TITLE
fix(SUPPORT-5): address PR review feedback for Fiddler credentials

### DIFF
--- a/packages-answers/ui/src/Admin/index.tsx
+++ b/packages-answers/ui/src/Admin/index.tsx
@@ -20,7 +20,7 @@ const AdminDashboard = () => {
                 <Box
                     sx={{
                         display: 'grid',
-                        gridTemplateColumns: 'repeat(3, 1fr)',
+                        gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
                         gap: 3
                     }}
                 >

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -96,6 +96,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
             setCredentials(response.data || [])
         } catch (error) {
             console.error('Failed to load Fiddler credentials:', error)
+            showSnackbar('Failed to load credentials', 'error')
         } finally {
             setLoadingCredentials(false)
         }
@@ -339,7 +340,6 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                                 variant='outlined'
                                 size='small'
                                 color='error'
-                                disabled={!enabled}
                                 onClick={handleDisconnect}
                                 startIcon={<IconUnlink size={16} />}
                             >


### PR DESCRIPTION
## Summary
- Add error snackbar when credential loading fails (was silent `console.error` only)
- Make admin dashboard grid responsive (`xs: 1col`, `sm: 2col`, `md: 3col`)
- Remove `disabled={!enabled}` from Disconnect button in connected state — users should be able to disconnect regardless of toggle state

## Test plan
- [ ] Verify error snackbar appears when credential API fails
- [ ] Verify admin dashboard grid stacks on narrow viewports
- [ ] Verify Disconnect button works when guardrails toggle is off