### PR TITLE
fix(SUPPORT-5): add ConfirmDialog and persist disconnect to API

### DIFF
--- a/packages-answers/ui/src/GuardrailsSettings.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings.tsx
@@ -97,7 +97,7 @@ export default function GuardrailsSettings({ organizationId }: { organizationId:
             </Typography>
 
             {/* Master Configuration - Shared across all modes */}
-            <MasterConfig config={config} onConfigChange={handleConfigChange} />
+            <MasterConfig config={config} onConfigChange={handleConfigChange} onSave={handleSave} />
 
             <Box
                 sx={{

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -17,6 +17,7 @@ import { IconX, IconUnlink, IconEdit, IconShieldCheck } from '@tabler/icons-reac
 
 // Use core Flowise dialog with defaultVisibility prop for org-wide credentials
 const AddEditCredentialDialog = dynamic(() => import('flowise-ui/src/views/credentials/AddEditCredentialDialog'), { ssr: false })
+const ConfirmDialog = dynamic(() => import('flowise-ui/src/ui-component/dialog/ConfirmDialog'), { ssr: false })
 
 const FIDDLER_CREDENTIAL_NAME = 'fiddlerApi'
 
@@ -37,6 +38,7 @@ interface CredentialDialogProps {
 interface MasterConfigProps {
     config: GuardrailConfig
     onConfigChange: (updates: Partial<GuardrailConfig>) => void
+    onSave: (config: GuardrailConfig) => void
 }
 
 interface Credential {
@@ -45,7 +47,7 @@ interface Credential {
     credentialName: string
 }
 
-export default function MasterConfig({ config, onConfigChange }: MasterConfigProps) {
+export default function MasterConfig({ config, onConfigChange, onSave }: MasterConfigProps) {
     const [enabled, setEnabled] = useState<boolean>(config?.enabled ?? false)
     const [selectedCredential, setSelectedCredential] = useState<string>(config?.credentialId ?? '')
     const [credentials, setCredentials] = useState<Credential[]>([])
@@ -190,6 +192,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
         if (isConfirmed) {
             setSelectedCredential('')
             onConfigChange({ credentialId: '', enabled: false })
+            onSave({ ...config, credentialId: '', enabled: false })
             showSnackbar('Credential disconnected from guardrails', 'success')
         }
     }
@@ -424,6 +427,7 @@ export default function MasterConfig({ config, onConfigChange }: MasterConfigPro
                 onCancel={handleCredentialDialogCancel}
                 onConfirm={handleCredentialDialogConfirm}
             />
+            <ConfirmDialog />
         </Box>
     )
 }

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -146,6 +146,7 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
             setSelectedCredential(credentialId)
             setEnabled(true)
             onConfigChange({ credentialId: credentialId, enabled: true })
+            onSave({ ...config, credentialId, enabled: true })
         }
     }
 
@@ -409,6 +410,7 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                                         setSelectedCredential(cred.id)
                                         setEnabled(true)
                                         onConfigChange({ credentialId: cred.id, enabled: true })
+                                        onSave({ ...config, credentialId: cred.id, enabled: true })
                                         setShowCredentialDropdown(false)
                                     }}
                                 >


### PR DESCRIPTION
## Summary
- Add missing `<ConfirmDialog />` render in MasterConfig so `useConfirm()` actually displays the dialog (disconnect button was silently hanging)
- Persist disconnect to the API by calling `onSave` after local state update, so disconnecting survives a page refresh

## Test plan
- [ ] Click Disconnect in read-only mode → confirm dialog appears → credential disconnects → persists on refresh
- [ ] Click Disconnect in connected mode → same behavior
- [ ] Edit button still works (no regression)