### PR TITLE
fix(SUPPORT-5): PR review feedback for Fiddler credentials

### DIFF
--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -269,7 +269,8 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                             {/* Show Change when user owns any credentials they could switch to */}
                             {credentials.length > 0 && (
                                 <Button
-                                    variant='outlined'
+                                    variant='contained'
+                                    color='secondary'
                                     size='small'
                                     onClick={() => setShowCredentialDropdown(!showCredentialDropdown)}
                                 >
@@ -352,7 +353,8 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                             {/* > 1 because the currently selected credential doesn't count as an alternative */}
                             {credentials.length > 1 && (
                                 <Button
-                                    variant='outlined'
+                                    variant='contained'
+                                    color='secondary'
                                     size='small'
                                     disabled={!enabled}
                                     onClick={() => setShowCredentialDropdown(!showCredentialDropdown)}
@@ -374,7 +376,8 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                             </Button>
                             {credentials.length > 0 && (
                                 <Button
-                                    variant='outlined'
+                                    variant='contained'
+                                    color='secondary'
                                     onClick={() => setShowCredentialDropdown(!showCredentialDropdown)}
                                     sx={{ minWidth: 140 }}
                                 >


### PR DESCRIPTION
## Summary
- Fix disconnect button silently hanging by adding missing `<ConfirmDialog />` render
- Persist disconnect and credential connect to the API immediately (no manual save needed)
- Use `contained secondary` style for "Use existing" and "Change" buttons for better visibility
- Add error snackbar on credential load failure, responsive admin grid, allow disconnect when disabled

## Test plan
- [ ] Click Disconnect → confirm dialog appears → credential disconnects → persists on refresh
- [ ] Connect new credential via dialog → auto-saves without hitting Save
- [ ] Select existing credential from dropdown → auto-saves without hitting Save
- [ ] "Use existing" and "Change" buttons are clearly visible
- [ ] Edit button still works (no regression)