### PR TITLE
fix(guardrails): apply Fiddler guardrails to embed endpoint

### DIFF
--- a/packages/server/src/services/guardrails/FiddlerGuardrailsService.ts
+++ b/packages/server/src/services/guardrails/FiddlerGuardrailsService.ts
@@ -18,7 +18,6 @@ import { getGuardrailsConfig } from './config'
 import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
 import { Credential } from '../../database/entities/Credential'
 import { decryptCredentialData } from '../../utils'
-import { IUser } from '../../Interface'
 import {
     GuardrailsConfig,
     GuardrailAction,
@@ -82,29 +81,34 @@ export class FiddlerGuardrailsService {
      * Handles config loading, credential resolution, and service initialization
      *
      * @param chatflowId - Chatflow ID for config hierarchy
-     * @param user - User context for organization scoping
+     * @param workspaceId - Workspace ID for credential lookup (required, credentials are workspace-scoped)
+     * @param organizationId - Organization ID for org-level config (optional)
      * @returns Initialized service or null if disabled/no credentials
      *
      * @example
-     * const service = await FiddlerGuardrailsService.createFromContext(chatflowId, user)
+     * const service = await FiddlerGuardrailsService.createFromContext(chatflowId, workspaceId, orgId)
      * if (service) {
      *   const result = await service.validateInput(text)
      * }
      */
-    public static async createFromContext(chatflowId: string, user: IUser): Promise<FiddlerGuardrailsService | null> {
+    public static async createFromContext(
+        chatflowId: string,
+        workspaceId: string,
+        organizationId?: string
+    ): Promise<FiddlerGuardrailsService | null> {
         try {
             // 1. Load configuration (env → org → chatflow)
-            const config = await getGuardrailsConfig(chatflowId, user)
+            const config = await getGuardrailsConfig(chatflowId, organizationId)
 
             // 2. Check if guardrails are enabled
             if (!config.enabled) {
                 return null
             }
 
-            // 3. Load credentials with fallback chain
-            const credentials = await this.loadCredentials(user.organizationId!, config)
+            // 3. Load credentials with fallback chain (using workspaceId since credentials are workspace-scoped)
+            const credentials = await this.loadCredentials(workspaceId, config)
             if (!credentials) {
-                console.warn(`Guardrails enabled but no credentials found for organization ${user.organizationId}`)
+                console.warn(`Guardrails enabled but no credentials found for workspace ${workspaceId}`)
                 return null
             }
 
@@ -119,13 +123,13 @@ export class FiddlerGuardrailsService {
 
     /**
      * Load Fiddler credentials with multi-tier fallback
-     * Priority: Config credentialId → Org credential by name → Environment variables
+     * Priority: Config credentialId → Workspace credential by name → Environment variables
      *
-     * @param organizationId - Organization ID for scoping
+     * @param workspaceId - Workspace ID for credential scoping (credentials are workspace-scoped)
      * @param config - Guardrails configuration
      * @returns Credentials or null if not found
      */
-    private static async loadCredentials(organizationId: string, config: GuardrailsConfig): Promise<FiddlerCredentials | null> {
+    private static async loadCredentials(workspaceId: string, config: GuardrailsConfig): Promise<FiddlerCredentials | null> {
         try {
             const appServer = getRunningExpressApp()
             const credentialRepository = appServer.AppDataSource.getRepository(Credential)
@@ -135,7 +139,7 @@ export class FiddlerGuardrailsService {
                 const credential = await credentialRepository.findOne({
                     where: {
                         id: config.credentialId,
-                        organizationId
+                        workspaceId
                     }
                 })
 
@@ -148,11 +152,11 @@ export class FiddlerGuardrailsService {
                 }
             }
 
-            // Priority 2: Find org's Fiddler credential by name
+            // Priority 2: Find workspace's Fiddler credential by name
             const credentials = await credentialRepository.find({
                 where: {
                     credentialName: 'fiddlerApi',
-                    organizationId
+                    workspaceId
                 }
             })
 
@@ -169,7 +173,7 @@ export class FiddlerGuardrailsService {
             const envApiUrl = process.env.FIDDLER_API_URL
 
             if (envApiKey && envApiUrl) {
-                console.log(`Using Fiddler credentials from environment variables for organization ${organizationId}`)
+                console.log(`Using Fiddler credentials from environment variables for workspace ${workspaceId}`)
                 return {
                     apiKey: envApiKey,
                     apiUrl: envApiUrl

--- a/packages/server/src/services/guardrails/config.ts
+++ b/packages/server/src/services/guardrails/config.ts
@@ -14,7 +14,6 @@ import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
 import { Organization } from '../../database/entities/Organization'
 import { ChatFlow } from '../../database/entities/ChatFlow'
 import { GuardrailsConfig, DEFAULT_GUARDRAILS_CONFIG, OrganizationConfig, ChatflowConfig, GuardrailAction } from '../../types/guardrails'
-import { IUser } from '../../Interface'
 
 /**
  * Load configuration from environment variables
@@ -192,8 +191,11 @@ export function deepMergeConfigs(base: Partial<GuardrailsConfig>, override: Part
 /**
  * Get complete guardrails configuration for a chatflow
  * Merges: Environment → Organization → Chatflow
+ *
+ * @param chatflowId - Chatflow ID for config hierarchy
+ * @param organizationId - Organization ID for org-level config (works for both authenticated and embed requests)
  */
-export async function getGuardrailsConfig(chatflowId: string, user: IUser): Promise<GuardrailsConfig> {
+export async function getGuardrailsConfig(chatflowId: string, organizationId?: string): Promise<GuardrailsConfig> {
     // Start with defaults
     let config: Partial<GuardrailsConfig> = { ...DEFAULT_GUARDRAILS_CONFIG }
 
@@ -202,8 +204,8 @@ export async function getGuardrailsConfig(chatflowId: string, user: IUser): Prom
     config = deepMergeConfigs(config, envConfig)
 
     // Layer 2: Organization config
-    if (user?.organizationId) {
-        const orgConfig = await getOrganizationConfig(user.organizationId)
+    if (organizationId) {
+        const orgConfig = await getOrganizationConfig(organizationId)
         config = deepMergeConfigs(config, orgConfig)
     }
 

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -354,9 +354,9 @@ export const executeFlow = async ({
      * - Actions: block, redact, warn, continue
      */
     let guardrailsMetadata: Partial<GuardrailsMetadata> | undefined
-    if (user?.organizationId) {
+    if (workspaceId) {
         try {
-            const guardrailsService = await FiddlerGuardrailsService.createFromContext(chatflowid, user)
+            const guardrailsService = await FiddlerGuardrailsService.createFromContext(chatflowid, workspaceId, orgId)
 
             if (guardrailsService) {
                 const validationResult = await guardrailsService.validateInput(question)
@@ -718,9 +718,9 @@ export const executeFlow = async ({
              * - Faithfulness checks (RAG hallucination detection)
              * - Always fails open (never blocks output)
              */
-            if (user?.organizationId && guardrailsMetadata) {
+            if (workspaceId && guardrailsMetadata) {
                 try {
-                    const guardrailsService = await FiddlerGuardrailsService.createFromContext(chatflowid, user)
+                    const guardrailsService = await FiddlerGuardrailsService.createFromContext(chatflowid, workspaceId, orgId)
 
                     if (guardrailsService) {
                         // Extract context from sourceDocuments for faithfulness checking
@@ -1026,9 +1026,9 @@ export const executeFlow = async ({
          * - Faithfulness checks (RAG hallucination detection)
          * - Always fails open (never blocks output)
          */
-        if (user?.organizationId && guardrailsMetadata) {
+        if (workspaceId && guardrailsMetadata) {
             try {
-                const guardrailsService = await FiddlerGuardrailsService.createFromContext(chatflowid, user)
+                const guardrailsService = await FiddlerGuardrailsService.createFromContext(chatflowid, workspaceId, orgId)
 
                 if (guardrailsService) {
                     // Extract context from sourceDocuments for faithfulness checking


### PR DESCRIPTION
## Summary

Fixes a security gap where Fiddler guardrails (safety checks, PII detection) were bypassed for embed/public API requests because they don't have an authenticated user object.

**Root cause:** The code checked `if (user?.organizationId)` before applying guardrails - embed requests don't have a user, so guardrails were skipped entirely.

## Changes

- **config.ts** - `getGuardrailsConfig(chatflowId, user)` → `getGuardrailsConfig(chatflowId, organizationId?)` - Takes organizationId directly instead of extracting from user object
- **FiddlerGuardrailsService.ts** - `createFromContext(chatflowId, user)` → `createFromContext(chatflowId, workspaceId, organizationId?)` - Now requires workspaceId for credential lookup (credentials are workspace-scoped)
- **buildChatflow.ts** - Changed `if (user?.organizationId)` to `if (workspaceId)` at 3 locations:
  - Line 357: Input validation
  - Line 721: Agent flow output validation  
  - Line 1029: Regular flow output validation

## Impact

| Before | After |
|--------|-------|
| Embed users could bypass safety checks | All requests validated through Fiddler |
| PII could leak through embed endpoint | PII detected/redacted for all requests |
| No logging for embed violations | Violations logged (with `userId: undefined`) |

## Test plan

- [ ] Test authenticated request still works with guardrails
- [ ] Test embed endpoint (`/api/v1/prediction/{chatflowId}`) now applies guardrails
- [ ] Test PII content is blocked/redacted on embed requests
- [ ] Test safety violations are blocked on embed requests

```bash
# Should now be blocked (was previously allowed)
curl -X POST /api/v1/prediction/{chatflowId} \
  -d '{"question": "my credit card number is 567890"}'
# Expected: "Content blocked - Safety: fdl_illegal, fdl_harmful, fdl_unethical"
```

🤖 Generated with [Claude Code](https://claude.ai/code)