### PR TITLE
fix(AGENT-582): fix chat selector not switching chatflows when viewing previous chat

### DIFF
--- a/packages-answers/ui/src/SidekickSelect/hooks/useSidekickSelectionHandlers.ts
+++ b/packages-answers/ui/src/SidekickSelect/hooks/useSidekickSelectionHandlers.ts
@@ -44,19 +44,14 @@ const useSidekickSelectionHandlers = ({ chat, navigate }: UseSidekickSelectionHa
                 setSelectedSidekick(sidekick as unknown as SidekickListItem)
                 setSidekick(sidekick as unknown as SidekickListItem)
 
-                if (!chat?.id) {
-                    // No active chat - navigate to chat with this sidekick
-                    router.push(`/chat/${sidekick.id}`)
-                } else {
-                    // Already in chat - just switch sidekicks (no navigation)
-                    setIsMarketplaceDialogOpen(false)
-                }
+                setIsMarketplaceDialogOpen(false)
+                router.push(`/chat/${sidekick.id}`)
             } else {
                 // Non-executable sidekicks (templates) - navigate to marketplace to view/clone
                 router.push(`/sidekick-studio/marketplace/${sidekick.id}`)
             }
         },
-        [chat, setSidekick, setSelectedSidekick, router]
+        [setSidekick, setSelectedSidekick, router]
     )
 
     const handleCreateNewSidekick = useCallback(() => {


### PR DESCRIPTION
## Summary
Fixes [AGENT-582](https://linear.app/answeragent/issue/AGENT-582): When viewing a previous chat from the sidebar (`/chat/[chatId]`), selecting a different chatflow from the "Search for a sidekick" dropdown didn't actually switch chatflows. The UI appeared to change but the active chat remained unchanged.

## Root Cause
In `useSidekickSelectionHandlers.ts`, the `handleSidekickSelect` function had conditional logic that only navigated when no chat existed:

```typescript
if (!chat?.id) {
    router.push(`/chat/${sidekick.id}`)  // Works: navigates to new chatflow
} else {
    setIsMarketplaceDialogOpen(false)    // BUG: Only closes dialog, no navigation!
}
```

The chat page is a **Server Component** that fetches data based on URL params. Without navigation, the server component doesn't re-fetch, so the chatflow doesn't change.

## Changes
- **`packages-answers/ui/src/SidekickSelect/hooks/useSidekickSelectionHandlers.ts`**
  - Removed conditional logic that skipped navigation when viewing an existing chat
  - Now always calls `router.push(`/chat/${sidekick.id}`)` to trigger Server Component re-fetch
  - Removed unused `chat` from the useCallback dependency array

## Impact
- Fixes chatflow switching when viewing previous chats
- No breaking changes - maintains existing behavior for fresh `/chat` page
- Minimal change: 3 lines added, 8 lines removed

## Test plan
- [ ] Go to `/chat`, switch chatflows (should still work)
- [ ] Click a previous chat from sidebar to navigate to `/chat/[chatId]`
- [ ] Open sidekick selector and choose a different chatflow
- [ ] Verify the chatflow actually switches (URL changes, new chat starts)
- [ ] Test multiple rapid switches
- [ ] Test browser back button behavior

🤖 Generated with [Claude Code](https://claude.ai/code)