### PR TITLE
fix(AGENT-612): Apply getImageSrc helper to SelectVariable.jsx

### DIFF
--- a/packages/ui/src/ui-component/json/SelectVariable.jsx
+++ b/packages/ui/src/ui-component/json/SelectVariable.jsx
@@ -8,6 +8,9 @@ import diskPNG from '@/assets/images/floppy-disc.png'
 import fileAttachmentPNG from '@/assets/images/fileAttachment.png'
 import { baseURL } from '@/store/constant'
 
+// Helper to handle Next.js PNG imports that return {src, width, height} instead of URL strings
+const getImageSrc = (img) => img?.src || img || ''
+
 const sequentialStateMessagesSelection = [
     {
         primary: '$flow.state.messages',
@@ -74,7 +77,7 @@ const SelectVariable = ({ availableNodesForVariable, disabled = false, onSelectA
                                                         objectFit: 'contain'
                                                     }}
                                                     alt='AI'
-                                                    src={robotPNG}
+                                                    src={getImageSrc(robotPNG)}
                                                 />
                                             </div>
                                         </ListItemAvatar>
@@ -109,7 +112,7 @@ const SelectVariable = ({ availableNodesForVariable, disabled = false, onSelectA
                                                         objectFit: 'contain'
                                                     }}
                                                     alt='chatHistory'
-                                                    src={chatPNG}
+                                                    src={getImageSrc(chatPNG)}
                                                 />
                                             </div>
                                         </ListItemAvatar>
@@ -148,7 +151,7 @@ const SelectVariable = ({ availableNodesForVariable, disabled = false, onSelectA
                                                         objectFit: 'contain'
                                                     }}
                                                     alt='fileAttachment'
-                                                    src={fileAttachmentPNG}
+                                                    src={getImageSrc(fileAttachmentPNG)}
                                                 />
                                             </div>
                                         </ListItemAvatar>
@@ -249,7 +252,7 @@ const SelectVariable = ({ availableNodesForVariable, disabled = false, onSelectA
                                                                 objectFit: 'contain'
                                                             }}
                                                             alt='state'
-                                                            src={diskPNG}
+                                                            src={getImageSrc(diskPNG)}
                                                         />
                                                     </div>
                                                 </ListItemAvatar>


### PR DESCRIPTION
Completes the fix for AGENT-612 by applying the getImageSrc helper to SelectVariable.jsx, which was missed in PR #884.

## Problem
Next.js PNG imports return objects with structure {src, width, height} instead of URL strings. When used directly in img tags, they render as [object Object].

PR #884 fixed this in ChatMessage.jsx, ViewMessagesDialog.jsx, and AgentReasoningCard.jsx, but SelectVariable.jsx was missed.

## Solution
Added the getImageSrc helper function and applied it to all four PNG image usages in SelectVariable.jsx:
- robotPNG (line 80)
- chatPNG (line 115)
- fileAttachmentPNG (line 154)
- diskPNG (line 255)

## Testing
- Build succeeded: pnpm build completed without errors
- Changes follow the same pattern as PR #884
- All four PNG imports now properly handled

## Related
- Completes PR #884
- Fixes AGENT-612

Generated with Claude Code