### PR TITLE
fix(AGENT-664): include config fields when creating new chatflow from import

### DIFF
--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -255,6 +255,20 @@ const AgentflowCanvas = ({ chatflowid: chatflowId }) => {
             const flowData = JSON.stringify(rfInstanceObject)
 
             if (!chatflow.id) {
+                // Include configuration fields from imported JSON (stored in Redux)
+                const configFields = [
+                    'description',
+                    'category',
+                    'visibility',
+                    'chatbotConfig',
+                    'apiConfig',
+                    'analytic',
+                    'speechToText',
+                    'textToSpeech',
+                    'followUpPrompts',
+                    'answersConfig',
+                    'browserExtConfig'
+                ]
                 const newChatflowBody = {
                     name: chatflowName,
                     deployed: false,
@@ -262,6 +276,12 @@ const AgentflowCanvas = ({ chatflowid: chatflowId }) => {
                     flowData,
                     type: 'AGENTFLOW'
                 }
+                // Only include config fields that are defined to avoid sending undefined
+                configFields.forEach((field) => {
+                    if (chatflow[field] !== undefined) {
+                        newChatflowBody[field] = chatflow[field]
+                    }
+                })
                 createNewChatflowApi.request(newChatflowBody)
             } else {
                 // Only include configuration fields that are defined to avoid clearing existing data

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -264,6 +264,20 @@ const Canvas = ({ chatflowid: chatflowId }) => {
             const flowData = JSON.stringify(rfInstanceObject)
 
             if (!chatflow.id) {
+                // Include configuration fields from imported JSON (stored in Redux)
+                const configFields = [
+                    'description',
+                    'category',
+                    'visibility',
+                    'chatbotConfig',
+                    'apiConfig',
+                    'analytic',
+                    'speechToText',
+                    'textToSpeech',
+                    'followUpPrompts',
+                    'answersConfig',
+                    'browserExtConfig'
+                ]
                 const newChatflowBody = {
                     name: chatflowName,
                     deployed: false,
@@ -271,6 +285,12 @@ const Canvas = ({ chatflowid: chatflowId }) => {
                     flowData,
                     type: isAgentCanvas ? 'MULTIAGENT' : 'CHATFLOW'
                 }
+                // Only include config fields that are defined to avoid sending undefined
+                configFields.forEach((field) => {
+                    if (chatflow[field] !== undefined) {
+                        newChatflowBody[field] = chatflow[field]
+                    }
+                })
                 createNewChatflowApi.request(newChatflowBody)
             } else {
                 setChatflowName(chatflowName)


### PR DESCRIPTION
## Summary
- Fixes config fields not being saved when importing JSON to create a **new** chatflow
- The previous fix (#932) only addressed the UPDATE path, not the CREATE path

## Problem
When importing a downloaded JSON file:
1. `handleLoadFlow` correctly stores config fields in Redux
2. But `handleSaveFlow` for **new chatflows** only sent `name`, `flowData`, `type`
3. Config fields (description, category, visibility, etc.) were lost

## Solution
Include config fields from Redux state when creating new chatflows, same pattern as the update path.

## Files Changed
- `packages/ui/src/views/canvas/index.jsx` - Chatflows
- `packages/ui/src/views/agentflowsv2/Canvas.jsx` - AgentflowV2

## Test plan
1. Download an existing chatflow JSON with settings (description, category, etc.)
2. Go to create new chatflow
3. Import the downloaded JSON
4. Verify settings appear in the canvas
5. Save the chatflow with a name
6. Reload the page
7. Verify settings persisted

🤖 Generated with [Claude Code](https://claude.ai/code)