### PR TITLE
feat(AGENT-567): restore node-level Langfuse tracing for agentflows

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -1002,7 +1002,8 @@ class Agent_Agentflow implements INode {
                     llmWithoutToolsBind,
                     isStreamable,
                     isLastNode,
-                    iterationContext
+                    iterationContext,
+                    nodeData
                 })
 
                 response = result.response
@@ -1053,7 +1054,8 @@ class Agent_Agentflow implements INode {
                     llmNodeInstance,
                     isStreamable,
                     isLastNode,
-                    iterationContext
+                    iterationContext,
+                    nodeData
                 })
 
                 response = result.response
@@ -1706,7 +1708,8 @@ class Agent_Agentflow implements INode {
         llmNodeInstance,
         isStreamable,
         isLastNode,
-        iterationContext
+        iterationContext,
+        nodeData
     }: {
         response: AIMessageChunk
         messages: BaseMessageLike[]
@@ -1717,6 +1720,7 @@ class Agent_Agentflow implements INode {
         options: ICommonObject
         abortController: AbortController
         llmNodeInstance: BaseChatModel
+        nodeData: INodeData
         isStreamable: boolean
         isLastNode: boolean
         iterationContext: ICommonObject
@@ -1803,8 +1807,17 @@ class Agent_Agentflow implements INode {
                     return { response, usedTools, sourceDocuments, artifacts, totalTokens, isWaitingForHumanInput: true }
                 }
 
+                // Create Langfuse tool span for hierarchical tracing
+                const parentToolSpan = (options as any).parentLangfuseSpan
+                let toolSpan = options.analyticHandlers?.createToolSpan(parentToolSpan, toolCall.name, toolCall.args, {
+                    nodeId: nodeData.id,
+                    nodeLabel: nodeData.label,
+                    toolCallId: toolCall.id
+                })
+
+                // Fallback to legacy tracking if no tool span
                 let toolIds: ICommonObject | undefined
-                if (options.analyticHandlers) {
+                if (!toolSpan && options.analyticHandlers) {
                     toolIds = await options.analyticHandlers.onToolStart(toolCall.name, toolCall.args, options.parentTraceIds)
                 }
 
@@ -1812,7 +1825,14 @@ class Agent_Agentflow implements INode {
                     //@ts-ignore
                     let toolOutput = await selectedTool.call(toolCall.args, { signal: abortController?.signal }, undefined, flowConfig)
 
-                    if (options.analyticHandlers && toolIds) {
+                    // Finalize Langfuse tool span with output
+                    if (toolSpan && options.analyticHandlers) {
+                        const spanPayload: ICommonObject = {
+                            output: options.analyticHandlers.safeSerializeForTrace(toolOutput)
+                        }
+                        options.analyticHandlers.finishToolSpan(toolSpan, 'FINISHED', spanPayload)
+                        toolSpan = undefined
+                    } else if (options.analyticHandlers && toolIds) {
                         await options.analyticHandlers.onToolEnd(toolIds, toolOutput)
                     }
 
@@ -1870,7 +1890,13 @@ class Agent_Agentflow implements INode {
                         toolOutput
                     })
                 } catch (e) {
-                    if (options.analyticHandlers && toolIds) {
+                    // Finalize Langfuse tool span with error
+                    if (toolSpan && options.analyticHandlers) {
+                        options.analyticHandlers.finishToolSpan(toolSpan, 'ERROR', {
+                            error: options.analyticHandlers.safeSerializeForTrace(getErrorMessage(e))
+                        })
+                        toolSpan = undefined
+                    } else if (options.analyticHandlers && toolIds) {
                         await options.analyticHandlers.onToolEnd(toolIds, e)
                     }
 
@@ -1974,7 +2000,8 @@ class Agent_Agentflow implements INode {
                 llmNodeInstance,
                 isStreamable,
                 isLastNode,
-                iterationContext
+                iterationContext,
+                nodeData
             })
 
             // Merge results from recursive tool calls
@@ -2005,7 +2032,8 @@ class Agent_Agentflow implements INode {
         llmWithoutToolsBind,
         isStreamable,
         isLastNode,
-        iterationContext
+        iterationContext,
+        nodeData
     }: {
         humanInput: IHumanInput
         humanInputAction: Record<string, any> | undefined
@@ -2020,6 +2048,7 @@ class Agent_Agentflow implements INode {
         isStreamable: boolean
         isLastNode: boolean
         iterationContext: ICommonObject
+        nodeData: INodeData
     }): Promise<{
         response: AIMessageChunk
         usedTools: IUsedTool[]
@@ -2119,8 +2148,18 @@ class Agent_Agentflow implements INode {
                     }
                 }
                 if (humanInput.type === 'proceed') {
+                    // Create Langfuse tool span for hierarchical tracing
+                    const parentToolSpan = (options as any).parentLangfuseSpan
+                    let toolSpan = options.analyticHandlers?.createToolSpan(parentToolSpan, toolCall.name, toolCall.args, {
+                        nodeId: nodeData.id,
+                        nodeLabel: nodeData.label,
+                        toolCallId: toolCall.id,
+                        humanApproved: true
+                    })
+
+                    // Fallback to legacy tracking if no tool span
                     let toolIds: ICommonObject | undefined
-                    if (options.analyticHandlers) {
+                    if (!toolSpan && options.analyticHandlers) {
                         toolIds = await options.analyticHandlers.onToolStart(toolCall.name, toolCall.args, options.parentTraceIds)
                     }
 
@@ -2128,7 +2167,14 @@ class Agent_Agentflow implements INode {
                         //@ts-ignore
                         let toolOutput = await selectedTool.call(toolCall.args, { signal: abortController?.signal }, undefined, flowConfig)
 
-                        if (options.analyticHandlers && toolIds) {
+                        // Finalize Langfuse tool span with output
+                        if (toolSpan && options.analyticHandlers) {
+                            const spanPayload: ICommonObject = {
+                                output: options.analyticHandlers.safeSerializeForTrace(toolOutput)
+                            }
+                            options.analyticHandlers.finishToolSpan(toolSpan, 'FINISHED', spanPayload)
+                            toolSpan = undefined
+                        } else if (options.analyticHandlers && toolIds) {
                             await options.analyticHandlers.onToolEnd(toolIds, toolOutput)
                         }
 
@@ -2186,7 +2232,13 @@ class Agent_Agentflow implements INode {
                             toolOutput
                         })
                     } catch (e) {
-                        if (options.analyticHandlers && toolIds) {
+                        // Finalize Langfuse tool span with error
+                        if (toolSpan && options.analyticHandlers) {
+                            options.analyticHandlers.finishToolSpan(toolSpan, 'ERROR', {
+                                error: options.analyticHandlers.safeSerializeForTrace(getErrorMessage(e))
+                            })
+                            toolSpan = undefined
+                        } else if (options.analyticHandlers && toolIds) {
                             await options.analyticHandlers.onToolEnd(toolIds, e)
                         }
 
@@ -2293,7 +2345,8 @@ class Agent_Agentflow implements INode {
                 llmNodeInstance,
                 isStreamable,
                 isLastNode,
-                iterationContext
+                iterationContext,
+                nodeData
             })
 
             // Merge results from recursive tool calls

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -2093,6 +2093,21 @@ export class AnalyticHandler {
     }
 
     /**
+     * Get the Langfuse trace client for node-level span creation
+     * @param parentTraceIds - The parent trace IDs returned from onChainStart
+     * @returns LangfuseTraceClient if available, undefined otherwise
+     */
+    getLangfuseTrace(parentTraceIds?: ICommonObject): LangfuseTraceClient | undefined {
+        if (!parentTraceIds || !parentTraceIds['langFuse']?.trace) return undefined
+        if (!Object.prototype.hasOwnProperty.call(this.handlers, 'langFuse')) return undefined
+        try {
+            return this.handlers['langFuse']?.trace?.[parentTraceIds['langFuse'].trace]
+        } catch {
+            return undefined
+        }
+    }
+
+    /**
      * Create a Langfuse tool span for tracing tool execution
      * @param parentSpan - Parent Langfuse span to attach this tool span to
      * @param toolName - Name of the tool being executed

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm'
 import { v4 as uuidv4 } from 'uuid'
 import { cloneDeep, get } from 'lodash'
 import TurndownService from 'turndown'
+import { LangfuseSpanClient, LangfuseTraceClient } from 'langfuse'
 import {
     AnalyticHandler,
     ICommonObject,
@@ -137,6 +138,8 @@ interface IExecuteNodeParams {
     abortController?: AbortController
     parentTraceIds?: ICommonObject
     analyticHandlers?: AnalyticHandler
+    parentLangfuseTrace?: LangfuseTraceClient
+    parentLangfuseSpan?: LangfuseSpanClient
     parentExecutionId?: string
     isRecursive?: boolean
     iterationContext?: ICommonObject
@@ -1041,6 +1044,8 @@ const executeNode = async ({
     abortController,
     parentTraceIds,
     analyticHandlers,
+    parentLangfuseTrace,
+    parentLangfuseSpan,
     isInternal,
     isRecursive,
     iterationContext,
@@ -1055,6 +1060,55 @@ const executeNode = async ({
     agentFlowExecutedData?: IAgentflowExecutedData[]
     humanInput?: IHumanInput
 }> => {
+    // Langfuse span tracking for node-level observability - defined outside try for catch block access
+    let langfuseSpan: LangfuseSpanClient | undefined
+    let spanName = reactFlowNode?.data?.label || reactFlowNode.data.name
+    const nodeStartTime = Date.now()
+
+    const safeSerialize = (value: any) => {
+        if (value === undefined || value === null) return value
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+        try {
+            return JSON.parse(JSON.stringify(value))
+        } catch (err) {
+            logger.debug(`Failed to serialize Langfuse span payload: ${getErrorMessage(err)}`)
+            return '[Unserializable]'
+        }
+    }
+
+    const buildSpanOutput = (data: any): ICommonObject => {
+        const spanOutput: ICommonObject = {}
+        if (data) {
+            if (data.output !== undefined) spanOutput.output = safeSerialize(data.output)
+            if (data.state !== undefined) spanOutput.state = safeSerialize(data.state)
+            if (data.usedTools !== undefined) spanOutput.usedTools = safeSerialize(data.usedTools)
+            if (data.sourceDocuments !== undefined) spanOutput.sourceDocuments = safeSerialize(data.sourceDocuments)
+            if (!Object.keys(spanOutput).length) spanOutput.result = safeSerialize(data)
+        }
+        return spanOutput
+    }
+
+    const finishLangfuseSpan = (status: string, payload: ICommonObject, duration?: number) => {
+        if (!langfuseSpan) return
+        try {
+            langfuseSpan.update({
+                metadata: {
+                    nodeId,
+                    nodeName: reactFlowNode.data.name,
+                    nodeLabel: reactFlowNode.data.label ?? reactFlowNode.data.name,
+                    nodeType: reactFlowNode.data.type ?? reactFlowNode.data.name,
+                    status,
+                    spanName,
+                    ...(duration !== undefined ? { durationMs: duration } : {})
+                }
+            })
+            langfuseSpan.end({ output: payload })
+        } catch (err) {
+            logger.warn(`Failed to finalize Langfuse span for node ${spanName}: ${getErrorMessage(err)}`)
+        }
+        langfuseSpan = undefined
+    }
+
     try {
         if (abortController?.signal?.aborted) {
             throw new Error('Aborted')
@@ -1197,6 +1251,36 @@ const executeNode = async ({
             humanInputAction,
             iterationContext,
             evaluationRunId
+        }
+
+        // Create Langfuse span for node-level tracing
+        const langfuseTrace = parentLangfuseTrace
+        if (langfuseTrace) {
+            try {
+                const spanInput: ICommonObject = { nodeId }
+                if (finalInput !== undefined) spanInput.finalInput = safeSerialize(finalInput)
+                if (reactFlowNodeData.inputs !== undefined) spanInput.resolvedInputs = safeSerialize(reactFlowNodeData.inputs)
+
+                langfuseSpan = langfuseTrace.span({
+                    name: spanName,
+                    metadata: {
+                        nodeId,
+                        nodeName: reactFlowNode.data.name,
+                        nodeType: reactFlowNode.data.type ?? reactFlowNode.data.name,
+                        status: 'IN_PROGRESS'
+                    },
+                    input: spanInput
+                })
+            } catch (err) {
+                logger.warn(`Failed to create Langfuse span for node ${spanName}: ${getErrorMessage(err)}`)
+            }
+        }
+
+        // Pass the Langfuse span to the node for tool-level tracing
+        if (langfuseSpan) {
+            ;(runParams as any).parentLangfuseSpan = langfuseSpan
+        } else if (parentLangfuseSpan) {
+            ;(runParams as any).parentLangfuseSpan = parentLangfuseSpan
         }
 
         // Execute node
@@ -1394,6 +1478,9 @@ const executeNode = async ({
 
             sseStreamer?.streamActionEvent(chatId, humanInputAction)
 
+            // Finalize Langfuse span for human input stop
+            finishLangfuseSpan('STOPPED', buildSpanOutput(results), Date.now() - nodeStartTime)
+
             return { result: results, shouldStop: true, agentFlowExecutedData, humanInput: updatedHumanInput }
         }
 
@@ -1441,11 +1528,20 @@ const executeNode = async ({
 
             sseStreamer?.streamActionEvent(chatId, humanInputAction)
 
+            // Finalize Langfuse span for agent waiting for human input
+            finishLangfuseSpan('STOPPED', buildSpanOutput(results), Date.now() - nodeStartTime)
+
             return { result: results, shouldStop: true, agentFlowExecutedData, humanInput: updatedHumanInput }
         }
 
+        // Finalize Langfuse span for successful completion
+        finishLangfuseSpan('FINISHED', buildSpanOutput(results), Date.now() - nodeStartTime)
+
         return { result: results, agentFlowExecutedData, humanInput: updatedHumanInput }
     } catch (error) {
+        // Finalize Langfuse span for error
+        finishLangfuseSpan('ERROR', { error: getErrorMessage(error) }, Date.now() - nodeStartTime)
+
         logger.error(`[server]: Error executing node ${nodeId}: ${getErrorMessage(error)}`)
         throw error
     }
@@ -1883,6 +1979,7 @@ export const executeAgentFlow = async ({
 
     let analyticHandlers: AnalyticHandler | undefined
     let parentTraceIds: ICommonObject | undefined
+    let parentLangfuseTrace: LangfuseTraceClient | undefined
 
     try {
         if (isAnalyticsEnabled(chatflow.analytic)) {
@@ -1907,6 +2004,8 @@ export const executeAgentFlow = async ({
                 'Agentflow',
                 form && Object.keys(form).length > 0 ? JSON.stringify(form) : question || ''
             )
+            // Get Langfuse trace for node-level span creation
+            parentLangfuseTrace = analyticHandlers.getLangfuseTrace(parentTraceIds)
         }
     } catch (error) {
         logger.error(`[server]: Error initializing analytic handlers: ${getErrorMessage(error)}`)
@@ -1977,6 +2076,7 @@ export const executeAgentFlow = async ({
                 abortController,
                 parentTraceIds,
                 analyticHandlers,
+                parentLangfuseTrace,
                 isRecursive,
                 iterationContext,
                 loopCounts,


### PR DESCRIPTION
## Summary

Restores node-level Langfuse span tracing that was removed during the upgrade. This enables hierarchical visibility into agent flow execution, matching how executions display in the UI.

### What Was Lost (and Now Restored)

- **Per-node Langfuse spans** - Each node (Agent, Condition, LLM, ExecuteFlow) now creates a span
- **Tool-level spans** - Agent tool calls create nested spans with rich metadata
- **Execution hierarchy** - Traces are now hierarchical instead of flat
- **Rich metadata** - nodeId, nodeLabel, nodeType, status, duration captured
- **Source documents/artifacts** - Can be attached to tool spans

### Expected Trace Structure

```
Trace: AgentFlow
├── Span: Agent Node (FINISHED, 2340ms)
│   ├── Span: Tool:search_knowledge_base (FINISHED)
│   └── Span: Tool:send_email (FINISHED)
├── Span: Condition Node (FINISHED, 12ms)
└── Span: Direct Reply (FINISHED, 8ms)
```

## Changes

### `packages/server/src/utils/buildAgentflow.ts`
- Added Langfuse imports (`LangfuseSpanClient`, `LangfuseTraceClient`)
- Added `parentLangfuseTrace` and `parentLangfuseSpan` to `IExecuteNodeParams` interface
- Added span creation/finalization in `executeNode` with helper functions
- Pass `parentLangfuseTrace` from `executeAgentFlow` to `executeNode`

### `packages/components/src/handler.ts`
- Added `getLangfuseTrace()` method to `AnalyticHandler` to expose trace client

### `packages/components/nodes/agentflow/Agent/Agent.ts`
- Updated `handleToolCalls` and `handleResumedToolCalls` to accept `nodeData`
- Wire up `createToolSpan`/`finishToolSpan` for tool-level tracing
- Include node metadata in spans (nodeId, nodeLabel, toolCallId)

## Test Plan

- [ ] Run agentflow with Langfuse analytics enabled
- [ ] Verify hierarchical traces appear in Langfuse dashboard
- [ ] Verify tool calls show as nested spans under agent nodes
- [ ] Verify node metadata (nodeId, nodeLabel, status) is captured
- [ ] Verify error handling finalizes spans with ERROR status

## Related

- Ticket: [AGENT-567](https://linear.app/answeragent/issue/AGENT-567/bug-langfuse-not-calculating-tokens-when-calling-sub-workflows)
- Previous PR: #934 (token tracking fix)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)