### PR TITLE
feat(AGENT-567): Consolidate Langfuse token tracking across Execute Flow sub-workflows

### DIFF
--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -190,6 +190,17 @@ class ExecuteFlow_Agentflow implements INode {
             }
             if (chatflowApiKey) headers = { ...headers, Authorization: `Bearer ${chatflowApiKey}` }
 
+            // Pass parent Langfuse trace context if available
+            const parentLangfuseTrace = options.parentLangfuseTrace || options.analytic?.parentLangfuseTrace
+            const parentLangfuseSpan = options.parentLangfuseSpan
+
+            if (parentLangfuseTrace && parentLangfuseTrace.id) {
+                headers['X-Langfuse-Parent-Trace-Id'] = parentLangfuseTrace.id
+            }
+            if (parentLangfuseSpan && parentLangfuseSpan.id) {
+                headers['X-Langfuse-Parent-Span-Id'] = parentLangfuseSpan.id
+            }
+
             const finalUrl = `${baseURL}/api/v1/prediction/${selectedFlowId}`
             const requestConfig: AxiosRequestConfig = {
                 method: 'POST',

--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -8,7 +8,7 @@ import {
     IServerSideEventStreamer
 } from '../../../src/Interface'
 import axios, { AxiosRequestConfig } from 'axios'
-import { getCredentialData, getCredentialParam, processTemplateVariables, parseJsonBody } from '../../../src/utils'
+import { getCredentialData, getCredentialParam, processTemplateVariables, parseJsonBody, applyLangfuseTraceHeaders } from '../../../src/utils'
 import { DataSource } from 'typeorm'
 import { BaseMessageLike } from '@langchain/core/messages'
 import { updateFlowState } from '../utils'
@@ -191,15 +191,7 @@ class ExecuteFlow_Agentflow implements INode {
             if (chatflowApiKey) headers = { ...headers, Authorization: `Bearer ${chatflowApiKey}` }
 
             // Pass parent Langfuse trace context if available
-            const parentLangfuseTrace = options.parentLangfuseTrace || options.analytic?.parentLangfuseTrace
-            const parentLangfuseSpan = options.parentLangfuseSpan
-
-            if (parentLangfuseTrace && parentLangfuseTrace.id) {
-                headers['X-Langfuse-Parent-Trace-Id'] = parentLangfuseTrace.id
-            }
-            if (parentLangfuseSpan && parentLangfuseSpan.id) {
-                headers['X-Langfuse-Parent-Span-Id'] = parentLangfuseSpan.id
-            }
+            applyLangfuseTraceHeaders(options, headers)
 
             const finalUrl = `${baseURL}/api/v1/prediction/${selectedFlowId}`
             const requestConfig: AxiosRequestConfig = {

--- a/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
@@ -185,8 +185,19 @@ class ExecuteFlow_SeqAgents implements INode {
 
         if (selectedFlowId === options.chatflowid) throw new Error('Cannot call the same agentflow!')
 
-        let headers = {}
+        let headers: Record<string, string> = {}
         if (chatflowApiKey) headers = { Authorization: `Bearer ${chatflowApiKey}` }
+
+        // Pass parent Langfuse trace context if available
+        const parentLangfuseTrace = options.parentLangfuseTrace || options.analytic?.parentLangfuseTrace
+        const parentLangfuseSpan = options.parentLangfuseSpan
+
+        if (parentLangfuseTrace && parentLangfuseTrace.id) {
+            headers['X-Langfuse-Parent-Trace-Id'] = parentLangfuseTrace.id
+        }
+        if (parentLangfuseSpan && parentLangfuseSpan.id) {
+            headers['X-Langfuse-Parent-Span-Id'] = parentLangfuseSpan.id
+        }
 
         const chatflowId = options.chatflowid
         const sessionId = options.sessionId

--- a/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
@@ -1,5 +1,5 @@
 import { DataSource } from 'typeorm'
-import { getCredentialData, getCredentialParam, getVars, executeJavaScriptCode, createCodeExecutionSandbox } from '../../../src/utils'
+import { getCredentialData, getCredentialParam, getVars, executeJavaScriptCode, createCodeExecutionSandbox, applyLangfuseTraceHeaders } from '../../../src/utils'
 import { isValidUUID, isValidURL } from '../../../src/validator'
 import {
     ICommonObject,
@@ -189,15 +189,7 @@ class ExecuteFlow_SeqAgents implements INode {
         if (chatflowApiKey) headers = { Authorization: `Bearer ${chatflowApiKey}` }
 
         // Pass parent Langfuse trace context if available
-        const parentLangfuseTrace = options.parentLangfuseTrace || options.analytic?.parentLangfuseTrace
-        const parentLangfuseSpan = options.parentLangfuseSpan
-
-        if (parentLangfuseTrace && parentLangfuseTrace.id) {
-            headers['X-Langfuse-Parent-Trace-Id'] = parentLangfuseTrace.id
-        }
-        if (parentLangfuseSpan && parentLangfuseSpan.id) {
-            headers['X-Langfuse-Parent-Span-Id'] = parentLangfuseSpan.id
-        }
+        applyLangfuseTraceHeaders(options, headers)
 
         const chatflowId = options.chatflowid
         const sessionId = options.sessionId

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -759,7 +759,7 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                             // Construct span client directly to avoid sending a spurious create event.
                             // This sets observationId so the CallbackHandler nests LLM calls under the parent span.
                             handlerConfig.root = new LangfuseSpanClient(
-                                langfuseInstance as any,
+                                langfuseInstance,
                                 analytic.parentLangfuseSpanId,
                                 analytic.parentLangfuseTraceId
                             )
@@ -1172,8 +1172,10 @@ export class AnalyticHandler {
                     const analyticConfig = typeof analytic === 'string' ? JSON.parse(analytic) : analytic
                     parentLangfuseTraceId = analyticConfig.parentLangfuseTraceId
                     parentLangfuseSpanId = analyticConfig.parentLangfuseSpanId
-                } catch {
-                    // Ignore parse errors
+                } catch (err) {
+                    if (process.env.DEBUG === 'true') {
+                        console.error('Error parsing analytic config for parent trace context:', err)
+                    }
                 }
             }
 

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -745,6 +745,29 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                         }
 
                         analyticHandlersInstance?.setLangfuseCallbacksActive(true)
+                    } else if (analytic.parentLangfuseTraceId) {
+                        // Sub-workflow called via HTTP (Execute Flow) without parent trace objects.
+                        // Reconnect to parent trace using string IDs propagated via headers
+                        // so that LLM token usage is consolidated under the parent trace.
+                        const langfuseInstance = new Langfuse({
+                            secretKey: langFuseSecretKey,
+                            publicKey: langFusePublicKey,
+                            baseUrl: langFuseEndpoint ?? 'https://cloud.langfuse.com'
+                        })
+
+                        if (analytic.parentLangfuseSpanId) {
+                            // Construct span client directly to avoid sending a spurious create event.
+                            // This sets observationId so the CallbackHandler nests LLM calls under the parent span.
+                            handlerConfig.root = new LangfuseSpanClient(
+                                langfuseInstance as any,
+                                analytic.parentLangfuseSpanId,
+                                analytic.parentLangfuseTraceId
+                            )
+                        } else {
+                            handlerConfig.root = langfuseInstance.trace({ id: analytic.parentLangfuseTraceId })
+                        }
+                        handlerConfig.updateRoot = false
+                        analyticHandlersInstance?.setLangfuseCallbacksActive(true)
                     } else {
                         analyticHandlersInstance?.setLangfuseCallbacksActive(false)
                     }
@@ -1139,14 +1162,50 @@ export class AnalyticHandler {
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langFuse')) {
             let langfuseTraceClient: LangfuseTraceClient
 
+            // Check if parent trace context is provided from Execute Flow nodes
+            const analytic = this.options.analytic
+            let parentLangfuseTraceId: string | undefined
+            let parentLangfuseSpanId: string | undefined
+
+            if (analytic) {
+                try {
+                    const analyticConfig = typeof analytic === 'string' ? JSON.parse(analytic) : analytic
+                    parentLangfuseTraceId = analyticConfig.parentLangfuseTraceId
+                    parentLangfuseSpanId = analyticConfig.parentLangfuseSpanId
+                } catch {
+                    // Ignore parse errors
+                }
+            }
+
             if (!parentIds || !Object.keys(parentIds).length) {
                 const langfuse: Langfuse = this.handlers['langFuse'].client
-                langfuseTraceClient = langfuse.trace({
-                    name,
-                    sessionId: this.options.chatId,
-                    metadata: { tags: ['openai-assistant'] },
-                    ...this.nodeData?.inputs?.analytics?.langFuse
-                })
+
+                // If parent trace context is available, fetch the parent trace and create a child span
+                if (parentLangfuseTraceId) {
+                    try {
+                        // Fetch the parent trace by ID
+                        langfuseTraceClient = langfuse.trace({
+                            id: parentLangfuseTraceId
+                        })
+                    } catch (error) {
+                        // If fetching parent fails, create a new trace
+                        console.warn(`Failed to fetch parent Langfuse trace ${parentLangfuseTraceId}, creating new trace:`, error)
+                        langfuseTraceClient = langfuse.trace({
+                            name,
+                            sessionId: this.options.chatId,
+                            metadata: { tags: ['openai-assistant'] },
+                            ...this.nodeData?.inputs?.analytics?.langFuse
+                        })
+                    }
+                } else {
+                    // No parent trace context, create a new independent trace
+                    langfuseTraceClient = langfuse.trace({
+                        name,
+                        sessionId: this.options.chatId,
+                        metadata: { tags: ['openai-assistant'] },
+                        ...this.nodeData?.inputs?.analytics?.langFuse
+                    })
+                }
             } else {
                 langfuseTraceClient = this.handlers['langFuse'].trace[parentIds['langFuse']]
             }
@@ -1157,12 +1216,24 @@ export class AnalyticHandler {
                         text: input
                     }
                 })
-                const span = langfuseTraceClient.span({
-                    name,
-                    input: {
-                        text: input
-                    }
-                })
+                // If parent span ID is available, create span as child of parent span
+                // using langfuse.span() directly to set parentObservationId
+                const langfuse: Langfuse = this.handlers['langFuse'].client
+                const span = parentLangfuseSpanId
+                    ? langfuse.span({
+                          traceId: langfuseTraceClient.id,
+                          parentObservationId: parentLangfuseSpanId,
+                          name,
+                          input: {
+                              text: input
+                          }
+                      })
+                    : langfuseTraceClient.span({
+                          name,
+                          input: {
+                              text: input
+                          }
+                      })
                 this.handlers['langFuse'].trace = { [langfuseTraceClient.id]: langfuseTraceClient }
                 this.handlers['langFuse'].span = { [span.id]: span }
                 returnIds['langFuse'].trace = langfuseTraceClient.id

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -21,6 +21,23 @@ import { Sandbox } from '@e2b/code-interpreter'
 import { secureFetch, checkDenyList, secureAxiosRequest } from './httpSecurity'
 import JSON5 from 'json5'
 
+/**
+ * Apply Langfuse trace context headers to outgoing HTTP requests (e.g. Execute Flow).
+ * Extracts parent trace/span IDs from node options and sets X-Langfuse-Parent-* headers
+ * so that sub-workflows consolidate token usage under the parent trace.
+ */
+export const applyLangfuseTraceHeaders = (options: ICommonObject, headers: Record<string, string>): void => {
+    const parentLangfuseTrace = options.parentLangfuseTrace || options.analytic?.parentLangfuseTrace
+    const parentLangfuseSpan = options.parentLangfuseSpan
+
+    if (parentLangfuseTrace && parentLangfuseTrace.id) {
+        headers['X-Langfuse-Parent-Trace-Id'] = parentLangfuseTrace.id
+    }
+    if (parentLangfuseSpan && parentLangfuseSpan.id) {
+        headers['X-Langfuse-Parent-Span-Id'] = parentLangfuseSpan.id
+    }
+}
+
 export const numberOrExpressionRegex = '^(\\d+\\.?\\d*|{{.*}})$' //return true if string consists only numbers OR expression {{}}
 export const notEmptyRegex = '(.|\\s)*\\S(.|\\s)*' //return true if string is not empty or blank
 export const FLOWISE_CHATID = 'flowise_chatId'

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -564,6 +564,8 @@ export interface IExecuteFlowParams extends IPredictionQueueAppServer {
     parentExecutionId?: string
     iterationContext?: ICommonObject
     isTool?: boolean
+    parentLangfuseTraceId?: string
+    parentLangfuseSpanId?: string
 }
 
 export interface INodeOverrides {

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -1246,6 +1246,10 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
     const abortControllerId = `${chatflow.id}_${chatId}`
     const isTool = req.get('flowise-tool') === 'true'
 
+    // Extract parent Langfuse trace context from headers (if present from Execute Flow nodes)
+    const parentLangfuseTraceId = req.get('x-langfuse-parent-trace-id')
+    const parentLangfuseSpanId = req.get('x-langfuse-parent-span-id')
+
     await validateAndSaveChat(req, chatflow, isInternal, chatId, incomingInput, chatflowid)
 
     const isEvaluation: boolean = req.headers['X-Flowise-Evaluation'] || req.body.evaluation
@@ -1261,6 +1265,27 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
             }
         }
         chatflow.analytic = JSON.stringify(newEval)
+    }
+
+    // Inject parent Langfuse trace context into analytic config if present
+    if (parentLangfuseTraceId || parentLangfuseSpanId) {
+        let analyticConfig = {}
+        if (chatflow.analytic) {
+            try {
+                analyticConfig = typeof chatflow.analytic === 'string' ? JSON.parse(chatflow.analytic) : chatflow.analytic
+            } catch {
+                analyticConfig = {}
+            }
+        }
+
+        // Inject parent trace context so it can be used by getAnalyticCallbacks
+        analyticConfig = {
+            ...analyticConfig,
+            parentLangfuseTraceId,
+            parentLangfuseSpanId
+        }
+
+        chatflow.analytic = JSON.stringify(analyticConfig)
     }
 
     let organizationId = ''
@@ -1318,7 +1343,9 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
             orgId,
             workspaceId,
             subscriptionId,
-            productId
+            productId,
+            parentLangfuseTraceId,
+            parentLangfuseSpanId
         }
 
         if (process.env.MODE === MODE.QUEUE) {


### PR DESCRIPTION
## Summary
- Execute Flow nodes now propagate parent Langfuse trace/span context via HTTP headers (`X-Langfuse-Parent-Trace-Id`, `X-Langfuse-Parent-Span-Id`) to sub-workflows
- Sub-agentflows reconnect to parent trace via `AnalyticHandler.onChainStart` with proper span nesting using `parentObservationId`
- Sub-chatflows reconnect via `additionalCallbacks` by constructing a `LangfuseSpanClient` as the langfuse-langchain `CallbackHandler` root
- All LLM token usage from sub-workflows is now consolidated under the parent trace in Langfuse

## What was broken
When an Execute Flow node called a sub-workflow (chatflow or agentflow), the sub-workflow created an independent Langfuse trace. Token usage was tracked separately, making it impossible to see the full cost of a parent workflow that delegates to sub-workflows.

## How it works now
```
Parent Trace
  └─ Execute Flow Span (parent workflow)
       └─ Sub-workflow LLM Generation 1  ← now properly nested
       └─ Sub-workflow LLM Generation 2  ← tokens consolidated
```

## Files changed
| File | Change |
|------|--------|
| `packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts` | Extract parent trace/span from options, send as HTTP headers |
| `packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts` | Same for Sequential Agents |
| `packages/components/src/handler.ts` | `AnalyticHandler.onChainStart`: reconnect to parent trace, nest spans. `additionalCallbacks`: reconnect for chatflow sub-workflows |
| `packages/server/src/Interface.ts` | Add `parentLangfuseTraceId`/`parentLangfuseSpanId` to `IExecuteFlowParams` |
| `packages/server/src/utils/buildChatflow.ts` | Read trace headers, inject into analytic config and executeData |

## Test plan
- [ ] Agentflow with Execute Flow node calling a sub-agentflow → verify single consolidated trace in Langfuse
- [ ] Agentflow with Execute Flow node calling a sub-chatflow → verify single consolidated trace in Langfuse
- [ ] Sequential Agents with Execute Flow → verify same consolidation
- [ ] Standalone chatflow/agentflow (no Execute Flow) → verify existing behavior unchanged
- [ ] Nested Execute Flows (A → B → C) → verify full chain consolidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)