### PR TITLE
chore: optimize CI caching and add auto-format hooks

### DIFF
--- a/.claude/hooks/format-on-save.sh
+++ b/.claude/hooks/format-on-save.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Auto-format files after Claude edits/writes them.
+# Runs prettier synchronously (~0.4s) for instant formatting.
+# Called by PostToolUse hook on Edit|Write events.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null)
+
+# Exit silently if no file path
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Only format JS/TS files
+case "$FILE_PATH" in
+    *.ts|*.tsx|*.js|*.jsx) ;;
+    *) exit 0 ;;
+esac
+
+# Skip files that don't exist (deleted files)
+[[ ! -f "$FILE_PATH" ]] && exit 0
+
+# Skip node_modules, dist, build, .next, public (minified bundles), embed submodule
+case "$FILE_PATH" in
+    */node_modules/*|*/dist/*|*/build/*|*/.next/*|*/public/*|*/packages/embed/*) exit 0 ;;
+esac
+
+# Run prettier --write (fast, ~0.4s)
+cd "$CLAUDE_PROJECT_DIR"
+npx prettier --write "$FILE_PATH" >/dev/null 2>&1 || true
+
+exit 0

--- a/.claude/hooks/lint-fix-async.sh
+++ b/.claude/hooks/lint-fix-async.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Async ESLint --fix for files in packages/ and packages-answers/.
+# Catches unused imports and other auto-fixable lint rules.
+# Reports results via systemMessage on next turn.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null)
+
+# Exit silently if no file path
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Only lint JS/TS files
+case "$FILE_PATH" in
+    *.ts|*.tsx|*.js|*.jsx) ;;
+    *) exit 0 ;;
+esac
+
+# Skip files that don't exist
+[[ ! -f "$FILE_PATH" ]] && exit 0
+
+# Only run ESLint for packages/* and packages-answers/* (where it has valuable rules)
+# Skip apps/web (no useful auto-fix rules beyond prettier)
+# Skip packages/embed (in .eslintignore)
+case "$FILE_PATH" in
+    */packages/server/*|*/packages/components/*|*/packages/ui/*|*/packages-answers/*) ;;
+    *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR"
+OUTPUT=$(npx eslint --fix "$FILE_PATH" 2>&1) || true
+
+# Only report if there were unfixable issues
+if [[ -n "$OUTPUT" ]] && echo "$OUTPUT" | grep -q "warning\|error"; then
+    # Escape for JSON
+    ESCAPED=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null)
+    echo "{\"systemMessage\": \"ESLint found issues in $(basename "$FILE_PATH"): ${ESCAPED}\"}"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,26 @@
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-on-save.sh",
+            "timeout": 10,
+            "statusMessage": "Formatting..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint-fix-async.sh",
+            "timeout": 30,
+            "async": true
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -5,6 +5,10 @@ on:
         branches:
             - staging
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 permissions:
     contents: write
     pull-requests: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,13 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,4 +46,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/docker-image-dockerhub.yml
+++ b/.github/workflows/docker-image-dockerhub.yml
@@ -16,9 +16,16 @@ on:
                 required: true
                 default: 'latest'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
-    docker:
+    setup:
         runs-on: ubuntu-latest
+        outputs:
+            node_version: ${{ steps.defaults.outputs.node_version }}
+            tag_version: ${{ steps.defaults.outputs.tag_version }}
         steps:
             - name: Set default values
               id: defaults
@@ -26,8 +33,14 @@ jobs:
                   echo "node_version=${{ github.event.inputs.node_version || '20' }}" >> $GITHUB_OUTPUT
                   echo "tag_version=${{ github.event.inputs.tag_version || 'latest' }}" >> $GITHUB_OUTPUT
 
+    main-image:
+        needs: setup
+        runs-on: ubuntu-latest
+        steps:
             - name: Checkout
               uses: actions/checkout@v4.1.1
+              with:
+                  fetch-depth: 1
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3.0.0
@@ -41,32 +54,51 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-            # -------------------------
-            # Build and push main image
-            # -------------------------
             - name: Build and push main image
               uses: docker/build-push-action@v5.3.0
               with:
                   context: .
                   file: ./docker/Dockerfile
                   build-args: |
-                      NODE_VERSION=${{ steps.defaults.outputs.node_version }}
+                      NODE_VERSION=${{ needs.setup.outputs.node_version }}
                   platforms: linux/amd64,linux/arm64
                   push: true
                   tags: |
-                      flowiseai/flowise:${{ steps.defaults.outputs.tag_version }}
+                      flowiseai/flowise:${{ needs.setup.outputs.tag_version }}
+                  cache-from: type=gha,scope=dockerhub-main
+                  cache-to: type=gha,mode=max,scope=dockerhub-main
 
-            # -------------------------
-            # Build and push worker image
-            # -------------------------
+    worker-image:
+        needs: setup
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4.1.1
+              with:
+                  fetch-depth: 1
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3.0.0
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3.0.0
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
             - name: Build and push worker image
               uses: docker/build-push-action@v5.3.0
               with:
                   context: .
                   file: docker/worker/Dockerfile
                   build-args: |
-                      NODE_VERSION=${{ steps.defaults.outputs.node_version }}
+                      NODE_VERSION=${{ needs.setup.outputs.node_version }}
                   platforms: linux/amd64,linux/arm64
                   push: true
                   tags: |
-                      flowiseai/flowise-worker:${{ steps.defaults.outputs.tag_version }}
+                      flowiseai/flowise-worker:${{ needs.setup.outputs.tag_version }}
+                  cache-from: type=gha,scope=dockerhub-worker
+                  cache-to: type=gha,mode=max,scope=dockerhub-worker

--- a/.github/workflows/docker-image-ecr.yml
+++ b/.github/workflows/docker-image-ecr.yml
@@ -24,6 +24,10 @@ on:
                 required: true
                 default: 'latest'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     docker:
         runs-on: ubuntu-latest
@@ -37,6 +41,8 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@v4.1.1
+              with:
+                  fetch-depth: 1
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3.0.0
@@ -67,7 +73,9 @@ jobs:
                   platforms: linux/amd64,linux/arm64
                   push: true
                   tags: |
-                      ${{ format('{0}.dkr.ecr.{1}.amazonaws.com/flowise:{2}', 
-                          secrets.AWS_ACCOUNT_ID, 
-                          secrets.AWS_REGION, 
+                      ${{ format('{0}.dkr.ecr.{1}.amazonaws.com/flowise:{2}',
+                          secrets.AWS_ACCOUNT_ID,
+                          secrets.AWS_REGION,
                           steps.defaults.outputs.tag_version) }}
+                  cache-from: type=gha,scope=ecr-main
+                  cache-to: type=gha,mode=max,scope=ecr-main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,9 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   cache: 'pnpm'
                   cache-dependency-path: 'pnpm-lock.yaml'
-            - run: pnpm install
+            - name: Setup Turbo cache
+              uses: dtinth/setup-github-actions-caching-for-turbo@v1
+            - run: pnpm install --frozen-lockfile
             - run: pnpm lint
             # Build step disabled - handled by separate build workflow
             # - run: pnpm build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,19 +3,42 @@ on:
     push:
         branches:
             - main
+        paths-ignore:
+            - '**.md'
+            - '.claude/**'
+            - '.alphaAgent/**'
+            - '.cursor/**'
+            - '.vscode/**'
+            - 'docker/**'
+            - 'docs/**'
+            - 'packages/docs/**'
+            - '.github/workflows/**'
+            - '!.github/workflows/main.yml'
     pull_request:
         branches:
             - '*'
+        paths-ignore:
+            - '**.md'
+            - '.claude/**'
+            - '.alphaAgent/**'
+            - '.cursor/**'
+            - '.vscode/**'
+            - 'docker/**'
+            - 'docs/**'
+            - 'packages/docs/**'
+            - '.github/workflows/**'
+            - '!.github/workflows/main.yml'
     workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 jobs:
     build:
-        strategy:
-            matrix:
-                platform: [ubuntu-latest]
-                node-version: [20.17.0]
-        runs-on: ${{ matrix.platform }}
+        runs-on: ubuntu-latest
         env:
             PUPPETEER_SKIP_DOWNLOAD: true
             BWS_ACCESS_TOKEN: ${{ secrets.BWS_ACCESS_TOKEN }}
@@ -23,37 +46,17 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: recursive
+                  fetch-depth: 1
             - uses: pnpm/action-setup@v4
               with:
                   version: 9.15.9
-            - name: Use Node.js ${{ matrix.node-version }}
+            - name: Use Node.js 20.17.0
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
+                  node-version: 20.17.0
                   cache: 'pnpm'
                   cache-dependency-path: 'pnpm-lock.yaml'
             - name: Setup Turbo cache
               uses: dtinth/setup-github-actions-caching-for-turbo@v1
             - run: pnpm install --frozen-lockfile
             - run: pnpm lint
-            # Build step disabled - handled by separate build workflow
-            # - run: pnpm build
-            #   env:
-            #       NODE_OPTIONS: '--max_old_space_size=4096'
-            # Cypress tests disabled temporarily
-            # - name: Cypress install
-            #   run: pnpm cypress install
-            # - name: Install dependencies (Cypress Action)
-            #   uses: cypress-io/github-action@v6
-            #   with:
-            #       working-directory: ./
-            #       runTests: false
-            # - name: Cypress test
-            #   uses: cypress-io/github-action@v6
-            #   with:
-            #       install: false
-            #       working-directory: packages/server
-            #       start: pnpm start
-            #       wait-on: 'http://localhost:3000'
-            #       wait-on-timeout: 120
-            #       browser: chrome

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -274,7 +274,7 @@ jobs:
                   node -e "const pkg = require('./package.json'); pkg.peerDependencies['aai-embed'] = '^$EMBED_VERSION'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));"
 
             - name: Install dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Build package
               working-directory: ./packages/embed-react

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,11 +7,18 @@ on:
     push:
         branches:
             - staging
+        paths:
+            - 'packages/embed-react/**'
+            - 'packages/embed'
     workflow_dispatch:
         inputs:
             version_override:
                 description: 'Version override for aai-embed-react (optional, e.g., 1.2.3)'
                 required: false
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
 
 jobs:
     detect-changes:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
             - production
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 permissions:
     contents: write
     issues: read

--- a/.github/workflows/sync-docs-to-docstore.yml
+++ b/.github/workflows/sync-docs-to-docstore.yml
@@ -18,6 +18,10 @@ on:
                 required: false
                 type: string
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     sync-docs:
         name: Sync Documentation
@@ -41,9 +45,7 @@ jobs:
                   version: 9
 
             - name: Install dependencies
-              run: |
-                  pnpm install --frozen-lockfile
-                  pnpm --filter flowise-docs install
+              run: pnpm install --frozen-lockfile
 
             - name: Build documentation
               run: pnpm --filter flowise-docs build

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -19,4 +19,15 @@ jobs:
               with:
                   submodules: true
 
-            - run: docker build --no-cache -t flowise .
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Build Docker image
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: false
+                  load: true
+                  tags: flowise:test
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -4,11 +4,34 @@ on:
     push:
         branches:
             - main
+        paths:
+            - 'Dockerfile'
+            - 'docker/**'
+            - 'packages/**'
+            - 'packages-answers/**'
+            - 'apps/**'
+            - 'pnpm-lock.yaml'
+            - 'turbo.json'
+            - '.github/workflows/test_docker_build.yml'
 
     pull_request:
         branches:
             - '*'
+        paths:
+            - 'Dockerfile'
+            - 'docker/**'
+            - 'packages/**'
+            - 'packages-answers/**'
+            - 'apps/**'
+            - 'pnpm-lock.yaml'
+            - 'turbo.json'
+            - '.github/workflows/test_docker_build.yml'
     workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -18,6 +41,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: true
+                  fetch-depth: 1
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3

--- a/packages-answers/ui/.eslintc.js
+++ b/packages-answers/ui/.eslintc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  root: true,
-  extends: ['custom'],
-  rules: {
-    'no-console': 'off'
-  }
-};
+    root: true,
+    extends: ['custom'],
+    rules: {
+        'no-console': 'off'
+    }
+}

--- a/packages-answers/utils/src/confluence/models/confluenceObject.js
+++ b/packages-answers/utils/src/confluence/models/confluenceObject.js
@@ -1,51 +1,43 @@
-import AnswersObject from '../../core/models/answersObject';
+import AnswersObject from '../../core/models/answersObject'
 
 class ConfluenceObject extends AnswersObject {
-  constructor(object) {
-    super(object);
-  }
-
-  static confluenceHtmlToMarkdown(node) {
-    if (!node) return '';
-
-    if (node.nodeType === 'doc') {
-      return node.content
-        .map((item) => `${ConfluenceObject.confluenceHtmlToMarkdown(item)}`)
-        .join('');
-    } else if (node.nodeType === 'text') {
-      return node.text;
-    } else if (node.nodeType === 'hardBreak') {
-      return ' ';
-    } else if (node.nodeType === 'mention') {
-      return `@${node.attrs.username}`;
-    } else if (node.nodeType === 'emoji') {
-      return ''; //`:${node.attrs.shortName}:`;
-    } else if (node.nodeType === 'link') {
-      return `[${node.attrs.title}](${node.attrs.href})`;
-    } else if (node.nodeType === 'mediaGroup') {
-      return node.content.map(ConfluenceObject.confluenceHtmlToMarkdown).join('');
-    } else if (node.nodeType === 'paragraph') {
-      return `${node.content.map(ConfluenceObject.confluenceHtmlToMarkdown).join('')}. `;
-    } else if (node.nodeType === 'bulletList') {
-      return node.content
-        .map((item) => `${ConfluenceObject.confluenceHtmlToMarkdown(item)}`)
-        .join('');
-    } else if (node.nodeType === 'orderedList') {
-      return node.content
-        .map((item, index) => `${index + 1}. ${ConfluenceObject.confluenceHtmlToMarkdown(item)}`)
-        .join('');
-    } else if (node.nodeType === 'heading') {
-      return `\n${'#'.repeat(node.attrs.level)} ${node.content
-        .map(ConfluenceObject.confluenceHtmlToMarkdown)
-        .join('')}\n`;
-    } else if (node.nodeType === 'codeBlock') {
-      return `\`\`\`\n${node.content}\n\`\`\`\n`;
-    } else if (node.nodeType === 'blockquote') {
-      return `> ${node.content.map(ConfluenceObject.confluenceHtmlToMarkdown).join('')}\n`;
-    } else {
-      return '';
+    constructor(object) {
+        super(object)
     }
-  }
+
+    static confluenceHtmlToMarkdown(node) {
+        if (!node) return ''
+
+        if (node.nodeType === 'doc') {
+            return node.content.map((item) => `${ConfluenceObject.confluenceHtmlToMarkdown(item)}`).join('')
+        } else if (node.nodeType === 'text') {
+            return node.text
+        } else if (node.nodeType === 'hardBreak') {
+            return ' '
+        } else if (node.nodeType === 'mention') {
+            return `@${node.attrs.username}`
+        } else if (node.nodeType === 'emoji') {
+            return '' //`:${node.attrs.shortName}:`;
+        } else if (node.nodeType === 'link') {
+            return `[${node.attrs.title}](${node.attrs.href})`
+        } else if (node.nodeType === 'mediaGroup') {
+            return node.content.map(ConfluenceObject.confluenceHtmlToMarkdown).join('')
+        } else if (node.nodeType === 'paragraph') {
+            return `${node.content.map(ConfluenceObject.confluenceHtmlToMarkdown).join('')}. `
+        } else if (node.nodeType === 'bulletList') {
+            return node.content.map((item) => `${ConfluenceObject.confluenceHtmlToMarkdown(item)}`).join('')
+        } else if (node.nodeType === 'orderedList') {
+            return node.content.map((item, index) => `${index + 1}. ${ConfluenceObject.confluenceHtmlToMarkdown(item)}`).join('')
+        } else if (node.nodeType === 'heading') {
+            return `\n${'#'.repeat(node.attrs.level)} ${node.content.map(ConfluenceObject.confluenceHtmlToMarkdown).join('')}\n`
+        } else if (node.nodeType === 'codeBlock') {
+            return `\`\`\`\n${node.content}\n\`\`\`\n`
+        } else if (node.nodeType === 'blockquote') {
+            return `> ${node.content.map(ConfluenceObject.confluenceHtmlToMarkdown).join('')}\n`
+        } else {
+            return ''
+        }
+    }
 }
 
-export default ConfluenceObject;
+export default ConfluenceObject

--- a/packages-answers/utils/src/confluence/models/page.js
+++ b/packages-answers/utils/src/confluence/models/page.js
@@ -1,39 +1,39 @@
-import ConfluenceObject from './confluenceObject';
+import ConfluenceObject from './confluenceObject'
 
 class ConfluencePage extends ConfluenceObject {
-  constructor(page) {
-    const tidiedPage = ConfluencePage.tidy(page);
-    super(tidiedPage);
-    this.object.objectType = 'Confluence Page';
-    this.object.uid = page.id;
-  }
+    constructor(page) {
+        const tidiedPage = ConfluencePage.tidy(page)
+        super(tidiedPage)
+        this.object.objectType = 'Confluence Page'
+        this.object.uid = page.id
+    }
 
-  static tidy(page) {
-    const { id, title, body } = page;
-    const attrs = {
-      objectType: 'Confluence Page',
-      title: title?.toLowerCase(),
-      text: ConfluencePage.confluenceToMarkdown(body)
-    };
-    return {
-      ...attrs,
-      text: createContext(id, attrs)
-    };
-  }
+    static tidy(page) {
+        const { id, title, body } = page
+        const attrs = {
+            objectType: 'Confluence Page',
+            title: title?.toLowerCase(),
+            text: ConfluencePage.confluenceToMarkdown(body)
+        }
+        return {
+            ...attrs,
+            text: createContext(id, attrs)
+        }
+    }
 }
 
 const createContext = (id, metadata) => {
-  let string = '' + id + ' ';
-  string += Object.keys(metadata)
-    .filter((key) => !!metadata[key])
-    .map((key) => {
-      if (metadata.hasOwnProperty(key)) {
-        return `${key?.replaceAll('_', ' ')} is ${metadata[key]}`;
-      }
-    })
-    ?.join(', ');
-  string += '.';
-  return string;
-};
+    let string = '' + id + ' '
+    string += Object.keys(metadata)
+        .filter((key) => !!metadata[key])
+        .map((key) => {
+            if (metadata.hasOwnProperty(key)) {
+                return `${key?.replaceAll('_', ' ')} is ${metadata[key]}`
+            }
+        })
+        ?.join(', ')
+    string += '.'
+    return string
+}
 
-export default ConfluencePage;
+export default ConfluencePage

--- a/packages-answers/utils/src/core/models/answersObject.js
+++ b/packages-answers/utils/src/core/models/answersObject.js
@@ -1,55 +1,55 @@
 // import natural from "natural";
 // const tokenizer = new natural.WordTokenizer();
-import OpenAI from '../../openai/openai';
-import Vector from '../../utilities/vector';
+import OpenAI from '../../openai/openai'
+import Vector from '../../utilities/vector'
 
-const embeddingJoinSeparator = ' ';
-const openAi = new OpenAI();
+const embeddingJoinSeparator = ' '
+const openAi = new OpenAI()
 class AnswersObject {
-  constructor(object) {
-    this.object = object;
-  }
+    constructor(object) {
+        this.object = object
+    }
 
-  getContext() {
-    return this.createContextFromObject(this.object);
-  }
+    getContext() {
+        return this.createContextFromObject(this.object)
+    }
 
-  // getTokenCount() {
-  //   return tokenizer.tokenize(this.context);
-  // }
+    // getTokenCount() {
+    //   return tokenizer.tokenize(this.context);
+    // }
 
-  createContextFromObject(obj) {
-    const trimValues = ['', undefined, null, 'indeterminate'];
-    if (obj?.text) return obj?.text;
-    let context = Object.entries(obj)
-      .filter(([, value]) => !trimValues.includes(value) && typeof value !== 'object')
-      .map(([key, value]) => `${key.replace(/([A-Z_])/g, ' $1').toUpperCase()}: ${value}`)
-      .join(embeddingJoinSeparator);
+    createContextFromObject(obj) {
+        const trimValues = ['', undefined, null, 'indeterminate']
+        if (obj?.text) return obj?.text
+        let context = Object.entries(obj)
+            .filter(([, value]) => !trimValues.includes(value) && typeof value !== 'object')
+            .map(([key, value]) => `${key.replace(/([A-Z_])/g, ' $1').toUpperCase()}: ${value}`)
+            .join(embeddingJoinSeparator)
 
-    return context;
-  }
+        return context
+    }
 
-  async prepareForEmbedding() {
-    this.context = await this.getContext();
-    // this.tokens = await this.getTokenCount();
-    this.embedding = await this.createEmbedding();
-    this.vector = this.createVector();
-    return this.vector;
-  }
+    async prepareForEmbedding() {
+        this.context = await this.getContext()
+        // this.tokens = await this.getTokenCount();
+        this.embedding = await this.createEmbedding()
+        this.vector = this.createVector()
+        return this.vector
+    }
 
-  async createEmbedding() {
-    const embedding = await openAi.createEmbedding(this.context);
-    return embedding;
-  }
+    async createEmbedding() {
+        const embedding = await openAi.createEmbedding(this.context)
+        return embedding
+    }
 
-  createVector() {
-    const objectType = this.object.objectType?.replace(/\s/g, '')?.toLowerCase();
-    const uid = this.object.uid;
-    const id = `${objectType}_${uid}`;
-    const vector = new Vector(id, this.object, this.embedding);
+    createVector() {
+        const objectType = this.object.objectType?.replace(/\s/g, '')?.toLowerCase()
+        const uid = this.object.uid
+        const id = `${objectType}_${uid}`
+        const vector = new Vector(id, this.object, this.embedding)
 
-    return vector;
-  }
+        return vector
+    }
 }
 
-export default AnswersObject;
+export default AnswersObject

--- a/packages-answers/utils/src/jira/models/comment.js
+++ b/packages-answers/utils/src/jira/models/comment.js
@@ -1,35 +1,35 @@
-import JiraObject from './jiraObject';
+import JiraObject from './jiraObject'
 class JiraComment extends JiraObject {
-  constructor(comment) {
-    const tidiedComment = JiraComment.tidy(comment);
-    super(tidiedComment);
-    this.object.objectType = 'JIRA Comment';
-    this.object.uid = comment.id;
-  }
+    constructor(comment) {
+        const tidiedComment = JiraComment.tidy(comment)
+        super(tidiedComment)
+        this.object.objectType = 'JIRA Comment'
+        this.object.uid = comment.id
+    }
 
-  static tidy(comment) {
-    // console.log('FIELDS', comment);
-    // delete comment.updateAuthor;
-    // delete comment.jsdPublic;
-    // delete comment.visibility;
-    const attrs = {
-      ...comment,
-      // key,
-      objectType: 'JIRA Comment',
-      author: comment?.author?.displayName,
-      link: comment?.self,
-      body: this.jiraAdfToMarkdown(comment?.body)
-    };
-    return {
-      ...attrs,
-      text: createContext(attrs)
-    };
-  }
+    static tidy(comment) {
+        // console.log('FIELDS', comment);
+        // delete comment.updateAuthor;
+        // delete comment.jsdPublic;
+        // delete comment.visibility;
+        const attrs = {
+            ...comment,
+            // key,
+            objectType: 'JIRA Comment',
+            author: comment?.author?.displayName,
+            link: comment?.self,
+            body: this.jiraAdfToMarkdown(comment?.body)
+        }
+        return {
+            ...attrs,
+            text: createContext(attrs)
+        }
+    }
 }
 const createContext = (metadata) => {
-  // let string = 'The context for ' + id + ' ';
-  let string = '';
-  string += `${metadata.author} commented "${metadata.body}" on ${metadata.created} and last updated on ${metadata.updated}.`;
-  return string;
-};
-export default JiraComment;
+    // let string = 'The context for ' + id + ' ';
+    let string = ''
+    string += `${metadata.author} commented "${metadata.body}" on ${metadata.created} and last updated on ${metadata.updated}.`
+    return string
+}
+export default JiraComment

--- a/packages-answers/utils/src/jira/models/issue.js
+++ b/packages-answers/utils/src/jira/models/issue.js
@@ -1,74 +1,71 @@
-import JiraObject from './jiraObject';
+import JiraObject from './jiraObject'
 
 class JiraIssue extends JiraObject {
-  constructor(issue) {
-    const tidiedIssue = JiraIssue.tidy(issue);
-    // console.log('Tidy');
-    // console.log(tidiedIssue);
-    super(tidiedIssue);
-    this.object.objectType = 'JIRA Issue';
-    this.object.uid = issue.key;
-    // this.vectors = this.getVectors();
-  }
+    constructor(issue) {
+        const tidiedIssue = JiraIssue.tidy(issue)
+        // console.log('Tidy');
+        // console.log(tidiedIssue);
+        super(tidiedIssue)
+        this.object.objectType = 'JIRA Issue'
+        this.object.uid = issue.key
+        // this.vectors = this.getVectors();
+    }
 
-  static tidy(issue) {
-    const { fields, key } = issue;
-    // console.log(fields);
-    const attrs = {
-      objectType: 'JIRA Issue',
-      // issueTypeId: fields?.issuetype?.id,
-      // issueType: fields?.issuetype?.name,
-      // 'issue id': key,
-      account: fields.customfield_10037?.value?.toLowerCase(),
-      project: fields.project?.name?.toLowerCase(),
-      reporter: fields.reporter?.displayName?.toLowerCase(),
-      assignee: fields.assignee?.displayName || 'Unassigned'?.toLowerCase(),
-      assignee_email: fields.assignee?.email?.toLowerCase(),
-      priority: fields.priority?.name?.toLowerCase(),
-      comments: fields?.comments?.toLowerCase(),
-      // priorityId: fields.priority?.id,
-      // creatorId: fields.creator?.accountId,
-      // creator: fields.creator?.displayName,
-      // statusId: parseInt(fields.status?.id, 10),
-      status: fields.status?.name?.toLowerCase(),
-      status_category: fields.status?.statusCategory?.name?.toLowerCase(),
-      parent_key: fields.parent?.key?.toLowerCase(),
-      description: (fields.description
-        ? JiraIssue.jiraAdfToMarkdown(fields.description)
-        : ''
-      )?.toLowerCase(),
-      summary: fields?.summary?.toLowerCase()
-      // statusCategoryId: fields.status?.statusCategory?.id,
-      // reporterId: fields.reporter?.accountId,
-      // assigneeId: fields.assignee?.accountId,
-      // parentIssue: {
-      // parentIssueSummary: fields.parent?.fields?.summary,
-      // parentIssueTypeId: fields.parent?.issuetype?.id,
-      // issueType: fields.parent?.issuetype?.name
-      // },
-      // projectId: fields.project?.key,
-      // objectType: 'JIRA Project'
-    };
+    static tidy(issue) {
+        const { fields, key } = issue
+        // console.log(fields);
+        const attrs = {
+            objectType: 'JIRA Issue',
+            // issueTypeId: fields?.issuetype?.id,
+            // issueType: fields?.issuetype?.name,
+            // 'issue id': key,
+            account: fields.customfield_10037?.value?.toLowerCase(),
+            project: fields.project?.name?.toLowerCase(),
+            reporter: fields.reporter?.displayName?.toLowerCase(),
+            assignee: fields.assignee?.displayName || 'Unassigned'?.toLowerCase(),
+            assignee_email: fields.assignee?.email?.toLowerCase(),
+            priority: fields.priority?.name?.toLowerCase(),
+            comments: fields?.comments?.toLowerCase(),
+            // priorityId: fields.priority?.id,
+            // creatorId: fields.creator?.accountId,
+            // creator: fields.creator?.displayName,
+            // statusId: parseInt(fields.status?.id, 10),
+            status: fields.status?.name?.toLowerCase(),
+            status_category: fields.status?.statusCategory?.name?.toLowerCase(),
+            parent_key: fields.parent?.key?.toLowerCase(),
+            description: (fields.description ? JiraIssue.jiraAdfToMarkdown(fields.description) : '')?.toLowerCase(),
+            summary: fields?.summary?.toLowerCase()
+            // statusCategoryId: fields.status?.statusCategory?.id,
+            // reporterId: fields.reporter?.accountId,
+            // assigneeId: fields.assignee?.accountId,
+            // parentIssue: {
+            // parentIssueSummary: fields.parent?.fields?.summary,
+            // parentIssueTypeId: fields.parent?.issuetype?.id,
+            // issueType: fields.parent?.issuetype?.name
+            // },
+            // projectId: fields.project?.key,
+            // objectType: 'JIRA Project'
+        }
 
-    return {
-      ...attrs,
-      text: createContext(key, attrs)
-    };
-  }
+        return {
+            ...attrs,
+            text: createContext(key, attrs)
+        }
+    }
 }
 
 const createContext = (id, metadata) => {
-  let string = '' + id + ' ';
-  string += Object.keys(metadata)
-    .filter((key) => !!metadata[key])
-    .map((key) => {
-      if (metadata.hasOwnProperty(key)) {
-        return `${key?.replaceAll('_', ' ')} is ${metadata[key]}`;
-      }
-    })
-    ?.join(', ');
-  string += '.';
-  return string;
-};
+    let string = '' + id + ' '
+    string += Object.keys(metadata)
+        .filter((key) => !!metadata[key])
+        .map((key) => {
+            if (metadata.hasOwnProperty(key)) {
+                return `${key?.replaceAll('_', ' ')} is ${metadata[key]}`
+            }
+        })
+        ?.join(', ')
+    string += '.'
+    return string
+}
 
-export default JiraIssue;
+export default JiraIssue

--- a/packages-answers/utils/src/jira/models/jiraObject.js
+++ b/packages-answers/utils/src/jira/models/jiraObject.js
@@ -1,50 +1,46 @@
-import AnswersObject from '../../core/models/answersObject';
+import AnswersObject from '../../core/models/answersObject'
 
 class JiraObject extends AnswersObject {
-  constructor(object) {
-    super(object);
-  }
-
-  static jiraAdfToMarkdown(node) {
-    if (!node) return '';
-
-    if (node.type === 'doc') {
-      return node.content.map((item) => `${JiraObject.jiraAdfToMarkdown(item)}`).join('');
-    } else if (node.type === 'text') {
-      return node.text;
-    } else if (node.type === 'hardBreak') {
-      // return "\n";
-      return ' ';
-    } else if (node.type === 'mention') {
-      return `@${node.attrs.username}`;
-    } else if (node.type === 'emoji') {
-      return ''; //`:${node.attrs.shortName}:`;
-    } else if (node.type === 'link') {
-      return `[${node.text}](${node.attrs.url})`;
-    } else if (node.type === 'mediaGroup') {
-      return node.content.map(JiraObject.jiraAdfToMarkdown).join('');
-    } else if (node.type === 'paragraph') {
-      return `${node.content.map(JiraObject.jiraAdfToMarkdown).join('')}. `;
-    } else if (node.type === 'bulletList') {
-      return node.content.map((item) => `${JiraObject.jiraAdfToMarkdown(item)}`).join('');
-    } else if (node.type === 'listItem') {
-      return node.content.map((item) => `- ${JiraObject.jiraAdfToMarkdown(item)}`).join('');
-    } else if (node.type === 'orderedList') {
-      return node.content
-        .map((item, index) => `${index + 1}. ${JiraObject.jiraAdfToMarkdown(item)}`)
-        .join('');
-    } else if (node.type === 'heading') {
-      return `\n${'#'.repeat(node.attrs.level)} ${node.content
-        .map(JiraObject.jiraAdfToMarkdown)
-        .join('')}\n`;
-    } else if (node.type === 'codeBlock') {
-      return `\`\`\`\n${node.text}\n\`\`\`\n`;
-    } else if (node.type === 'blockquote') {
-      return `> ${node.content.map(JiraObject.jiraAdfToMarkdown).join('')}\n`;
-    } else {
-      return '';
+    constructor(object) {
+        super(object)
     }
-  }
+
+    static jiraAdfToMarkdown(node) {
+        if (!node) return ''
+
+        if (node.type === 'doc') {
+            return node.content.map((item) => `${JiraObject.jiraAdfToMarkdown(item)}`).join('')
+        } else if (node.type === 'text') {
+            return node.text
+        } else if (node.type === 'hardBreak') {
+            // return "\n";
+            return ' '
+        } else if (node.type === 'mention') {
+            return `@${node.attrs.username}`
+        } else if (node.type === 'emoji') {
+            return '' //`:${node.attrs.shortName}:`;
+        } else if (node.type === 'link') {
+            return `[${node.text}](${node.attrs.url})`
+        } else if (node.type === 'mediaGroup') {
+            return node.content.map(JiraObject.jiraAdfToMarkdown).join('')
+        } else if (node.type === 'paragraph') {
+            return `${node.content.map(JiraObject.jiraAdfToMarkdown).join('')}. `
+        } else if (node.type === 'bulletList') {
+            return node.content.map((item) => `${JiraObject.jiraAdfToMarkdown(item)}`).join('')
+        } else if (node.type === 'listItem') {
+            return node.content.map((item) => `- ${JiraObject.jiraAdfToMarkdown(item)}`).join('')
+        } else if (node.type === 'orderedList') {
+            return node.content.map((item, index) => `${index + 1}. ${JiraObject.jiraAdfToMarkdown(item)}`).join('')
+        } else if (node.type === 'heading') {
+            return `\n${'#'.repeat(node.attrs.level)} ${node.content.map(JiraObject.jiraAdfToMarkdown).join('')}\n`
+        } else if (node.type === 'codeBlock') {
+            return `\`\`\`\n${node.text}\n\`\`\`\n`
+        } else if (node.type === 'blockquote') {
+            return `> ${node.content.map(JiraObject.jiraAdfToMarkdown).join('')}\n`
+        } else {
+            return ''
+        }
+    }
 }
 
-export default JiraObject;
+export default JiraObject

--- a/packages-answers/utils/src/jira/models/status.js
+++ b/packages-answers/utils/src/jira/models/status.js
@@ -1,31 +1,23 @@
-import JiraObject from "./jiraObject";
+import JiraObject from './jiraObject'
 
 class JiraStatus extends JiraObject {
-  constructor(status) {
-    const tidiedStatus = JiraStatus.tidy(status);
-    super(tidiedStatus);
-    this.object.objectType = "JIRA Status";
-    this.object.statusCategoryId = status?.statusCategory?.id;
-    this.object.uid = status.id;
-  }
+    constructor(status) {
+        const tidiedStatus = JiraStatus.tidy(status)
+        super(tidiedStatus)
+        this.object.objectType = 'JIRA Status'
+        this.object.statusCategoryId = status?.statusCategory?.id
+        this.object.uid = status.id
+    }
 
-  static tidy(status) {
-    const removeFields = [
-      "untranslatedName",
-      "scope",
-      "iconUrl",
-      "self",
-      "colorname",
-      "key",
-      "statusCategory",
-    ];
+    static tidy(status) {
+        const removeFields = ['untranslatedName', 'scope', 'iconUrl', 'self', 'colorname', 'key', 'statusCategory']
 
-    removeFields.forEach((fieldName) => {
-      delete status[fieldName];
-    });
+        removeFields.forEach((fieldName) => {
+            delete status[fieldName]
+        })
 
-    return status;
-  }
+        return status
+    }
 }
 
-export default JiraStatus;
+export default JiraStatus

--- a/packages-answers/utils/src/jira/models/statusCategory.js
+++ b/packages-answers/utils/src/jira/models/statusCategory.js
@@ -1,20 +1,20 @@
-import JiraObject from "./jiraObject";
+import JiraObject from './jiraObject'
 
 class JiraStatusCategory extends JiraObject {
-  constructor(statusCategory) {
-    const tidiedStatusCategory = JiraStatusCategory.tidy(statusCategory);
-    super(tidiedStatusCategory);
-    this.object.objectType = "JIRA Status Category";
-    this.object.uid = statusCategory.id;
-  }
+    constructor(statusCategory) {
+        const tidiedStatusCategory = JiraStatusCategory.tidy(statusCategory)
+        super(tidiedStatusCategory)
+        this.object.objectType = 'JIRA Status Category'
+        this.object.uid = statusCategory.id
+    }
 
-  static tidy(statusCategory) {
-    const removeFields = ["self", "colorName", "key"];
-    removeFields.forEach((fieldName) => {
-      delete statusCategory[fieldName];
-    });
-    return statusCategory;
-  }
+    static tidy(statusCategory) {
+        const removeFields = ['self', 'colorName', 'key']
+        removeFields.forEach((fieldName) => {
+            delete statusCategory[fieldName]
+        })
+        return statusCategory
+    }
 }
 
-export default JiraStatusCategory;
+export default JiraStatusCategory

--- a/packages-answers/utils/src/jira/models/thread.js
+++ b/packages-answers/utils/src/jira/models/thread.js
@@ -1,55 +1,55 @@
-import JiraObject from './jiraObject';
+import JiraObject from './jiraObject'
 class JiraThread extends JiraObject {
-  constructor(thread) {
-    const tidiedThread = JiraThread.tidy(thread);
+    constructor(thread) {
+        const tidiedThread = JiraThread.tidy(thread)
 
-    super(tidiedThread);
-    // this.thread = thread;
-    // this.object.objectType = 'JIRA Comments Thread';
-    this.object.uid = thread.issueKey;
-  }
+        super(tidiedThread)
+        // this.thread = thread;
+        // this.object.objectType = 'JIRA Comments Thread';
+        this.object.uid = thread.issueKey
+    }
 
-  static tidy(thread) {
-    return {
-      id: thread?.id?.toLowerCase(),
-      issueKey: thread?.issueKey?.toLowerCase(),
-      project: thread.issueKey?.split('-')[0]?.toLowerCase(),
-      // objectType: 'JIRA comments thread',
-      text: thread?.text || createContext(thread, this.jiraAdfToMarkdown)
-    };
-  }
+    static tidy(thread) {
+        return {
+            id: thread?.id?.toLowerCase(),
+            issueKey: thread?.issueKey?.toLowerCase(),
+            project: thread.issueKey?.split('-')[0]?.toLowerCase(),
+            // objectType: 'JIRA comments thread',
+            text: thread?.text || createContext(thread, this.jiraAdfToMarkdown)
+        }
+    }
 
-  getVectors() {
-    //chunk comments into 10 pero thread and add to vectors
-    const vectors = [];
-    const { comments } = this.object;
-    const chunkSize = 10;
-    chunkArray(comments, chunkSize).forEach((chunk, idx) => {
-      const vector = {
-        id: thread?.id,
-        // issueKey: `${this.object.uid}${idx}`,
-        // objectType: 'JIRA comments thread',
-        text: thread?.text || createContext({ ...thread, comments: chunk }, this.jiraAdfToMarkdown)
-      };
-      vectors.push(vector);
-    });
-    return vectors;
-  }
+    getVectors() {
+        //chunk comments into 10 pero thread and add to vectors
+        const vectors = []
+        const { comments } = this.object
+        const chunkSize = 10
+        chunkArray(comments, chunkSize).forEach((chunk, idx) => {
+            const vector = {
+                id: thread?.id,
+                // issueKey: `${this.object.uid}${idx}`,
+                // objectType: 'JIRA comments thread',
+                text: thread?.text || createContext({ ...thread, comments: chunk }, this.jiraAdfToMarkdown)
+            }
+            vectors.push(vector)
+        })
+        return vectors
+    }
 }
 
 // TODO : Use feature flag to determine context parser
 const createContext = (metadata, jiraAdfToMarkdown) => {
-  // let string = 'The context for ' + id + ' ';
-  let string = '';
-  const thread = metadata?.comments
-    ?.map(
-      ({ author, body, updated, self }) =>
-        // `[${updated} - ${author?.displayName}](${self}): ${jiraAdfToMarkdown(body)}`
-        `${author?.displayName} commented "${jiraAdfToMarkdown(body)}" on ${metadata?.issueKey}.`
-    )
-    ?.join('. ');
-  if (!thread) return '';
-  string += `${thread}`;
-  return string;
-};
-export default JiraThread;
+    // let string = 'The context for ' + id + ' ';
+    let string = ''
+    const thread = metadata?.comments
+        ?.map(
+            ({ author, body, updated, self }) =>
+                // `[${updated} - ${author?.displayName}](${self}): ${jiraAdfToMarkdown(body)}`
+                `${author?.displayName} commented "${jiraAdfToMarkdown(body)}" on ${metadata?.issueKey}.`
+        )
+        ?.join('. ')
+    if (!thread) return ''
+    string += `${thread}`
+    return string
+}
+export default JiraThread

--- a/packages-answers/utils/src/openapi/models/openApiUrl.js
+++ b/packages-answers/utils/src/openapi/models/openApiUrl.js
@@ -1,40 +1,40 @@
-import WebObject from './webObject';
+import WebObject from './webObject'
 
 class WebPage extends WebObject {
-  constructor(webPage) {
-    const tidiedPage = WebPage.tidy(webPage);
-    super(tidiedPage);
-    this.object.objectType = 'Web Page';
-    this.object.uid = webPage.url;
-    this.object.url = webPage.url;
-  }
+    constructor(webPage) {
+        const tidiedPage = WebPage.tidy(webPage)
+        super(tidiedPage)
+        this.object.objectType = 'Web Page'
+        this.object.uid = webPage.url
+        this.object.url = webPage.url
+    }
 
-  static tidy(webPage) {
-    const { url, html } = webPage;
-    const attrs = {
-      objectType: 'Web Page',
-      url: url,
-      content: WebObject.webToMarkdown(html)
-    };
+    static tidy(webPage) {
+        const { url, html } = webPage
+        const attrs = {
+            objectType: 'Web Page',
+            url: url,
+            content: WebObject.webToMarkdown(html)
+        }
 
-    return {
-      text: createContext(key, attrs)
-    };
-  }
+        return {
+            text: createContext(key, attrs)
+        }
+    }
 }
 
 const createContext = (id, metadata) => {
-  let string = '' + id + ' ';
-  string += Object.keys(metadata)
-    .filter((key) => !!metadata[key])
-    .map((key) => {
-      if (metadata.hasOwnProperty(key)) {
-        return `${key} is ${metadata[key]}`;
-      }
-    })
-    ?.join(', ');
-  string += '.';
-  return string;
-};
+    let string = '' + id + ' '
+    string += Object.keys(metadata)
+        .filter((key) => !!metadata[key])
+        .map((key) => {
+            if (metadata.hasOwnProperty(key)) {
+                return `${key} is ${metadata[key]}`
+            }
+        })
+        ?.join(', ')
+    string += '.'
+    return string
+}
 
-export default WebPage;
+export default WebPage

--- a/packages-answers/utils/src/slack/client.js
+++ b/packages-answers/utils/src/slack/client.js
@@ -1,120 +1,120 @@
-import { WebClient } from '@slack/web-api';
-import SlackChannel from './models/channel';
-import SlackUser from './models/user';
+import { WebClient } from '@slack/web-api'
+import SlackChannel from './models/channel'
+import SlackUser from './models/user'
 
 class SlackApiClient {
-  constructor({ accessToken: token }) {
-    this.client = new WebClient(token);
-    this.cache = {
-      users: {},
-      channels: {},
-      groups: {}
-    };
-  }
-
-  async initDataLookups() {
-    await this.initUserCache();
-    await this.initChannelCache();
-    // await this.initGroupCache();
-  }
-
-  async initUserCache() {
-    const users = [];
-    let cursor;
-
-    do {
-      const result = await this.client.users.list({ limit: 1000, cursor });
-      users.push(...result.members);
-      cursor = result.response_metadata.next_cursor;
-    } while (cursor);
-
-    for (const user of users) {
-      this.cache.users[user.id] = new SlackUser(this.client, user.id);
-    }
-  }
-
-  async initChannelCache() {
-    const channels = [];
-    let cursor;
-
-    do {
-      const result = await this.client.conversations.list({
-        types: 'public_channel,private_channel',
-        exclude_archived: true,
-        limit: 1000,
-        cursor
-      });
-      channels.push(...result.channels);
-      cursor = result.response_metadata.next_cursor;
-      // console.log('running');
-    } while (cursor);
-    // console.log('mid initChannelCache');
-    for (const channel of channels) {
-      this.cache.channels[channel.id] = channel;
-      // console.log('setting');
-    }
-    // console.log('end initChannelCache');
-  }
-
-  async initGroupCache() {
-    const groups = [];
-    let cursor;
-
-    do {
-      const result = await this.client.conversations.list({
-        types: 'mpim,im',
-        limit: 1000,
-        cursor
-      });
-      groups.push(...result.channels);
-      cursor = result.response_metadata.next_cursor;
-    } while (cursor);
-
-    for (const group of groups) {
-      this.cache.groups[group.id] = group;
-    }
-  }
-
-  async getChannel(channelId) {
-    if (!Object.keys(this.cache.channels).length) {
-      await this.initChannelCache();
-    }
-    if (this.cache.channels[channelId]) {
-      return this.cache.channels[channelId];
+    constructor({ accessToken: token }) {
+        this.client = new WebClient(token)
+        this.cache = {
+            users: {},
+            channels: {},
+            groups: {}
+        }
     }
 
-    const result = await this.client.conversations.info({ channel: channelId });
-    const channel = new SlackChannel(this.client, result.channel);
-    this.cache.channels[channelId] = channel;
-
-    return channel;
-  }
-  async getChannels() {
-    if (!Object.keys(this.cache.channels).length) {
-      await this.initChannelCache();
-    }
-    return Object.values(this.cache.channels);
-  }
-
-  async getUser(userId) {
-    if (this.cache.users[userId]) {
-      return this.cache.users[userId];
+    async initDataLookups() {
+        await this.initUserCache()
+        await this.initChannelCache()
+        // await this.initGroupCache();
     }
 
-    const result = await this.client.users.info({ user: userId });
-    const user = new SlackUser(this.client, result.user);
-    this.cache.users[userId] = user;
+    async initUserCache() {
+        const users = []
+        let cursor
 
-    return user;
-  }
+        do {
+            const result = await this.client.users.list({ limit: 1000, cursor })
+            users.push(...result.members)
+            cursor = result.response_metadata.next_cursor
+        } while (cursor)
 
-  getGroup(groupId) {
-    if (this.cache.groups[groupId]) {
-      return this.cache.groups[groupId];
+        for (const user of users) {
+            this.cache.users[user.id] = new SlackUser(this.client, user.id)
+        }
     }
 
-    throw new Error(`Group not found in cache: ${groupId}`);
-  }
+    async initChannelCache() {
+        const channels = []
+        let cursor
+
+        do {
+            const result = await this.client.conversations.list({
+                types: 'public_channel,private_channel',
+                exclude_archived: true,
+                limit: 1000,
+                cursor
+            })
+            channels.push(...result.channels)
+            cursor = result.response_metadata.next_cursor
+            // console.log('running');
+        } while (cursor)
+        // console.log('mid initChannelCache');
+        for (const channel of channels) {
+            this.cache.channels[channel.id] = channel
+            // console.log('setting');
+        }
+        // console.log('end initChannelCache');
+    }
+
+    async initGroupCache() {
+        const groups = []
+        let cursor
+
+        do {
+            const result = await this.client.conversations.list({
+                types: 'mpim,im',
+                limit: 1000,
+                cursor
+            })
+            groups.push(...result.channels)
+            cursor = result.response_metadata.next_cursor
+        } while (cursor)
+
+        for (const group of groups) {
+            this.cache.groups[group.id] = group
+        }
+    }
+
+    async getChannel(channelId) {
+        if (!Object.keys(this.cache.channels).length) {
+            await this.initChannelCache()
+        }
+        if (this.cache.channels[channelId]) {
+            return this.cache.channels[channelId]
+        }
+
+        const result = await this.client.conversations.info({ channel: channelId })
+        const channel = new SlackChannel(this.client, result.channel)
+        this.cache.channels[channelId] = channel
+
+        return channel
+    }
+    async getChannels() {
+        if (!Object.keys(this.cache.channels).length) {
+            await this.initChannelCache()
+        }
+        return Object.values(this.cache.channels)
+    }
+
+    async getUser(userId) {
+        if (this.cache.users[userId]) {
+            return this.cache.users[userId]
+        }
+
+        const result = await this.client.users.info({ user: userId })
+        const user = new SlackUser(this.client, result.user)
+        this.cache.users[userId] = user
+
+        return user
+    }
+
+    getGroup(groupId) {
+        if (this.cache.groups[groupId]) {
+            return this.cache.groups[groupId]
+        }
+
+        throw new Error(`Group not found in cache: ${groupId}`)
+    }
 }
 
-export default SlackApiClient;
+export default SlackApiClient

--- a/packages-answers/utils/src/slack/models/channel.js
+++ b/packages-answers/utils/src/slack/models/channel.js
@@ -1,60 +1,60 @@
-import SlackMessage from './message';
+import SlackMessage from './message'
 
 class SlackChannel {
-  constructor(slackApiClient, channel) {
-    this.slackApiClient = slackApiClient;
-    this.channelId = channel.id;
-    this.cache = {
-      info: channel,
-      messages: []
-    };
-  }
-
-  async getInfo() {
-    if (this.cache.info) {
-      return this.cache.info;
-    }
-
-    const result = await this.slackApiClient.conversations.info({
-      channel: this.channelId
-    });
-    this.cache.info = result.channel;
-
-    return this.cache.info;
-  }
-
-  async getMessages() {
-    if (this.cache?.messages?.length) {
-      return this.cache.messages;
-    }
-
-    const messages = [];
-
-    let cursor;
-    do {
-      const result = await this.slackApiClient.conversations.history({
-        channel: this.channelId,
-        cursor
-      });
-
-      for (const message of result.messages) {
-        const slackMessage = new SlackMessage(this.slackApiClient, this.channelId, message);
-        messages.push(slackMessage);
-
-        if (slackMessage?.mentionedUserIds?.length) {
-          // Replace user IDs with user objects in cache
-          for (const userId of slackMessage.mentionedUserIds) {
-            const user = await this.slackApiClient.getUser(userId);
-            slackMessage.text = slackMessage.text.replace(`<@${userId}>`, `@${user.realName}`);
-          }
+    constructor(slackApiClient, channel) {
+        this.slackApiClient = slackApiClient
+        this.channelId = channel.id
+        this.cache = {
+            info: channel,
+            messages: []
         }
-      }
-      cursor = result.response_metadata.next_cursor;
-    } while (cursor);
+    }
 
-    this.cache.messages = messages;
-    return messages;
-  }
+    async getInfo() {
+        if (this.cache.info) {
+            return this.cache.info
+        }
+
+        const result = await this.slackApiClient.conversations.info({
+            channel: this.channelId
+        })
+        this.cache.info = result.channel
+
+        return this.cache.info
+    }
+
+    async getMessages() {
+        if (this.cache?.messages?.length) {
+            return this.cache.messages
+        }
+
+        const messages = []
+
+        let cursor
+        do {
+            const result = await this.slackApiClient.conversations.history({
+                channel: this.channelId,
+                cursor
+            })
+
+            for (const message of result.messages) {
+                const slackMessage = new SlackMessage(this.slackApiClient, this.channelId, message)
+                messages.push(slackMessage)
+
+                if (slackMessage?.mentionedUserIds?.length) {
+                    // Replace user IDs with user objects in cache
+                    for (const userId of slackMessage.mentionedUserIds) {
+                        const user = await this.slackApiClient.getUser(userId)
+                        slackMessage.text = slackMessage.text.replace(`<@${userId}>`, `@${user.realName}`)
+                    }
+                }
+            }
+            cursor = result.response_metadata.next_cursor
+        } while (cursor)
+
+        this.cache.messages = messages
+        return messages
+    }
 }
 
-export default SlackChannel;
+export default SlackChannel

--- a/packages-answers/utils/src/slack/models/group.js
+++ b/packages-answers/utils/src/slack/models/group.js
@@ -1,40 +1,40 @@
 class SlackGroup {
-  constructor(slackApiClient, group) {
-    this.slackApiClient = slackApiClient;
-    this.group = group;
-    this.cache = {};
-  }
-
-  get id() {
-    return this.group.id;
-  }
-
-  get name() {
-    return this.group.name;
-  }
-
-  async getMembers() {
-    if (this.cache.members) {
-      return this.cache.members;
+    constructor(slackApiClient, group) {
+        this.slackApiClient = slackApiClient
+        this.group = group
+        this.cache = {}
     }
 
-    const members = [];
+    get id() {
+        return this.group.id
+    }
 
-    let cursor;
-    do {
-      const result = await this.slackApiClient.client.conversations.members({
-        channel: this.id,
-        cursor
-      });
-      for (const userId of result.members) {
-        const user = await this.slackApiClient.getUser(userId);
-        members.push(user);
-      }
-      cursor = result.response_metadata.next_cursor;
-    } while (cursor);
+    get name() {
+        return this.group.name
+    }
 
-    this.cache.members = members;
+    async getMembers() {
+        if (this.cache.members) {
+            return this.cache.members
+        }
 
-    return members;
-  }
+        const members = []
+
+        let cursor
+        do {
+            const result = await this.slackApiClient.client.conversations.members({
+                channel: this.id,
+                cursor
+            })
+            for (const userId of result.members) {
+                const user = await this.slackApiClient.getUser(userId)
+                members.push(user)
+            }
+            cursor = result.response_metadata.next_cursor
+        } while (cursor)
+
+        this.cache.members = members
+
+        return members
+    }
 }

--- a/packages-answers/utils/src/slack/models/message.js
+++ b/packages-answers/utils/src/slack/models/message.js
@@ -1,88 +1,88 @@
-import SlackObject from './slackObject';
+import SlackObject from './slackObject'
 
 class SlackMessage {
-  constructor(slackApiClient, channel, message, parentMessage) {
-    this.slackApiClient = slackApiClient;
-    this.channel = channel;
-    this.parentMessage = parentMessage;
-    this.cache = {
-      info: message
-    };
-  }
-
-  async getInfo() {
-    if (this.cache.info) {
-      return this.cache.info;
+    constructor(slackApiClient, channel, message, parentMessage) {
+        this.slackApiClient = slackApiClient
+        this.channel = channel
+        this.parentMessage = parentMessage
+        this.cache = {
+            info: message
+        }
     }
 
-    const result = await this.slackApiClient.client.conversations.history({
-      channel: this.channel,
-      ts: this.ts
-    });
-    const message = result.messages.find((m) => m.ts === this.ts);
+    async getInfo() {
+        if (this.cache.info) {
+            return this.cache.info
+        }
 
-    if (!message) {
-      throw new Error(`Message not found in channel ${this.channel}: ${this.ts}`);
+        const result = await this.slackApiClient.client.conversations.history({
+            channel: this.channel,
+            ts: this.ts
+        })
+        const message = result.messages.find((m) => m.ts === this.ts)
+
+        if (!message) {
+            throw new Error(`Message not found in channel ${this.channel}: ${this.ts}`)
+        }
+
+        this.cache.info = message
+
+        return this.cache.info
     }
 
-    this.cache.info = message;
+    async getTidiedInfo() {
+        if (this.cache.tidiedInfo) {
+            return this.cache.tidiedInfo
+        }
 
-    return this.cache.info;
-  }
+        const messageInfo = await this.getInfo()
+        const tidiedInfo = {
+            objectType: 'Slack Message',
+            message: messageInfo.text,
+            dateSent: SlackObject.convertTimestampToDate(messageInfo.ts),
+            dateEdited: messageInfo.edited ? SlackObject.convertTimestampToDate(messageInfo.edited.ts) : null,
+            user: await this.getUserName(messageInfo)
+        }
 
-  async getTidiedInfo() {
-    if (this.cache.tidiedInfo) {
-      return this.cache.tidiedInfo;
+        this.cache.tidiedInfo = tidiedInfo
+
+        return tidiedInfo
     }
 
-    const messageInfo = await this.getInfo();
-    const tidiedInfo = {
-      objectType: 'Slack Message',
-      message: messageInfo.text,
-      dateSent: SlackObject.convertTimestampToDate(messageInfo.ts),
-      dateEdited: messageInfo.edited ? SlackObject.convertTimestampToDate(messageInfo.edited.ts) : null,
-      user: await this.getUserName(messageInfo)
-    };
+    async getReplies() {
+        if (this.cache.replies) {
+            return this.cache.replies
+        }
 
-    this.cache.tidiedInfo = tidiedInfo;
+        const result = await this.slackApiClient.client.conversations.replies({
+            channel: this.channel,
+            ts: this.ts
+        })
+        const replies = result.messages.map((m) => new SlackMessage(this.slackApiClient, this.channel, m, this))
+        this.cache.replies = replies
 
-    return tidiedInfo;
-  }
-
-  async getReplies() {
-    if (this.cache.replies) {
-      return this.cache.replies;
+        return this.cache.replies
     }
 
-    const result = await this.slackApiClient.client.conversations.replies({
-      channel: this.channel,
-      ts: this.ts
-    });
-    const replies = result.messages.map((m) => new SlackMessage(this.slackApiClient, this.channel, m, this));
-    this.cache.replies = replies;
+    async getUserName(messageInfo) {
+        if (messageInfo.bot_id) {
+            return messageInfo.username || 'Unknown bot'
+        }
 
-    return this.cache.replies;
-  }
+        if (!messageInfo?.user) {
+            return 'Unknown user'
+        }
 
-  async getUserName(messageInfo) {
-    if (messageInfo.bot_id) {
-      return messageInfo.username || 'Unknown bot';
+        const user = await this.slackApiClient.getUser(messageInfo?.user?.id)
+        return user?.real_name_normalized || 'Unknown User'
     }
 
-    if (!messageInfo?.user) {
-      return 'Unknown user';
+    static replaceUserMentions(message, slackApiClient) {
+        return message.replace(/<@(U\w+)>/g, async (match, userId) => {
+            const user = await slackApiClient.getUser(userId)
+            return user.real_name_normalized
+        })
     }
-
-    const user = await this.slackApiClient.getUser(messageInfo?.user?.id);
-    return user?.real_name_normalized || 'Unknown User';
-  }
-
-  static replaceUserMentions(message, slackApiClient) {
-    return message.replace(/<@(U\w+)>/g, async (match, userId) => {
-      const user = await slackApiClient.getUser(userId);
-      return user.real_name_normalized;
-    });
-  }
 }
 
-export default SlackMessage;
+export default SlackMessage

--- a/packages-answers/utils/src/slack/models/slackObject.js
+++ b/packages-answers/utils/src/slack/models/slackObject.js
@@ -1,17 +1,17 @@
-import AnswersObject from "../../core/models/answersObject";
+import AnswersObject from '../../core/models/answersObject'
 
 class SlackObject extends AnswersObject {
-  constructor(object) {
-    super(object);
-  }
+    constructor(object) {
+        super(object)
+    }
 
-  static convertTimestampToDate(timestamp) {
-    if (!timestamp) return null;
-    const unixTimestamp = parseInt(timestamp.split(".")[0]); // remove the microseconds
-    if (isNaN(unixTimestamp)) throw new Error("Date is invalid");
-    const date = new Date(unixTimestamp * 1000); // multiply by 1000 to convert to milliseconds
-    return date;
-  }
+    static convertTimestampToDate(timestamp) {
+        if (!timestamp) return null
+        const unixTimestamp = parseInt(timestamp.split('.')[0]) // remove the microseconds
+        if (isNaN(unixTimestamp)) throw new Error('Date is invalid')
+        const date = new Date(unixTimestamp * 1000) // multiply by 1000 to convert to milliseconds
+        return date
+    }
 }
 
-export default SlackObject;
+export default SlackObject

--- a/packages-answers/utils/src/slack/models/user.js
+++ b/packages-answers/utils/src/slack/models/user.js
@@ -1,28 +1,28 @@
-import SlackObject from './slackObject';
+import SlackObject from './slackObject'
 
 class SlackUser {
-  constructor(slackApiClient, userId) {
-    this.slackApiClient = slackApiClient;
-    this.userId = userId;
-    this.cache = {};
-  }
-
-  async getInfo() {
-    if (this.cache.info) {
-      return this.cache.info;
+    constructor(slackApiClient, userId) {
+        this.slackApiClient = slackApiClient
+        this.userId = userId
+        this.cache = {}
     }
 
-    const result = await this.slackApiClient.client.users.info({
-      user: this.userId
-    });
-    this.cache.info = result.user;
+    async getInfo() {
+        if (this.cache.info) {
+            return this.cache.info
+        }
 
-    return this.cache.info;
-  }
+        const result = await this.slackApiClient.client.users.info({
+            user: this.userId
+        })
+        this.cache.info = result.user
 
-  get real_name_normalized() {
-    return this.getInfo().then((info) => info.real_name_normalized);
-  }
+        return this.cache.info
+    }
+
+    get real_name_normalized() {
+        return this.getInfo().then((info) => info.real_name_normalized)
+    }
 }
 
-export default SlackUser;
+export default SlackUser

--- a/packages-answers/utils/src/utilities/answerSession.js
+++ b/packages-answers/utils/src/utilities/answerSession.js
@@ -1,97 +1,94 @@
-import fs from 'fs';
-import Pinecone from '../pinecone/client';
+import fs from 'fs'
+import Pinecone from '../pinecone/client'
 
 class AnswerSession {
-  constructor(config) {
-    this.vectors = [];
-    Object.assign(this, config);
-  }
-
-  initPinecone(options) {
-    const pinecone = new Pinecone(options);
-    this.pinecone = pinecone;
-  }
-
-  addVectors(vectors) {
-    if (Array.isArray(vectors)) {
-      this.vectors.push(...vectors);
-    } else {
-      this.vectors.push(vectors);
-    }
-  }
-
-  replaceVectors(vectors) {
-    if (Array.isArray(vectors)) {
-      this.vectors = vectors;
-    } else {
-      this.vectors = [vectors];
-    }
-  }
-
-  clearVectors() {
-    this.vectors = [];
-  }
-
-  writeVectorsToFile() {
-    const maxFileSize = 1.8 * 1024 * 1024; // 1.5MB in bytes
-
-    let currentFileSize = 0;
-    let currentFileIndex = 0;
-    let currentFileArray = [];
-
-    const currentDate = new Date().toISOString().slice(0, 19).replace(/T/, ' ');
-
-    const folderPath = `output/${this.namespace}/${currentDate}`;
-
-    if (!fs.existsSync(folderPath)) {
-      fs.mkdirSync(folderPath, { recursive: true });
+    constructor(config) {
+        this.vectors = []
+        Object.assign(this, config)
     }
 
-    const outputFileName = `${folderPath}/${Date.now()}`;
-    const namespace = this.namespace;
-    this.vectors.forEach(function (element) {
-      let jsonString = JSON.stringify(element);
-      let jsonStringSize = Buffer.byteLength(jsonString, 'utf8');
-      if (currentFileSize + jsonStringSize > maxFileSize) {
-        fs.writeFileSync(
-          `${outputFileName}-${currentFileIndex}.json`,
-          JSON.stringify({
-            namespace,
-            vectors: currentFileArray
-          })
-        );
-        currentFileIndex++;
-        currentFileArray = [];
-        currentFileSize = 0;
-      }
-      currentFileArray.push(element);
-      currentFileSize += jsonStringSize;
-    });
-
-    fs.writeFileSync(
-      `${outputFileName}-${currentFileIndex}.json`,
-      JSON.stringify({ namespace, vectors: currentFileArray })
-    );
-  }
-
-  async prepareAllForEmbedding(objects) {
-    console.time('prepareAllForEmbedding');
-    let preparedStatuses;
-    try {
-      if (!objects) throw new Error('Invalid objects');
-      let promises = [];
-
-      for (const obj of objects) {
-        if (obj) promises.push(obj.prepareForEmbedding());
-      }
-      preparedStatuses = await Promise.all(promises);
-    } catch (error) {
-      console.error(error);
+    initPinecone(options) {
+        const pinecone = new Pinecone(options)
+        this.pinecone = pinecone
     }
 
-    console.timeEnd('prepareAllForEmbedding');
-    return preparedStatuses;
-  }
+    addVectors(vectors) {
+        if (Array.isArray(vectors)) {
+            this.vectors.push(...vectors)
+        } else {
+            this.vectors.push(vectors)
+        }
+    }
+
+    replaceVectors(vectors) {
+        if (Array.isArray(vectors)) {
+            this.vectors = vectors
+        } else {
+            this.vectors = [vectors]
+        }
+    }
+
+    clearVectors() {
+        this.vectors = []
+    }
+
+    writeVectorsToFile() {
+        const maxFileSize = 1.8 * 1024 * 1024 // 1.5MB in bytes
+
+        let currentFileSize = 0
+        let currentFileIndex = 0
+        let currentFileArray = []
+
+        const currentDate = new Date().toISOString().slice(0, 19).replace(/T/, ' ')
+
+        const folderPath = `output/${this.namespace}/${currentDate}`
+
+        if (!fs.existsSync(folderPath)) {
+            fs.mkdirSync(folderPath, { recursive: true })
+        }
+
+        const outputFileName = `${folderPath}/${Date.now()}`
+        const namespace = this.namespace
+        this.vectors.forEach(function (element) {
+            let jsonString = JSON.stringify(element)
+            let jsonStringSize = Buffer.byteLength(jsonString, 'utf8')
+            if (currentFileSize + jsonStringSize > maxFileSize) {
+                fs.writeFileSync(
+                    `${outputFileName}-${currentFileIndex}.json`,
+                    JSON.stringify({
+                        namespace,
+                        vectors: currentFileArray
+                    })
+                )
+                currentFileIndex++
+                currentFileArray = []
+                currentFileSize = 0
+            }
+            currentFileArray.push(element)
+            currentFileSize += jsonStringSize
+        })
+
+        fs.writeFileSync(`${outputFileName}-${currentFileIndex}.json`, JSON.stringify({ namespace, vectors: currentFileArray }))
+    }
+
+    async prepareAllForEmbedding(objects) {
+        console.time('prepareAllForEmbedding')
+        let preparedStatuses
+        try {
+            if (!objects) throw new Error('Invalid objects')
+            let promises = []
+
+            for (const obj of objects) {
+                if (obj) promises.push(obj.prepareForEmbedding())
+            }
+            preparedStatuses = await Promise.all(promises)
+        } catch (error) {
+            console.error(error)
+        }
+
+        console.timeEnd('prepareAllForEmbedding')
+        return preparedStatuses
+    }
 }
 
-export default AnswerSession;
+export default AnswerSession

--- a/packages-answers/utils/src/utilities/renderTemplate.js
+++ b/packages-answers/utils/src/utilities/renderTemplate.js
@@ -1,21 +1,21 @@
-import Handlebars from 'handlebars';
+import Handlebars from 'handlebars'
 
 // Register the helper function
 Handlebars.registerHelper('helperMissing', function () {
-  return '';
-});
+    return ''
+})
 
 export function precompileTemplate(templateString) {
-  return Handlebars.precompile(templateString);
+    return Handlebars.precompile(templateString)
 }
 
 export function getTemplate(precompiled) {
-  return Handlebars.template(eval('(' + precompiled + ')'));
+    return Handlebars.template(eval('(' + precompiled + ')'))
 }
 
 export function renderTemplate(templateString, context) {
-  // console.log(JSON.stringify(context, null, 2));
-  const template = Handlebars.compile(templateString);
-  const renderedTemplate = template(context);
-  return renderedTemplate;
+    // console.log(JSON.stringify(context, null, 2));
+    const template = Handlebars.compile(templateString)
+    const renderedTemplate = template(context)
+    return renderedTemplate
 }

--- a/packages-answers/utils/src/utilities/sessionData.js
+++ b/packages-answers/utils/src/utilities/sessionData.js
@@ -1,97 +1,94 @@
-import fs from 'fs';
-import PineconeClient from '../pinecone/client';
+import fs from 'fs'
+import PineconeClient from '../pinecone/client'
 
 class AnswerSession {
-  constructor(config) {
-    this.vectors = [];
-    Object.assign(this, config);
-  }
-
-  initPinecone(options) {
-    const pinecone = new PineconeClient(options);
-    this.pinecone = pinecone;
-  }
-
-  addVectors(vectors) {
-    if (Array.isArray(vectors)) {
-      this.vectors.push(...vectors);
-    } else {
-      this.vectors.push(vectors);
-    }
-  }
-
-  replaceVectors(vectors) {
-    if (Array.isArray(vectors)) {
-      this.vectors = vectors;
-    } else {
-      this.vectors = [vectors];
-    }
-  }
-
-  clearVectors() {
-    this.vectors = [];
-  }
-
-  writeVectorsToFile() {
-    const maxFileSize = 1.8 * 1024 * 1024; // 1.5MB in bytes
-
-    let currentFileSize = 0;
-    let currentFileIndex = 0;
-    let currentFileArray = [];
-
-    const currentDate = new Date().toISOString().slice(0, 19).replace(/T/, ' ');
-
-    const folderPath = `output/${this.namespace}/${currentDate}`;
-
-    if (!fs.existsSync(folderPath)) {
-      fs.mkdirSync(folderPath, { recursive: true });
+    constructor(config) {
+        this.vectors = []
+        Object.assign(this, config)
     }
 
-    const outputFileName = `${folderPath}/${Date.now()}`;
-    const namespace = this.namespace;
-    this.vectors.forEach(function (element) {
-      let jsonString = JSON.stringify(element);
-      let jsonStringSize = Buffer.byteLength(jsonString, 'utf8');
-      if (currentFileSize + jsonStringSize > maxFileSize) {
-        fs.writeFileSync(
-          `${outputFileName}-${currentFileIndex}.json`,
-          JSON.stringify({
-            namespace,
-            vectors: currentFileArray
-          })
-        );
-        currentFileIndex++;
-        currentFileArray = [];
-        currentFileSize = 0;
-      }
-      currentFileArray.push(element);
-      currentFileSize += jsonStringSize;
-    });
-
-    fs.writeFileSync(
-      `${outputFileName}-${currentFileIndex}.json`,
-      JSON.stringify({ namespace, vectors: currentFileArray })
-    );
-  }
-
-  async prepareAllForEmbedding(objects) {
-    console.time('prepareAllForEmbedding');
-    let preparedStatuses;
-    try {
-      if (!objects) throw new Error('Invalid objects');
-      let promises = [];
-
-      for (const obj of objects) {
-        if (obj) promises.push(obj.prepareForEmbedding());
-      }
-      preparedStatuses = await Promise.all(promises);
-    } catch (error) {
-      console.error(error);
+    initPinecone(options) {
+        const pinecone = new PineconeClient(options)
+        this.pinecone = pinecone
     }
 
-    console.timeEnd('prepareAllForEmbedding');
-    return preparedStatuses;
-  }
+    addVectors(vectors) {
+        if (Array.isArray(vectors)) {
+            this.vectors.push(...vectors)
+        } else {
+            this.vectors.push(vectors)
+        }
+    }
+
+    replaceVectors(vectors) {
+        if (Array.isArray(vectors)) {
+            this.vectors = vectors
+        } else {
+            this.vectors = [vectors]
+        }
+    }
+
+    clearVectors() {
+        this.vectors = []
+    }
+
+    writeVectorsToFile() {
+        const maxFileSize = 1.8 * 1024 * 1024 // 1.5MB in bytes
+
+        let currentFileSize = 0
+        let currentFileIndex = 0
+        let currentFileArray = []
+
+        const currentDate = new Date().toISOString().slice(0, 19).replace(/T/, ' ')
+
+        const folderPath = `output/${this.namespace}/${currentDate}`
+
+        if (!fs.existsSync(folderPath)) {
+            fs.mkdirSync(folderPath, { recursive: true })
+        }
+
+        const outputFileName = `${folderPath}/${Date.now()}`
+        const namespace = this.namespace
+        this.vectors.forEach(function (element) {
+            let jsonString = JSON.stringify(element)
+            let jsonStringSize = Buffer.byteLength(jsonString, 'utf8')
+            if (currentFileSize + jsonStringSize > maxFileSize) {
+                fs.writeFileSync(
+                    `${outputFileName}-${currentFileIndex}.json`,
+                    JSON.stringify({
+                        namespace,
+                        vectors: currentFileArray
+                    })
+                )
+                currentFileIndex++
+                currentFileArray = []
+                currentFileSize = 0
+            }
+            currentFileArray.push(element)
+            currentFileSize += jsonStringSize
+        })
+
+        fs.writeFileSync(`${outputFileName}-${currentFileIndex}.json`, JSON.stringify({ namespace, vectors: currentFileArray }))
+    }
+
+    async prepareAllForEmbedding(objects) {
+        console.time('prepareAllForEmbedding')
+        let preparedStatuses
+        try {
+            if (!objects) throw new Error('Invalid objects')
+            let promises = []
+
+            for (const obj of objects) {
+                if (obj) promises.push(obj.prepareForEmbedding())
+            }
+            preparedStatuses = await Promise.all(promises)
+        } catch (error) {
+            console.error(error)
+        }
+
+        console.timeEnd('prepareAllForEmbedding')
+        return preparedStatuses
+    }
 }
 
-export default AnswerSession;
+export default AnswerSession

--- a/packages-answers/utils/src/utilities/vector.js
+++ b/packages-answers/utils/src/utilities/vector.js
@@ -1,36 +1,34 @@
 class Vector {
-  constructor(id, metadata, values) {
-    this.id = id;
-    this.metadata = Vector.flattenObject(metadata);
+    constructor(id, metadata, values) {
+        this.id = id
+        this.metadata = Vector.flattenObject(metadata)
 
-    this.values = values;
-  }
-
-  static removeObjNulls(obj) {
-    return Object.fromEntries(
-      Object.entries(obj).filter(([key, value]) => value !== null && value !== undefined)
-    );
-  }
-
-  static flattenObject(ob) {
-    let toReturn = {};
-
-    for (let i in ob) {
-      if (!ob.hasOwnProperty(i)) continue;
-
-      if (typeof ob[i] == 'object') {
-        let flatObject = Vector.flattenObject(ob[i]);
-        for (let x in flatObject) {
-          if (!flatObject.hasOwnProperty(x)) continue;
-          toReturn[i + x.charAt(0).toUpperCase() + x.slice(1)] = flatObject[x];
-        }
-      } else {
-        toReturn[i] = ob[i];
-      }
+        this.values = values
     }
-    toReturn = this.removeObjNulls(toReturn);
-    return toReturn;
-  }
+
+    static removeObjNulls(obj) {
+        return Object.fromEntries(Object.entries(obj).filter(([key, value]) => value !== null && value !== undefined))
+    }
+
+    static flattenObject(ob) {
+        let toReturn = {}
+
+        for (let i in ob) {
+            if (!ob.hasOwnProperty(i)) continue
+
+            if (typeof ob[i] == 'object') {
+                let flatObject = Vector.flattenObject(ob[i])
+                for (let x in flatObject) {
+                    if (!flatObject.hasOwnProperty(x)) continue
+                    toReturn[i + x.charAt(0).toUpperCase() + x.slice(1)] = flatObject[x]
+                }
+            } else {
+                toReturn[i] = ob[i]
+            }
+        }
+        toReturn = this.removeObjNulls(toReturn)
+        return toReturn
+    }
 }
 
-export default Vector;
+export default Vector

--- a/packages-answers/utils/src/web/models/page.js
+++ b/packages-answers/utils/src/web/models/page.js
@@ -1,40 +1,40 @@
-import WebObject from './webObject';
+import WebObject from './webObject'
 
 class WebPage extends WebObject {
-  constructor(webPage) {
-    const tidiedPage = WebPage.tidy(webPage);
-    super(tidiedPage);
-    this.object.objectType = 'Web Page';
-    this.object.uid = webPage.url;
-    this.object.url = webPage.url;
-  }
+    constructor(webPage) {
+        const tidiedPage = WebPage.tidy(webPage)
+        super(tidiedPage)
+        this.object.objectType = 'Web Page'
+        this.object.uid = webPage.url
+        this.object.url = webPage.url
+    }
 
-  static tidy(webPage) {
-    const { url, html } = webPage;
-    const attrs = {
-      objectType: 'Web Page',
-      url: url,
-      content: WebObject.webToMarkdown(html)
-    };
+    static tidy(webPage) {
+        const { url, html } = webPage
+        const attrs = {
+            objectType: 'Web Page',
+            url: url,
+            content: WebObject.webToMarkdown(html)
+        }
 
-    return {
-      text: createContext(key, attrs)
-    };
-  }
+        return {
+            text: createContext(key, attrs)
+        }
+    }
 }
 
 const createContext = (id, metadata) => {
-  let string = '' + id + ' ';
-  string += Object.keys(metadata)
-    .filter((key) => !!metadata[key])
-    .map((key) => {
-      if (metadata.hasOwnProperty(key)) {
-        return `${key} is ${metadata[key]}`;
-      }
-    })
-    ?.join(', ');
-  string += '.';
-  return string;
-};
+    let string = '' + id + ' '
+    string += Object.keys(metadata)
+        .filter((key) => !!metadata[key])
+        .map((key) => {
+            if (metadata.hasOwnProperty(key)) {
+                return `${key} is ${metadata[key]}`
+            }
+        })
+        ?.join(', ')
+    string += '.'
+    return string
+}
 
-export default WebPage;
+export default WebPage

--- a/packages-answers/utils/src/web/models/webObject.js
+++ b/packages-answers/utils/src/web/models/webObject.js
@@ -1,20 +1,20 @@
-import AnswersObject from '../../core/models/answersObject';
-import { NodeHtmlMarkdown, NodeHtmlMarkdownOptions } from 'node-html-markdown';
+import AnswersObject from '../../core/models/answersObject'
+import { NodeHtmlMarkdown, NodeHtmlMarkdownOptions } from 'node-html-markdown'
 
 class WebObj extends AnswersObject {
-  constructor(object) {
-    super(object);
-  }
+    constructor(object) {
+        super(object)
+    }
 
-  static webToMarkdown(html) {
-    const markdown = NodeHtmlMarkdown.translate(
-      /* html */ response.data,
-      /* options (optional) */ {},
-      /* customTranslators (optional) */ undefined,
-      /* customCodeBlockTranslators (optional) */ undefined
-    );
-    return markdown;
-  }
+    static webToMarkdown(html) {
+        const markdown = NodeHtmlMarkdown.translate(
+            /* html */ response.data,
+            /* options (optional) */ {},
+            /* customTranslators (optional) */ undefined,
+            /* customCodeBlockTranslators (optional) */ undefined
+        )
+        return markdown
+    }
 }
 
-export default WebObj;
+export default WebObj

--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -8,7 +8,13 @@ import {
     IServerSideEventStreamer
 } from '../../../src/Interface'
 import axios, { AxiosRequestConfig } from 'axios'
-import { getCredentialData, getCredentialParam, processTemplateVariables, parseJsonBody, applyLangfuseTraceHeaders } from '../../../src/utils'
+import {
+    getCredentialData,
+    getCredentialParam,
+    processTemplateVariables,
+    parseJsonBody,
+    applyLangfuseTraceHeaders
+} from '../../../src/utils'
 import { DataSource } from 'typeorm'
 import { BaseMessageLike } from '@langchain/core/messages'
 import { updateFlowState } from '../utils'

--- a/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
@@ -1,5 +1,12 @@
 import { DataSource } from 'typeorm'
-import { getCredentialData, getCredentialParam, getVars, executeJavaScriptCode, createCodeExecutionSandbox, applyLangfuseTraceHeaders } from '../../../src/utils'
+import {
+    getCredentialData,
+    getCredentialParam,
+    getVars,
+    executeJavaScriptCode,
+    createCodeExecutionSandbox,
+    applyLangfuseTraceHeaders
+} from '../../../src/utils'
 import { isValidUUID, isValidURL } from '../../../src/validator'
 import {
     ICommonObject,


### PR DESCRIPTION
## Summary

- Optimize GitHub Actions CI workflows with Docker Buildx caching and Turbo remote caching
- Add Claude Code PostToolUse hooks for auto-formatting on file edits
- Run prettier across codebase to establish consistent formatting baseline

## CI Caching

| Workflow | Change | Impact |
|----------|--------|--------|
| `test_docker_build.yml` | Docker Buildx + GHA cache | ~3-4 min saved per run |
| `main.yml` | Turbo remote cache + frozen lockfile | 50-80% faster subsequent builds |
| `publish-packages.yml` | Frozen lockfile | Faster, deterministic installs |

No secrets required — all caching uses GitHub Actions built-in cache backend.

## Auto-Format Hooks

Two PostToolUse hooks trigger on every `Edit`/`Write` of JS/TS files:

| Hook | Sync/Async | Time | What it does |
|------|-----------|------|--------------|
| `format-on-save.sh` | Sync | ~0.4s | Prettier format |
| `lint-fix-async.sh` | Async | ~1.5s | ESLint --fix (packages/* only) |

Skips: `node_modules/`, `dist/`, `build/`, `.next/`, `public/`, `packages/embed/`

## Prettier Baseline

Ran `prettier --write` across all source files to establish a clean formatting baseline. Formatting-only changes in `packages-answers/` and `packages/components/`.

## Test plan

- [x] Hook scripts tested manually (format, skip logic, error handling)
- [ ] Verify CI workflows pass on this PR
- [ ] Confirm cache hits on subsequent CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)