### PR TITLE
fix: reference correct _chats prop in ChatDrawer

### DIFF
--- a/packages-answers/ui/src/ChatDrawer.tsx
+++ b/packages-answers/ui/src/ChatDrawer.tsx
@@ -76,7 +76,7 @@ export default function ChatDrawer({ journeys: _journeys, chats: _chats, default
     }
 
     const { data, size, setSize, isValidating } = useSWRInfinite<Chat[]>(getKey, fetcher, {
-        fallbackData: chats ? [chats] : undefined,
+        fallbackData: _chats ? [_chats] : undefined,
         revalidateFirstPage: false
     })
 


### PR DESCRIPTION
## Summary
- Fixes `ReferenceError: chats is not defined` runtime crash in `ChatDrawer.tsx`
- The `useSWRInfinite` fallbackData referenced `chats` but the destructured prop was named `_chats`

## Changes
- `packages-answers/ui/src/ChatDrawer.tsx`: Changed `chats` → `_chats` on line 79

## Test plan
- [ ] Verify ChatDrawer renders without ReferenceError
- [ ] Verify chat list loads with infinite scroll

**Linear:** [AGENT-673](https://linear.app/answeragent/issue/AGENT-673/fix-referenceerror-chats-is-not-defined-in-chatdrawer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)