### PR TITLE
fix(AGENT-76): address PR review feedback for credential refresh

### DIFF
--- a/apps/web/e2e/tests/canvas-credential-refresh.spec.ts
+++ b/apps/web/e2e/tests/canvas-credential-refresh.spec.ts
@@ -152,17 +152,7 @@ test.describe('Canvas Credential Refresh (AGENT-76)', () => {
                     // 3. Verify the canvas node still exists and is visible (it wasn't reset)
                     await expect(canvasNode).toBeVisible()
 
-                    // 4. Verify ReactFlow node data actually contains the credential
-                    // This is the actual verification that the fix works
-                    const credentialSetInNode = await page
-                        .evaluate(() => {
-                            // Access ReactFlow context to verify node data was updated
-                            const nodes = (window as any).__REACT_FLOW_NODES || []
-                            return nodes.some((node: any) => node.data?.credential || node.data?.inputs?.['flowise_credential'])
-                        })
-                        .catch(() => false)
-
-                    // Even if we can't access internal state, verify the UI reflects the change
+                    // 4. Verify the UI reflects the credential change without a page reload
                     expect(updatedValue).not.toBe(initialValue)
                 } else {
                     // No existing credentials - test is inconclusive but not a failure

--- a/packages/ui/src/store/context/ReactFlowContext.jsx
+++ b/packages/ui/src/store/context/ReactFlowContext.jsx
@@ -70,15 +70,15 @@ export const ReactFlowContext = ({ children }) => {
                 })
 
                 // Handle credential inputs: update both credential field and FLOWISE_CREDENTIAL_ID
+                if (inputParam.type === 'credential') {
+                    updatedInputs[FLOWISE_CREDENTIAL_ID] = newValue
+                }
+
                 const updatedData = {
                     ...node.data,
                     inputParams: updatedInputParams,
-                    inputs: updatedInputs
-                }
-
-                if (inputParam.type === 'credential') {
-                    updatedData.credential = newValue
-                    updatedInputs.FLOWISE_CREDENTIAL_ID = newValue
+                    inputs: updatedInputs,
+                    ...(inputParam.type === 'credential' && { credential: newValue })
                 }
 
                 return {
@@ -89,9 +89,13 @@ export const ReactFlowContext = ({ children }) => {
             return node
         })
 
-        // Check if any node's inputParams have changed before updating
+        // Check if any node data has changed before updating
+        const currentNodes = reactFlowInstance.getNodes()
         const hasChanges = updatedNodes.some(
-            (node, index) => !isEqual(node.data.inputParams, reactFlowInstance.getNodes()[index].data.inputParams)
+            (node, index) =>
+                !isEqual(node.data.inputParams, currentNodes[index].data.inputParams) ||
+                !isEqual(node.data.inputs, currentNodes[index].data.inputs) ||
+                node.data.credential !== currentNodes[index].data.credential
         )
 
         if (hasChanges) {

--- a/packages/ui/src/views/docstore/DocStoreInputHandler.jsx
+++ b/packages/ui/src/views/docstore/DocStoreInputHandler.jsx
@@ -154,10 +154,15 @@ const DocStoreInputHandler = ({ inputParam, data, disabled = false, onNodeDataCh
                                 data={getCredential()}
                                 inputParam={inputParam}
                                 onSelect={(newValue) => {
-                                    data.credential = newValue
-                                    data.inputs[FLOWISE_CREDENTIAL_ID] = newValue // in case data.credential is not updated
                                     setSelectedCredential(newValue)
                                     setSelectedCredentialData(null) // Reset credential data when credential changes
+                                    // Use centralized state handler for consistent ReactFlow state management
+                                    if (nodeDataChangeHandler) {
+                                        nodeDataChangeHandler({ nodeId: data.id, inputParam, newValue })
+                                    } else {
+                                        data.credential = newValue
+                                        data.inputs[FLOWISE_CREDENTIAL_ID] = newValue
+                                    }
                                 }}
                             />
                         )}


### PR DESCRIPTION
## Summary
Follow-up to PR #935 addressing review feedback:

- **Fix mutation ordering in ReactFlowContext**: `FLOWISE_CREDENTIAL_ID` is now updated in `updatedInputs` *before* spreading into `updatedData`, eliminating confusing reference-based side effects
- **Fix hasChanges detection bug**: The change detection only compared `inputParams`, meaning credential-only changes (that don't affect input visibility) were silently dropped and `setNodes` was never called. Now also compares `inputs` and `credential`
- **Refactor DocStoreInputHandler**: Credential `onSelect` now uses the centralized `nodeDataChangeHandler` (consistent with NodeInputHandler) instead of direct state mutation
- **Clean up E2E test**: Removed unused `credentialSetInNode` variable that was computed but never asserted on

## Test plan
- [ ] Verify credential selection updates canvas node immediately (no page refresh)
- [ ] Verify credential selection works in DocStore input handler
- [ ] Verify switching between different credentials reflects correctly
- [ ] Verify E2E test passes: `pnpm --filter web test:e2e -- tests/canvas-credential-refresh.spec.ts`

## Linear
AGENT-76

🤖 Generated with [Claude Code](https://claude.com/claude-code)