### PR TITLE
fix(AGENT-674): scope Personal Workspace lookup to current user

### DIFF
--- a/packages/server/src/middlewares/authentication/findOrCreateDefaultChatflowsForUser.ts
+++ b/packages/server/src/middlewares/authentication/findOrCreateDefaultChatflowsForUser.ts
@@ -48,10 +48,13 @@ export const findOrCreateDefaultChatflowsForUser = async (AppDataSource: DataSou
         // If user already has this chatflow, update their defaultChatflowId if not set
         if (existingChatflow) {
             // Auto-heal: ensure chatflow is in Personal Workspace (AGENT-674)
-            const workspaceRepo = queryRunner.manager.getRepository(Workspace)
-            const personalWs = await workspaceRepo.findOne({
-                where: { organizationId: user.organizationId, name: 'Personal Workspace' }
-            })
+            const personalWs = await queryRunner.manager
+                .createQueryBuilder(Workspace, 'w')
+                .innerJoin('workspace_user', 'wu', 'w.id = wu."workspaceId"')
+                .where('w."organizationId" = :orgId', { orgId: user.organizationId })
+                .andWhere('w.name = :name', { name: 'Personal Workspace' })
+                .andWhere('(wu."userId" = :userId OR w."createdBy" = :userId)', { userId: user.id })
+                .getOne()
             if (personalWs && existingChatflow.workspaceId !== personalWs.id) {
                 await chatFlowRepo.update(existingChatflow.id, { workspaceId: personalWs.id })
             }
@@ -77,13 +80,12 @@ export const findOrCreateDefaultChatflowsForUser = async (AppDataSource: DataSou
 
         if (template) {
             // Always use Personal Workspace for default chatflows
-            const workspaceRepo = AppDataSource.getRepository(Workspace)
-            const personalWs = await workspaceRepo.findOne({
-                where: {
-                    organizationId: user.organizationId,
-                    name: 'Personal Workspace'
-                }
-            })
+            const personalWs = await AppDataSource.createQueryBuilder(Workspace, 'w')
+                .innerJoin('workspace_user', 'wu', 'w.id = wu."workspaceId"')
+                .where('w."organizationId" = :orgId', { orgId: user.organizationId })
+                .andWhere('w.name = :name', { name: 'Personal Workspace' })
+                .andWhere('(wu."userId" = :userId OR w."createdBy" = :userId)', { userId: user.id })
+                .getOne()
             const targetWorkspaceId = personalWs?.id || activeWorkspaceId
 
             const templateCopy = { ...template }


### PR DESCRIPTION
## Summary

- Fixes Personal Workspace lookup in `findOrCreateDefaultChatflowsForUser` to find THIS user's workspace, not just any in the org
- Joins through `workspace_user` on `userId` with `createdBy` fallback
- Fixes both the auto-heal path (AGENT-674) and the pre-existing new-chatflow creation path

## Context

This commit was pushed after PR #947 was merged and missed the merge. Cherry-picked onto a new branch.

The previous queries used `findOne({ where: { organizationId, name: 'Personal Workspace' } })` which could return any user's Personal Workspace in a multi-user org.

## Test plan

- [ ] In multi-user org: each user's default chatflow should point to their OWN Personal Workspace
- [ ] Single-user org: no behavior change

## Linear ticket

AGENT-674