### PR TITLE
fix(AGENT-677): fix version history 500 Unauthorized in Enterprise Admin

### DIFF
--- a/packages-answers/ui/src/Admin/Chatflows/index.tsx
+++ b/packages-answers/ui/src/Admin/Chatflows/index.tsx
@@ -1570,7 +1570,7 @@ const AdminChatflows = () => {
                         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                             {chatflowVersions.map((version: any) => (
                                 <Box
-                                    key={version.version}
+                                    key={`${version.version}-${version.timestamp}`}
                                     sx={{
                                         p: 2,
                                         border: version.isCurrent

--- a/packages/server/src/routes/admin/index.ts
+++ b/packages/server/src/routes/admin/index.ts
@@ -3,16 +3,17 @@ import chatflowsController from '../../controllers/chatflows'
 import documentStoreController from '../../controllers/documentstore'
 import organizationsController from '../../controllers/organizations'
 import enforceAbility from '../../middlewares/authentication/enforceAbility'
+import { checkPermission } from '../../enterprise/rbac/PermissionCheck'
 const router = express.Router()
 
 // CHATFLOWS
 // READ
 router.get('/chatflows', enforceAbility('ChatFlow'), chatflowsController.getAdminChatflows)
 router.get('/chatflows/default-template', enforceAbility('ChatFlow'), chatflowsController.getDefaultChatflowTemplate)
-router.get('/chatflows/:id/versions', enforceAbility('ChatFlow'), chatflowsController.getChatflowVersions)
+router.get('/chatflows/:id/versions', checkPermission('chatflows:view'), chatflowsController.getChatflowVersions)
 // UPDATE
 router.put('/chatflows/bulk-update', enforceAbility('ChatFlow'), chatflowsController.bulkUpdateChatflows)
-router.post('/chatflows/:id/rollback/:version', enforceAbility('ChatFlow'), chatflowsController.rollbackChatflowToVersion)
+router.post('/chatflows/:id/rollback/:version', checkPermission('chatflows:update'), chatflowsController.rollbackChatflowToVersion)
 
 // DOCUMENT STORES
 // READ

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -21,7 +21,6 @@ import logger from '../../utils/logger'
 import { updateStorageUsage } from '../../utils/quotaUsage'
 import chatflowStorageService from '../chatflow-storage'
 import { Chat } from '../../database/entities/Chat'
-import checkOwnership from '../../utils/checkOwnership'
 import { Organization } from '../../database/entities/Organization'
 export const enum ChatflowErrorMessage {
     INVALID_CHATFLOW_TYPE = 'Invalid Chatflow Type'
@@ -702,11 +701,6 @@ const getChatflowVersions = async (chatflowId: string, user: IUser): Promise<any
             throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
         }
 
-        // Check ownership
-        if (!(await checkOwnership(chatflow, user))) {
-            throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `Unauthorized`)
-        }
-
         // Get versions from S3
         const versions = await chatflowStorageService.listChatflowVersions(chatflowId)
 
@@ -777,11 +771,6 @@ const getChatflowVersion = async (chatflowId: string, version: number | undefine
             throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
         }
 
-        // Check ownership
-        if (!(await checkOwnership(chatflow, user))) {
-            throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `Unauthorized`)
-        }
-
         // Get specific version or published version from S3
         const flowData = await chatflowStorageService.getChatflowVersion(chatflowId, version)
         if (!flowData) {
@@ -809,11 +798,6 @@ const rollbackChatflowToVersion = async (chatflowId: string, version: number, us
         const chatflow = await chatFlowRepository.findOne({ where: { id: chatflowId } })
         if (!chatflow) {
             throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
-        }
-
-        // Check ownership
-        if (!(await checkOwnership(chatflow, user))) {
-            throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `Unauthorized`)
         }
 
         // Get the version content from S3


### PR DESCRIPTION
## Summary
- Replace deprecated `enforceAbility` with `checkPermission` on admin version history routes — fixes 500 Unauthorized for enterprise admin/org admin users
- Remove deprecated `checkOwnership` calls from version service functions (`getChatflowVersions`, `getChatflowVersion`, `rollbackChatflowToVersion`)
- Fix duplicate React key warning in version history dialog

## Root Cause
Enterprise admin users (e.g., Kumello) could see chatflows via `getAdminChatflows` (which handles its own auth), but clicking "Version History" hit `checkOwnership()` which didn't recognize org admin permissions — returning 500 Unauthorized.

## Test plan
- [ ] Enterprise admin user can view version history on chatflows they don't own
- [ ] Enterprise admin user can rollback versions
- [ ] Regular users can still view/rollback their own chatflow versions
- [ ] No duplicate React key warnings in version history dialog

Closes AGENT-677