### PR TITLE
fix(AGENT-678): fix View Metrics crash in Enterprise Admin

### DIFF
--- a/packages-answers/ui/src/Admin/Chatflows/metrics.tsx
+++ b/packages-answers/ui/src/Admin/Chatflows/metrics.tsx
@@ -40,7 +40,7 @@ const Metrics = ({ chatflowId }: MetricsProps) => {
     const [endDate, setEndDate] = useState(new Date())
     const [_leadEmail, setLeadEmail] = useState('')
     const [selectedChat, setSelectedChat] = useState<ChatLog | null>(null)
-    const [_isFilterExpanded, setIsFilterExpanded] = useState(true) // Default expanded for metrics
+    const [isFilterExpanded, setIsFilterExpanded] = useState(true) // Default expanded for metrics
 
     // API hooks
     const {


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: isFilterExpanded is not defined` crash when clicking View Metrics on agent flows in Enterprise Admin
- One-line fix: rename `_isFilterExpanded` to `isFilterExpanded` in `metrics.tsx`

## Root Cause
State variable was destructured as `_isFilterExpanded` (underscore prefix, treated as unused) but referenced as `isFilterExpanded` throughout the component.

## Test plan
- [ ] Click View Metrics on any agent flow in Enterprise Admin — should open metrics panel without crash

Closes AGENT-678