### PR TITLE
fix(AGENT-654): Change marketplace AppBar position from fixed to relative

### DIFF
--- a/packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx
+++ b/packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx
@@ -65,7 +65,7 @@ const MarketplaceCanvas = () => {
             <Box>
                 <AppBar
                     enableColorOnDark
-                    position='fixed'
+                    position='relative'
                     color='inherit'
                     elevation={1}
                     sx={{


### PR DESCRIPTION
## Summary
- Fix back button hidden behind global navigation in marketplace template detail view

## Changes
- `packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx` — Changed AppBar `position='fixed'` to `position='relative'`
- Matches the working implementation in `packages/ui/src/views/agentflowsv2/MarketplaceCanvas.jsx` (fixed in PR #675 for v2 routes)

## Impact
- Fixes navigation on `/sidekick-studio/marketplace/{id}` and `/org/{domain}/marketplace/{id}` routes
- No breaking changes — aligns with existing v2 behavior

## Test plan
- [ ] Navigate to marketplace listing, click a non-agent template
- [ ] Verify back button (chevron) is visible and clickable in the top-left
- [ ] Verify "Use Template" button remains functional
- [ ] Verify canvas flow visualization renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)