### PR TITLE
fix(SUPPORT-19): handle googleDriveOAuth2 v2 token refresh and re-auth in GoogleDrivePicker

### DIFF
--- a/packages/components/nodes/documentloaders/GoogleDrive/GoogleDrive.ts
+++ b/packages/components/nodes/documentloaders/GoogleDrive/GoogleDrive.ts
@@ -60,7 +60,7 @@ class GoogleDrive_DocumentLoaders implements INode {
             name: 'credential',
             type: 'credential',
             description: 'Google Drive OAuth2 Credential',
-            credentialNames: ['googleDriveOAuth2', 'googleOAuth']
+            credentialNames: ['googleDriveOAuth2']
         }
         this.inputs = [
             {
@@ -205,7 +205,7 @@ class GoogleDrive_DocumentLoaders implements INode {
             try {
                 let credentialData = await getCredentialData(nodeData.credential ?? '', options)
                 credentialData = await refreshOAuth2Token(nodeData.credential ?? '', credentialData, options)
-                const accessToken = getCredentialParam('access_token', credentialData, nodeData) || credentialData.googleAccessToken
+                const accessToken = getCredentialParam('access_token', credentialData, nodeData)
 
                 if (!accessToken) {
                     return returnData

--- a/packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx
+++ b/packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx
@@ -3,9 +3,18 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { Button, List, ListItem, ListItemAvatar, ListItemText, Avatar, IconButton, Stack, Alert } from '@mui/material'
 import useApi from '@/hooks/useApi'
 import credentialsApi from '@/api/credentials'
+import oauth2Api from '@/api/oauth2'
 import { IconX, IconTrash } from '@tabler/icons-react'
 import { useDispatch } from 'react-redux'
 import { enqueueSnackbar as enqueueSnackbarAction, closeSnackbar as closeSnackbarAction } from '@/store/actions'
+
+// Extract token fields from credential data — handles both googleOAuth (v1) and googleDriveOAuth2 (v2)
+const getTokenFields = (plainDataObj) => {
+    const token = plainDataObj.googleAccessToken || plainDataObj.access_token || ''
+    const expiryStr = plainDataObj.expiresAt || plainDataObj.expires_at
+    const isV2 = !!plainDataObj.access_token && !plainDataObj.googleAccessToken
+    return { token, expiryStr, isV2 }
+}
 
 export const SUPPORTED_MIME_TYPES = [
     'application/vnd.google-apps.document',
@@ -176,6 +185,8 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
     const [accessToken, setAccessToken] = useState(null)
     const [isTokenExpired, setIsTokenExpired] = useState(false)
     const [isRefreshing, setIsRefreshing] = useState(false)
+    const [isV2Credential, setIsV2Credential] = useState(false)
+    const [isReauthRequired, setIsReauthRequired] = useState(false)
 
     const enqueueSnackbar = useCallback((...args) => dispatch(enqueueSnackbarAction(...args)), [dispatch])
     const closeSnackbar = useCallback((...args) => dispatch(closeSnackbarAction(...args)), [dispatch])
@@ -210,30 +221,30 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
             // Reset token state
             setAccessToken(null)
             setIsTokenExpired(false)
+            setIsV2Credential(false)
+            setIsReauthRequired(false)
         }
     }, [credentialId])
 
     // Handle credential data from prop
     useEffect(() => {
         if (credentialData?.plainDataObj) {
-            const expiresAt = new Date(credentialData.plainDataObj.expiresAt)
-            const now = new Date()
-            const isExpired = expiresAt < now
-
+            const { token, expiryStr, isV2 } = getTokenFields(credentialData.plainDataObj)
+            const isExpired = expiryStr ? new Date(expiryStr) < new Date() : false
+            setIsV2Credential(isV2)
             setIsTokenExpired(isExpired)
-            setAccessToken(credentialData.plainDataObj.googleAccessToken ?? '')
+            setAccessToken(token)
         }
     }, [credentialData])
 
     // Handle credential data from API
     useEffect(() => {
         if (getCredentialDataApi.data) {
-            const expiresAt = new Date(getCredentialDataApi.data?.plainDataObj.expiresAt)
-            const now = new Date()
-            const isExpired = expiresAt < now
-
+            const { token, expiryStr, isV2 } = getTokenFields(getCredentialDataApi.data?.plainDataObj)
+            const isExpired = expiryStr ? new Date(expiryStr) < new Date() : false
+            setIsV2Credential(isV2)
             setIsTokenExpired(isExpired)
-            setAccessToken(getCredentialDataApi.data?.plainDataObj.googleAccessToken ?? '')
+            setAccessToken(token)
             handleCredentialDataChange?.(getCredentialDataApi.data)
         }
     }, [getCredentialDataApi.data, handleCredentialDataChange])
@@ -301,35 +312,70 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
 
         try {
             setIsRefreshing(true)
-            // console.log('🔄 [FRONTEND] Iniciando refresh para credential:', credentialId)
 
-            // Obtener token actual antes del refresh
-            // const currentCred = await credentialsApi.getSpecificCredential(credentialId)
-            // const oldToken = currentCred?.data?.plainDataObj?.googleAccessToken?.substring(0, 20)
-            // console.log('🔄 [FRONTEND] Token actual:', oldToken + '...')
-
-            const response = await credentialsApi.refreshAccessToken({ credentialId })
-
-            if (response.status === 200) {
-                getCredentialDataApi.request(credentialId)
-
-                // Verificar que el token cambió
-                setTimeout(async () => {
-                    // const newCred = await credentialsApi.getSpecificCredential(credentialId)
-                    // const newToken = newCred?.data?.plainDataObj?.googleAccessToken?.substring(0, 20)
-                    // console.log('✅ [FRONTEND] Token nuevo:', newToken + '...')
-                    // console.log('🔍 [FRONTEND] ¿Token cambió?', oldToken !== newToken)
-                }, 1000)
-
-                setIsTokenExpired(false)
-                showSnackbar('Successfully refreshed access token', 'success')
+            if (isV2Credential) {
+                // googleDriveOAuth2 (v2) — use the generic OAuth2 refresh endpoint
+                await oauth2Api.refresh(credentialId)
+            } else {
+                // googleOAuth (v1) — use the legacy refresh endpoint
+                await credentialsApi.refreshAccessToken({ credentialId })
             }
+
+            getCredentialDataApi.request(credentialId)
+            setIsTokenExpired(false)
+            setIsReauthRequired(false)
+            showSnackbar('Successfully refreshed access token', 'success')
         } catch (error) {
-            console.error('❌ [FRONTEND] Error refreshing access token:', error)
-            const errorMessage = error.response?.data?.message || 'Error refreshing access token'
-            showSnackbar(errorMessage, 'error')
+            const status = error.response?.status
+            const errorMessage = error.response?.data?.message || error.message || 'Error refreshing access token'
+
+            if (status === 401 || errorMessage.includes('REAUTH_REQUIRED') || errorMessage.includes('re-authenticate')) {
+                // Refresh token is revoked — full re-auth needed via OAuth popup
+                setIsReauthRequired(true)
+                showSnackbar('Re-authentication required. Please click "Re-authenticate with Google".', 'warning')
+            } else {
+                showSnackbar(errorMessage, 'error')
+            }
         } finally {
             setIsRefreshing(false)
+        }
+    }, [credentialId, isV2Credential, getCredentialDataApi, showSnackbar])
+
+    const handleReauthenticate = useCallback(async () => {
+        if (!credentialId) return
+
+        try {
+            const authResponse = await oauth2Api.authorize(credentialId)
+
+            if (authResponse.data?.authorizationUrl) {
+                const authWindow = window.open(
+                    authResponse.data.authorizationUrl,
+                    '_blank',
+                    'width=600,height=700,scrollbars=yes,resizable=yes'
+                )
+
+                if (!authWindow) {
+                    showSnackbar('Popup blocked. Please allow popups for this site and try again.', 'error')
+                    return
+                }
+
+                const handleMessage = (event) => {
+                    if (event.data?.type === 'OAUTH2_SUCCESS') {
+                        window.removeEventListener('message', handleMessage)
+                        getCredentialDataApi.request(credentialId)
+                        setIsTokenExpired(false)
+                        setIsReauthRequired(false)
+                        showSnackbar('Successfully re-authenticated with Google', 'success')
+                    } else if (event.data?.type === 'OAUTH2_ERROR') {
+                        window.removeEventListener('message', handleMessage)
+                        showSnackbar(event.data.error || 'Re-authentication failed', 'error')
+                    }
+                }
+
+                window.addEventListener('message', handleMessage)
+            }
+        } catch (error) {
+            showSnackbar(error.response?.data?.message || 'Failed to start re-authentication', 'error')
         }
     }, [credentialId, getCredentialDataApi, showSnackbar])
 
@@ -359,7 +405,7 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
                     </Button>
                 )}
 
-                {isTokenExpired && (
+                {isTokenExpired && !isReauthRequired && (
                     <Button
                         variant='outlined'
                         onClick={handleRefreshAccessToken}
@@ -374,11 +420,23 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
                         {isRefreshing ? 'Refreshing...' : 'Refresh Access Token'}
                     </Button>
                 )}
+
+                {isReauthRequired && (
+                    <Button variant='outlined' color='warning' onClick={handleReauthenticate} disabled={!credentialId}>
+                        Re-authenticate with Google
+                    </Button>
+                )}
             </Stack>
 
-            {isTokenExpired && (
+            {isTokenExpired && !isReauthRequired && (
                 <Alert severity='warning' sx={{ mb: 1 }}>
-                    Access token has expired. Please re-authenticate or refresh the access token.
+                    Access token has expired. Click &quot;Refresh Access Token&quot; to renew it.
+                </Alert>
+            )}
+
+            {isReauthRequired && (
+                <Alert severity='error' sx={{ mb: 1 }}>
+                    Google authorization has expired or been revoked. Click &quot;Re-authenticate with Google&quot; to reconnect.
                 </Alert>
             )}
 

--- a/packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx
+++ b/packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx
@@ -8,14 +8,6 @@ import { IconX, IconTrash } from '@tabler/icons-react'
 import { useDispatch } from 'react-redux'
 import { enqueueSnackbar as enqueueSnackbarAction, closeSnackbar as closeSnackbarAction } from '@/store/actions'
 
-// Extract token fields from credential data — handles both googleOAuth (v1) and googleDriveOAuth2 (v2)
-const getTokenFields = (plainDataObj) => {
-    const token = plainDataObj.googleAccessToken || plainDataObj.access_token || ''
-    const expiryStr = plainDataObj.expiresAt || plainDataObj.expires_at
-    const isV2 = !!plainDataObj.access_token && !plainDataObj.googleAccessToken
-    return { token, expiryStr, isV2 }
-}
-
 export const SUPPORTED_MIME_TYPES = [
     'application/vnd.google-apps.document',
     'application/vnd.google-apps.spreadsheet',
@@ -185,7 +177,6 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
     const [accessToken, setAccessToken] = useState(null)
     const [isTokenExpired, setIsTokenExpired] = useState(false)
     const [isRefreshing, setIsRefreshing] = useState(false)
-    const [isV2Credential, setIsV2Credential] = useState(false)
     const [isReauthRequired, setIsReauthRequired] = useState(false)
 
     const enqueueSnackbar = useCallback((...args) => dispatch(enqueueSnackbarAction(...args)), [dispatch])
@@ -221,7 +212,6 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
             // Reset token state
             setAccessToken(null)
             setIsTokenExpired(false)
-            setIsV2Credential(false)
             setIsReauthRequired(false)
         }
     }, [credentialId])
@@ -229,22 +219,20 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
     // Handle credential data from prop
     useEffect(() => {
         if (credentialData?.plainDataObj) {
-            const { token, expiryStr, isV2 } = getTokenFields(credentialData.plainDataObj)
-            const isExpired = expiryStr ? new Date(expiryStr) < new Date() : false
-            setIsV2Credential(isV2)
+            const { access_token, expires_at } = credentialData.plainDataObj
+            const isExpired = expires_at ? new Date(expires_at) < new Date() : false
             setIsTokenExpired(isExpired)
-            setAccessToken(token)
+            setAccessToken(access_token ?? '')
         }
     }, [credentialData])
 
     // Handle credential data from API
     useEffect(() => {
         if (getCredentialDataApi.data) {
-            const { token, expiryStr, isV2 } = getTokenFields(getCredentialDataApi.data?.plainDataObj)
-            const isExpired = expiryStr ? new Date(expiryStr) < new Date() : false
-            setIsV2Credential(isV2)
+            const { access_token, expires_at } = getCredentialDataApi.data?.plainDataObj
+            const isExpired = expires_at ? new Date(expires_at) < new Date() : false
             setIsTokenExpired(isExpired)
-            setAccessToken(token)
+            setAccessToken(access_token ?? '')
             handleCredentialDataChange?.(getCredentialDataApi.data)
         }
     }, [getCredentialDataApi.data, handleCredentialDataChange])
@@ -312,15 +300,7 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
 
         try {
             setIsRefreshing(true)
-
-            if (isV2Credential) {
-                // googleDriveOAuth2 (v2) — use the generic OAuth2 refresh endpoint
-                await oauth2Api.refresh(credentialId)
-            } else {
-                // googleOAuth (v1) — use the legacy refresh endpoint
-                await credentialsApi.refreshAccessToken({ credentialId })
-            }
-
+            await oauth2Api.refresh(credentialId)
             getCredentialDataApi.request(credentialId)
             setIsTokenExpired(false)
             setIsReauthRequired(false)
@@ -330,7 +310,6 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
             const errorMessage = error.response?.data?.message || error.message || 'Error refreshing access token'
 
             if (status === 401 || errorMessage.includes('REAUTH_REQUIRED') || errorMessage.includes('re-authenticate')) {
-                // Refresh token is revoked — full re-auth needed via OAuth popup
                 setIsReauthRequired(true)
                 showSnackbar('Re-authentication required. Please click "Re-authenticate with Google".', 'warning')
             } else {
@@ -339,7 +318,7 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
         } finally {
             setIsRefreshing(false)
         }
-    }, [credentialId, isV2Credential, getCredentialDataApi, showSnackbar])
+    }, [credentialId, getCredentialDataApi, showSnackbar])
 
     const handleReauthenticate = useCallback(async () => {
         if (!credentialId) return


### PR DESCRIPTION
## Summary

- Fixes Google Drive credential re-authentication for v2 (`googleDriveOAuth2`) credentials in `GoogleDrivePicker`
- Added `getTokenFields()` helper to detect credential version and read the correct token fields (`access_token`/`expires_at` for v2 vs `googleAccessToken`/`expiresAt` for v1)
- Routes refresh calls to the correct endpoint: `/oauth2-credential/refresh/:id` for v2 and `/credentials/refresh-token` for v1
- Catches 401/`REAUTH_REQUIRED` errors and shows a "Re-authenticate with Google" button that triggers the OAuth2 popup flow instead of redirecting to Auth0 login

## Problem

The GoogleDrivePicker component only handled v1 (`googleOAuth`) credential fields. When users had v2 (`googleDriveOAuth2`) credentials, the "Refresh Access Token" button called the wrong endpoint, received a 401, and redirected users to the Auth0 login page instead of re-authenticating with Google.

## Changes

- `packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx`: Add credential version detection, route to correct refresh endpoint, and surface re-authentication UI on auth failure

## Test Plan

- [ ] Verify Google Drive picker loads correctly with v1 (`googleOAuth`) credentials
- [ ] Verify Google Drive picker loads correctly with v2 (`googleDriveOAuth2`) credentials
- [ ] Verify "Refresh Access Token" works for v1 credentials
- [ ] Verify "Refresh Access Token" works for v2 credentials
- [ ] Verify expired/invalid v2 credentials show "Re-authenticate with Google" button
- [ ] Verify OAuth2 popup flow completes re-authentication without redirecting to Auth0