### PR TITLE
fix(SUPPORT-19): address GoogleDrivePicker code review issues

### DIFF
--- a/packages/components/nodes/documentloaders/GoogleDrive/GoogleDrive.ts
+++ b/packages/components/nodes/documentloaders/GoogleDrive/GoogleDrive.ts
@@ -297,7 +297,7 @@ class GoogleDrive_DocumentLoaders implements INode {
 
         let credentialData = await getCredentialData(nodeData.credential ?? '', options)
         credentialData = await refreshOAuth2Token(nodeData.credential ?? '', credentialData, options)
-        const accessToken = getCredentialParam('access_token', credentialData, nodeData) || credentialData.googleAccessToken
+        const accessToken = getCredentialParam('access_token', credentialData, nodeData)
 
         if (!accessToken) {
             throw new Error('No access token found in credential')

--- a/packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx
+++ b/packages/ui/src/ui-component/drive/GoogleDrivePicker.jsx
@@ -178,6 +178,7 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
     const [isTokenExpired, setIsTokenExpired] = useState(false)
     const [isRefreshing, setIsRefreshing] = useState(false)
     const [isReauthRequired, setIsReauthRequired] = useState(false)
+    const [isReauthenticating, setIsReauthenticating] = useState(false)
 
     const enqueueSnackbar = useCallback((...args) => dispatch(enqueueSnackbarAction(...args)), [dispatch])
     const closeSnackbar = useCallback((...args) => dispatch(closeSnackbarAction(...args)), [dispatch])
@@ -223,6 +224,7 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
             const isExpired = expires_at ? new Date(expires_at) < new Date() : false
             setIsTokenExpired(isExpired)
             setAccessToken(access_token ?? '')
+            if (!isExpired) setIsReauthRequired(false)
         }
     }, [credentialData])
 
@@ -233,6 +235,7 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
             const isExpired = expires_at ? new Date(expires_at) < new Date() : false
             setIsTokenExpired(isExpired)
             setAccessToken(access_token ?? '')
+            if (!isExpired) setIsReauthRequired(false)
             handleCredentialDataChange?.(getCredentialDataApi.data)
         }
     }, [getCredentialDataApi.data, handleCredentialDataChange])
@@ -324,6 +327,7 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
         if (!credentialId) return
 
         try {
+            setIsReauthenticating(true)
             const authResponse = await oauth2Api.authorize(credentialId)
 
             if (authResponse.data?.authorizationUrl) {
@@ -335,25 +339,45 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
 
                 if (!authWindow) {
                     showSnackbar('Popup blocked. Please allow popups for this site and try again.', 'error')
+                    setIsReauthenticating(false)
                     return
                 }
 
-                const handleMessage = (event) => {
+                const trustedOrigin = window.location.origin
+                let messageListener = null
+                let closedPoller = null
+
+                const cleanup = () => {
+                    if (messageListener) window.removeEventListener('message', messageListener)
+                    if (closedPoller) clearInterval(closedPoller)
+                    setIsReauthenticating(false)
+                }
+
+                messageListener = (event) => {
+                    if (event.origin !== trustedOrigin) return
                     if (event.data?.type === 'OAUTH2_SUCCESS') {
-                        window.removeEventListener('message', handleMessage)
+                        cleanup()
                         getCredentialDataApi.request(credentialId)
                         setIsTokenExpired(false)
                         setIsReauthRequired(false)
                         showSnackbar('Successfully re-authenticated with Google', 'success')
                     } else if (event.data?.type === 'OAUTH2_ERROR') {
-                        window.removeEventListener('message', handleMessage)
+                        cleanup()
                         showSnackbar(event.data.error || 'Re-authentication failed', 'error')
                     }
                 }
 
-                window.addEventListener('message', handleMessage)
+                // Detect popup closed by user without completing auth
+                closedPoller = setInterval(() => {
+                    if (authWindow.closed) cleanup()
+                }, 500)
+
+                window.addEventListener('message', messageListener)
+            } else {
+                setIsReauthenticating(false)
             }
         } catch (error) {
+            setIsReauthenticating(false)
             showSnackbar(error.response?.data?.message || 'Failed to start re-authentication', 'error')
         }
     }, [credentialId, getCredentialDataApi, showSnackbar])
@@ -401,8 +425,13 @@ export const GoogleDrivePicker = ({ onChange, value, disabled, credentialId, cre
                 )}
 
                 {isReauthRequired && (
-                    <Button variant='outlined' color='warning' onClick={handleReauthenticate} disabled={!credentialId}>
-                        Re-authenticate with Google
+                    <Button
+                        variant='outlined'
+                        color='warning'
+                        onClick={handleReauthenticate}
+                        disabled={!credentialId || isReauthenticating}
+                    >
+                        {isReauthenticating ? 'Opening Google sign-in...' : 'Re-authenticate with Google'}
                     </Button>
                 )}
             </Stack>


### PR DESCRIPTION
## Summary

Follow-up to #963 addressing all code review issues:

- **Critical**: Validate `event.origin` against `window.location.origin` in `handleMessage` to prevent cross-origin message spoofing
- **Critical**: Add `setInterval` popup close detection to clean up the `message` event listener when user dismisses the OAuth popup without completing auth
- **Major**: Remove remaining `|| credentialData.googleAccessToken` v1 fallback from `GoogleDrive.ts init()` (was missed in previous migration commit)
- **Major**: Add `isReauthenticating` loading state — button shows "Opening Google sign-in..." while popup is open
- **Major**: Reset `isReauthRequired` in both credential data `useEffect` handlers when a fresh (non-expired) token is detected

## Test plan

- [ ] Expired v2 credential: "Refresh Access Token" button calls `/oauth2-credential/refresh/:id` and reloads credential
- [ ] Fully revoked token: refresh fails → "Re-authenticate with Google" button appears
- [ ] Re-authenticate flow: button shows loading state, popup opens, closes on success/error/dismiss
- [ ] After successful re-auth: `isReauthRequired` clears, picker becomes available
- [ ] Closing popup without auth: listener cleaned up, button re-enabled