### PR TITLE
docs: add OpenCode bootstrap context validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,18 @@
 # AGENTS.md - TheAnswer Codebase Guide
 
+## Index
+
+| Key | Purpose |
+|-----|---------|
+| `CLAUDE.md` | Root workflow, safety requirements, daily commands |
+| `packages/components/CLAUDE.md` | Flowise node/component patterns |
+| `packages/server/CLAUDE.md` | API/controller/service/entity patterns |
+| `apps/web/CLAUDE.md` | Next.js, Auth0, frontend patterns |
+| `.claude/commands/*.md` | Slash commands (`/ticket-start`, `/push`, etc.) |
+| `.claude/agents/*.md` | Specialized agents (Linear, Git, Fleet) |
+| `.claude/skills/*.md` | Reusable workflows and guardrails |
+| `.claude/rules/*.md` | Path-based coding constraints |
+
 ## Overview
 
 TheAnswer is a comprehensive AI-powered productivity suite built on top of Flowise, an open-source tool for creating customized LLM flows. This codebase extends Flowise's capabilities with additional services, UI components, and enterprise features.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://opencode.ai/config.json",
+    "instructions": [
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".claude/README.md",
+        ".claude/ARCHITECTURE.md",
+        ".claude/commands/*.md",
+        ".claude/agents/*.md",
+        ".claude/skills/*.md",
+        ".claude/rules/*.md"
+    ]
+}


### PR DESCRIPTION
## Summary
- add an OpenCode parity bootstrap section to `AGENTS.md` so Claude workflow docs/config are treated as first-class context
- add `.opencode/README.md` documenting required config/docs directories and instruction precedence
- add `scripts/validate-opencode-bootstrap.js` plus `pnpm opencode:validate-context` to verify required bootstrap files/directories are present