### PR TITLE
fix: restore credential when editing document store loader (AGENT-710)

### DIFF
--- a/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
+++ b/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
@@ -312,6 +312,13 @@ const LoaderConfigPreviewChunks = () => {
                 nodeData.inputs = existingLoaderFromDocStoreTable.loaderConfig
                 setLoaderName(existingLoaderFromDocStoreTable.loaderName)
             }
+            // Restore credential from the separate credential field (fixes AGENT-710:
+            // credential-gated loaders failing on process/preview despite being authorized)
+            if (existingLoaderFromDocStoreTable?.credential) {
+                nodeData.credential = existingLoaderFromDocStoreTable.credential
+                if (!nodeData.inputs) nodeData.inputs = {}
+                nodeData.inputs['FLOWISE_CREDENTIAL_ID'] = existingLoaderFromDocStoreTable.credential
+            }
             setSelectedDocumentLoader(nodeData)
 
             // Check if the loader has a text splitter, if yes, get the text splitter nodes

--- a/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
+++ b/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
@@ -30,7 +30,7 @@ import documentStoreApi from '@/api/documentstore'
 import documentsApi from '@/api/documentstore'
 
 // Const
-import { baseURL, gridSpacing } from '@/store/constant'
+import { baseURL, gridSpacing, FLOWISE_CREDENTIAL_ID } from '@/store/constant'
 import { closeSnackbar as closeSnackbarAction, enqueueSnackbar as enqueueSnackbarAction } from '@/store/actions'
 import { useError } from '@/store/context/ErrorContext'
 
@@ -145,7 +145,7 @@ const LoaderConfigPreviewChunks = () => {
                 if (
                     inputParam.type === 'credential' &&
                     !selectedDocumentLoader.credential &&
-                    !selectedDocumentLoader.inputs['FLOWISE_CREDENTIAL_ID']
+                    !selectedDocumentLoader.inputs[FLOWISE_CREDENTIAL_ID]
                 ) {
                     canSubmit = false
                     missingFields.push(inputParam.label || inputParam.name)
@@ -312,12 +312,17 @@ const LoaderConfigPreviewChunks = () => {
                 nodeData.inputs = existingLoaderFromDocStoreTable.loaderConfig
                 setLoaderName(existingLoaderFromDocStoreTable.loaderName)
             }
-            // Restore credential from the separate credential field (fixes AGENT-710:
-            // credential-gated loaders failing on process/preview despite being authorized)
+            // Restore credential from the separate `credential` field on the loader entity.
+            // This block intentionally runs outside the loaderConfig guard above because
+            // `loader.credential` is persisted as its own DB column — independent of
+            // loaderConfig — and may be the *only* place the credential ID is stored for
+            // loaders created before FLOWISE_CREDENTIAL_ID was written into inputs.
+            // Without this, checkMandatoryFields and prepareConfig both miss the credential,
+            // causing a false "Connect Credential" validation error on process/preview.
             if (existingLoaderFromDocStoreTable?.credential) {
                 nodeData.credential = existingLoaderFromDocStoreTable.credential
                 if (!nodeData.inputs) nodeData.inputs = {}
-                nodeData.inputs['FLOWISE_CREDENTIAL_ID'] = existingLoaderFromDocStoreTable.credential
+                nodeData.inputs[FLOWISE_CREDENTIAL_ID] = existingLoaderFromDocStoreTable.credential
             }
             setSelectedDocumentLoader(nodeData)
 


### PR DESCRIPTION
## Summary

Fixes AGENT-710 — Google Drive and Google Sheets document loaders show \"Connect Credential\" error on Process/Preview Chunks despite credentials being assigned.

## Root Cause

In \`LoaderConfigPreviewChunks.jsx\`, when loading an existing loader for editing, the code restored \`nodeData.inputs\` from \`loaderConfig\` but never restored \`nodeData.credential\` from \`existingLoaderFromDocStoreTable.credential\`.

This caused:
1. **Validation failure** — for loaders where credential was only in \`loader.credential\` (separate DB field), \`checkMandatoryFields\` would fail with \"Connect Credential\" missing
2. **Missing credential in request** — \`prepareConfig()\` only sends \`config.credential\` when \`selectedDocumentLoader.credential\` is set, so server never received it

## Fix

Restore credential from \`existingLoaderFromDocStoreTable.credential\` into both \`nodeData.credential\` and \`nodeData.inputs['FLOWISE_CREDENTIAL_ID']\` when loading an existing loader.

## Files

- \`packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx\`