### PR TITLE
fix: add drive scope to googleSheetsOAuth2 credential

### DIFF
--- a/packages/components/credentials/GoogleSheetsOAuth2.credential.ts
+++ b/packages/components/credentials/GoogleSheetsOAuth2.credential.ts
@@ -1,5 +1,6 @@
 import { INodeParams, INodeCredential } from '../src/Interface'
 const scopes = [
+    'https://www.googleapis.com/auth/drive',
     'https://www.googleapis.com/auth/drive.file',
     'https://www.googleapis.com/auth/spreadsheets',
     'https://www.googleapis.com/auth/drive.metadata'


### PR DESCRIPTION
## Summary

- Adds `https://www.googleapis.com/auth/drive` scope to `googleSheetsOAuth2` credential
- Aligns with `googleDocsOAuth2` which already has this scope
- Fixes empty spreadsheet dropdown in Google Sheets document loader (`listSpreadsheets` uses Drive API to list files)

## Root Cause

`drive.file` scope (previously only Drive scope in Sheets cred) only allows listing files the app explicitly opened — not all spreadsheets in Drive. `googleDocsOAuth2` already had the broader `drive` scope, so Docs worked correctly while Sheets did not.

## Impact

Users need to re-authorize their `googleSheetsOAuth2` credential to receive the new scope. After re-auth, the spreadsheet dropdown will populate correctly.