### PR TITLE
fix(agents): handle .text field in agent output extraction (KUMELLO-22)

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -2234,9 +2234,28 @@ export const executeAgentFlow = async ({
     logger.debug(`\n🏁 Flow execution completed`)
     logger.debug(`   Status: ${status}`)
 
-    // check if last agentFlowExecutedData.data.output contains the key "content"
-    const lastNodeOutput = agentFlowExecutedData[agentFlowExecutedData.length - 1].data?.output as ICommonObject | undefined
-    const content = (lastNodeOutput?.content as string) ?? ' '
+    // Extract final output — agent outputs vary: string, {text:...}, {content:...}, {json:...}
+    const lastNodeOutput = agentFlowExecutedData.length > 0
+        ? agentFlowExecutedData[agentFlowExecutedData.length - 1].data?.output as ICommonObject | undefined
+        : undefined
+
+    let content: string
+    if (typeof lastNodeOutput === 'string') {
+        content = lastNodeOutput
+    } else if (lastNodeOutput && typeof lastNodeOutput === 'object') {
+        const outputObj = lastNodeOutput as ICommonObject
+        if (typeof outputObj.text === 'string') {
+            content = outputObj.text
+        } else if (typeof outputObj.content === 'string') {
+            content = outputObj.content
+        } else if (outputObj.json !== undefined) {
+            content = typeof outputObj.json === 'string' ? outputObj.json : JSON.stringify(outputObj.json)
+        } else {
+            content = JSON.stringify(outputObj)
+        }
+    } else {
+        content = ''
+    }
 
     // remove credentialId from agentFlowExecutedData
     agentFlowExecutedData = agentFlowExecutedData.map((data) => _removeCredentialId(data))


### PR DESCRIPTION
## Summary

Fixes KUMELLO-22 — AI agents producing empty responses despite successfully generating output.

## Root Cause

`buildAgentflow.ts:2239` extracted the final agent output by reading `.content`, but `ToolAgent` and `AAIToolAgent` write their output to `.text`:

```typescript
// BEFORE — always undefined for ToolAgent output
const content = (lastNodeOutput?.content as string) ?? ' '
```

`ToolAgent` returns `{ text: output, usedTools: [...] }`. The `.content` key doesn't exist → `??` fell through to a space `' '` → users saw a blank response.

## What Changed

**File:** `packages/server/src/utils/buildAgentflow.ts` (+22 / -3 lines at line 2237)

Replaced the single-field lookup with a multi-format extractor that handles every output shape agents can produce:

```typescript
// AFTER — handles all agent output formats
const lastNodeOutput = agentFlowExecutedData.length > 0
    ? agentFlowExecutedData[agentFlowExecutedData.length - 1].data?.output
    : undefined

let content: string
if (typeof lastNodeOutput === 'string') {
    content = lastNodeOutput                          // direct string output
} else if (lastNodeOutput && typeof lastNodeOutput === 'object') {
    const outputObj = lastNodeOutput as ICommonObject
    if (typeof outputObj.text === 'string') {
        content = outputObj.text                      // ToolAgent: {text, usedTools}
    } else if (typeof outputObj.content === 'string') {
        content = outputObj.content                   // legacy backward compat
    } else if (outputObj.json !== undefined) {
        content = typeof outputObj.json === 'string'  // AAIToolAgent structured output
            ? outputObj.json
            : JSON.stringify(outputObj.json)
    } else {
        content = JSON.stringify(outputObj)
    }
} else {
    content = ''
}
```

**Priority chain:** `string` → `{text}` → `{content}` → `{json}` → stringify → `''`

## Agent output formats covered

| Agent | Output shape | Extracted via |
|-------|-------------|---------------|
| `ToolAgent` (no tools used) | `"string"` or `{ text: string }` | `typeof === 'string'` / `.text` |
| `ToolAgent` (tools used) | `{ text: string, usedTools: [...] }` | `.text` |
| `AAIToolAgent` (parsed output) | `{ json: object, ...metadata }` | `JSON.stringify(.json)` |
| `AAIToolAgent` (text output) | `{ text: string, ...metadata }` | `.text` |
| Legacy / unknown | `{ content: string }` | `.content` |

## Behaviour changes

- **Fallback changed** from `' '` (space) to `''` (empty string). Downstream effect: TTS at line 2388 no longer fires for agents that genuinely return nothing — this is correct behaviour.
- **Empty flow guard added** — `agentFlowExecutedData.length > 0` check before array access prevents a crash if the flow array is somehow empty.

## What was NOT changed

- Line 412 (variable resolution has the same `.content`-only pattern — separate ticket)
- No new imports, interfaces, or test files added
- All downstream consumers of `content` (lines 2264, 2272, ~2335, 2388) are unaffected — `let content: string` covers all paths

## Verification

- ✅ `pnpm --filter flowise build` — TypeScript compiles clean, exit 0
- ✅ LSP diagnostics — zero errors on changed file
- ✅ Oracle compliance audit — all Must Have / Must NOT Have requirements verified
- ✅ Code quality review — no `as any`, no `@ts-ignore`, clean type narrowing
- ✅ Scope fidelity — only `buildAgentflow.ts` changed, diff confined to lines 2237-2258
