### PR TITLE
Fix cross-workspace chatflow access

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -73,11 +73,16 @@ const getAllChatflows = async (req: Request, res: Response, next: NextFunction) 
     try {
         const { page, limit } = getPageAndLimitParams(req)
 
+        const assignedWorkspaces = (req.user as any)?.assignedWorkspaces as Array<{ id: string }> | undefined
+        const workspaceIds = assignedWorkspaces && assignedWorkspaces.length > 0 ? assignedWorkspaces.map((ws) => ws.id) : undefined
+        const workspaceId = workspaceIds ? undefined : req.user?.activeWorkspaceId
+
         const apiResponse = await chatflowsService.getAllChatflows(
             req.query?.type as ChatflowType,
-            req.user?.activeWorkspaceId,
+            workspaceId,
             page,
-            limit
+            limit,
+            workspaceIds
         )
         return res.json(apiResponse)
     } catch (error) {

--- a/packages/server/src/controllers/internal-predictions/index.ts
+++ b/packages/server/src/controllers/internal-predictions/index.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express'
+import type { NextFunction, Request, Response } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 import { getErrorMessage } from '../../errors/utils'
@@ -10,10 +10,17 @@ import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
 // Send input message and get prediction result (Internal)
 const createInternalPrediction = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const workspaceId = req.user?.activeWorkspaceId
-
-        const chatflow = await chatflowService.getChatflowById(req.params.id, workspaceId)
+        const chatflow = await chatflowService.getChatflowById(req.params.id)
         if (!chatflow) {
+            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${req.params.id} not found`)
+        }
+
+        const assignedWorkspaces =
+            (req.user as { assignedWorkspaces?: Array<{ id: string }> } | undefined)?.assignedWorkspaces || []
+        const hasWorkspaceAccess = chatflow.workspaceId
+            ? assignedWorkspaces.some((ws: { id: string }) => ws.id === chatflow.workspaceId)
+            : false
+        if (!hasWorkspaceAccess) {
             throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${req.params.id} not found`)
         }
 

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -144,7 +144,13 @@ const deleteChatflow = async (chatflowId: string, orgId: string, workspaceId: st
     }
 }
 
-const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: number = -1, limit: number = -1) => {
+const getAllChatflows = async (
+    type?: ChatflowType,
+    workspaceId?: string,
+    page: number = -1,
+    limit: number = -1,
+    workspaceIds?: string[]
+) => {
     try {
         const appServer = getRunningExpressApp()
 
@@ -166,7 +172,11 @@ const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: 
             // fetch all chatflows that are not agentflow
             queryBuilder.andWhere('chat_flow.type = :type', { type: 'CHATFLOW' })
         }
-        if (workspaceId) queryBuilder.andWhere('chat_flow.workspaceId = :workspaceId', { workspaceId })
+        if (workspaceIds && workspaceIds.length > 0) {
+            queryBuilder.andWhere('chat_flow.workspaceId IN (:...workspaceIds)', { workspaceIds })
+        } else if (workspaceId) {
+            queryBuilder.andWhere('chat_flow.workspaceId = :workspaceId', { workspaceId })
+        }
         const [data, total] = await queryBuilder.getManyAndCount()
         if (page > 0 && limit > 0) {
             return { data, total }


### PR DESCRIPTION
## Summary
- allow internal predictions to access chatflows across assigned workspaces by removing active workspace filtering
- enforce workspace membership checks before internal predictions execute
- list chatflows across all assigned workspaces via IN query in getAllChatflows

## Testing
- not run (local build fails on Node v24/gulp ESM mismatch)