### PR TITLE
fix(document-store): inject req.user into refresh body (AGENT-714)

### DIFF
--- a/packages/server/src/controllers/documentstore/index.ts
+++ b/packages/server/src/controllers/documentstore/index.ts
@@ -712,7 +712,8 @@ const refreshDocStoreMiddleware = async (req: Request, res: Response, next: Next
             )
         }
         const subscriptionId = req.user?.activeOrganizationSubscriptionId || ''
-        const body = req.body
+        const body = req.body || {}
+        body.user = req.user
         const apiResponse = await documentStoreService.refreshDocStoreMiddleware(
             req.params.id,
             body,


### PR DESCRIPTION
## Summary
- Fixes AGENT-714: Refresh button on document stores throws `Cannot read properties of undefined (reading 'user')`
- Root cause: controller passed `req.body` (undefined for empty POST) to service; service accessed `data.user` on undefined
- Fix: initialize body as `{}` and inject `req.user` before passing to service layer

## Changes
- `packages/server/src/controllers/documentstore/index.ts`: 2-line fix in `refreshDocStoreMiddleware`

## Testing
- TypeScript build passes
- Refresh endpoint returns 200 (was 500 TypeError)
- Affects all document stores on Moonstruck and any other instance

Linear: AGENT-714