### PR TITLE
fix(documentstore): batch bulk chunk deletes to prevent PostgreSQL parameter overflow

### DIFF
--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -60,6 +60,7 @@ import nodesService from '../nodes'
 // Batch sizes for chunk DB operations and vector store upsert
 const SAVE_BATCH_SIZE = 500
 const UPSERT_BATCH_SIZE = 500
+const DELETE_BATCH_SIZE = 1000
 
 const createDocumentStore = async (newDocumentStore: DocumentStore, orgId: string) => {
     try {
@@ -496,7 +497,9 @@ const syncAndRefreshChunks = async (storeId: string, fileId: string, userId: str
         if (!saveFailed) {
             // Delete old chunks only after all new chunks are confirmed saved
             if (existingChunkIds.length > 0) {
-                await chunkRepository.delete({ id: In(existingChunkIds) })
+                for (let i = 0; i < existingChunkIds.length; i += DELETE_BATCH_SIZE) {
+                    await chunkRepository.delete({ id: In(existingChunkIds.slice(i, i + DELETE_BATCH_SIZE)) })
+                }
             }
             loader.totalChunks = persistedChunks
             loader.totalChars = persistedChars
@@ -1332,7 +1335,9 @@ const _saveChunksToStorage = async (
             if (!saveFailed) {
                 //step 8: delete old chunks only after all new chunks are confirmed saved
                 if (existingChunkIds.length > 0) {
-                    await chunkRepository.delete({ id: In(existingChunkIds) })
+                    for (let i = 0; i < existingChunkIds.length; i += DELETE_BATCH_SIZE) {
+                        await chunkRepository.delete({ id: In(existingChunkIds.slice(i, i + DELETE_BATCH_SIZE)) })
+                    }
                 }
                 loader.totalChunks = persistedChunks
                 loader.totalChars = persistedChars


### PR DESCRIPTION
## Summary

- **Batch bulk DELETE operations** on `document_store_file_chunk` to prevent PostgreSQL wire protocol parameter overflow
- Adds `DELETE_BATCH_SIZE = 1000` constant and applies batching loop to 2 unbatched delete calls

## Problem

When processing documents with 13,000+ chunks, the `DELETE FROM "document_store_file_chunk" WHERE "id" IN ($1, $2, ..., $13879)` query fails with:

```
error: bind message has 3325 parameter formats but 0 parameters
```

TypeORM's `In([...ids])` expands every ID as a separate `$N` bind parameter. With 13,000+ IDs, the PostgreSQL `pg` driver desynchronizes the bind message, causing a parameter format/count mismatch.

## Root Cause

Two calls to `chunkRepository.delete({ id: In(existingChunkIds) })` pass the full array without chunking:

- **Line 499** — `syncAndRefreshChunks()` (refresh/sync path)
- **Line 1335** — `_saveChunksToStorage()` (save/process path)

## Fix

Added `DELETE_BATCH_SIZE = 1000` and wrapped both deletes in a batching loop:

```typescript
// Before (crashes with 13k+ chunks):
await chunkRepository.delete({ id: In(existingChunkIds) })

// After (max 1,000 params per query):
for (let i = 0; i < existingChunkIds.length; i += DELETE_BATCH_SIZE) {
    await chunkRepository.delete({ id: In(existingChunkIds.slice(i, i + DELETE_BATCH_SIZE)) })
}
```

## What's preserved

- Safe-delete timing: new chunks saved first, old chunks deleted after ✅
- `existingChunkIds` pre-capture before save (only deletes pre-existing chunks) ✅
- Memory GC optimization from PR #1017 ✅
- All other logic untouched ✅

## Verification

```bash
grep -c "In(existingChunkIds)" index.ts    # 0 (no unbatched calls)
grep -c "In(existingChunkIds.slice" index.ts  # 2 (both batched)
grep -c "DELETE_BATCH_SIZE" index.ts       # 5 (1 def + 4 usages)
```