### PR TITLE
fix(langfuse): enrich agentflow trace metadata, tags, and cost tracking

### DIFF
--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -715,7 +715,12 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                         metadata: metadata,
                         userId: options?.user?.id,
                         sessionId: options.sessionId,
-                        tags: [`Name:${chatflow.name}`],
+                        tags: [
+                            `Name:${chatflow.name}`,
+                            `chatflow_id:${options.chatflowid}`,
+                            `chat_id:${options.chatId}`,
+                            ...(options.messageId ? [`chatmessage_id:${options.messageId}`] : [])
+                        ],
                         version: chatflow.updatedDate
                         // TODO: This is still causing an error
                         // This works to keep the root trace name and have everything else update on the root trace
@@ -731,7 +736,12 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                         try {
                             if (parentLangfuseTrace) {
                                 parentLangfuseTrace.update({
-                                    tags: [`Name:${chatflow.name}`],
+                                    tags: [
+                                        `Name:${chatflow.name}`,
+                                        `chatflow_id:${options.chatflowid}`,
+                                        `chat_id:${options.chatId}`,
+                                        ...(options.messageId ? [`chatmessage_id:${options.messageId}`] : [])
+                                    ],
                                     metadata,
                                     userId: options?.user?.id,
                                     sessionId: options.sessionId,
@@ -1193,18 +1203,50 @@ export class AnalyticHandler {
                         // If fetching parent fails, create a new trace
                         console.warn(`Failed to fetch parent Langfuse trace ${parentLangfuseTraceId}, creating new trace:`, error)
                         langfuseTraceClient = langfuse.trace({
-                            name,
+                            name: this.options.chatflowName || name,
                             sessionId: this.options.chatId,
-                            metadata: { tags: ['openai-assistant'] },
+                            userId: this.options.user?.id,
+                            metadata: {
+                                chatflowid: this.options.chatflowid || this.options.chatflowId,
+                                chatflowName: this.options.chatflowName,
+                                chatId: this.options.chatId,
+                                userId: this.options.user?.id,
+                                organizationId: this.options.user?.organizationId,
+                                messageId: this.options.messageId,
+                                sessionId: this.options.sessionId || this.options.chatId,
+                                stripeCustomerId: this.options.billingStripeCustomerId || this.options.user?.stripeCustomerId
+                            },
+                            tags: [
+                                ...(this.options.chatflowName ? [`Name:${this.options.chatflowName}`] : []),
+                                ...(this.options.chatflowid ? [`chatflow_id:${this.options.chatflowid}`] : []),
+                                ...(this.options.chatId ? [`chat_id:${this.options.chatId}`] : []),
+                                ...(this.options.messageId ? [`chatmessage_id:${this.options.messageId}`] : [])
+                            ].filter(Boolean),
                             ...this.nodeData?.inputs?.analytics?.langFuse
                         })
                     }
                 } else {
                     // No parent trace context, create a new independent trace
                     langfuseTraceClient = langfuse.trace({
-                        name,
+                        name: this.options.chatflowName || name,
                         sessionId: this.options.chatId,
-                        metadata: { tags: ['openai-assistant'] },
+                        userId: this.options.user?.id,
+                        metadata: {
+                            chatflowid: this.options.chatflowid || this.options.chatflowId,
+                            chatflowName: this.options.chatflowName,
+                            chatId: this.options.chatId,
+                            userId: this.options.user?.id,
+                            organizationId: this.options.user?.organizationId,
+                            messageId: this.options.messageId,
+                            sessionId: this.options.sessionId || this.options.chatId,
+                            stripeCustomerId: this.options.billingStripeCustomerId || this.options.user?.stripeCustomerId
+                        },
+                        tags: [
+                            ...(this.options.chatflowName ? [`Name:${this.options.chatflowName}`] : []),
+                            ...(this.options.chatflowid ? [`chatflow_id:${this.options.chatflowid}`] : []),
+                            ...(this.options.chatId ? [`chat_id:${this.options.chatId}`] : []),
+                            ...(this.options.messageId ? [`chatmessage_id:${this.options.messageId}`] : [])
+                        ].filter(Boolean),
                         ...this.nodeData?.inputs?.analytics?.langFuse
                     })
                 }

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -1981,6 +1981,11 @@ export const executeAgentFlow = async ({
     let parentTraceIds: ICommonObject | undefined
     let parentLangfuseTrace: LangfuseTraceClient | undefined
 
+    // Compute billing Stripe customer ID before analytics init
+    const billedUserId = user?.id || chatflow.userId
+    const billedUser = await appDataSource.getRepository(User).findOne({ where: { id: billedUserId } })
+    const billingStripeCustomerId = OVERRIDE_CUSTOMER_ID ? DEFAULT_CUSTOMER_ID : billedUser?.stripeCustomerId
+
     try {
         if (isAnalyticsEnabled(chatflow.analytic)) {
             // Override config analytics
@@ -1997,7 +2002,15 @@ export const executeAgentFlow = async ({
                 databaseEntities,
                 componentNodes,
                 analytic: chatflow.analytic,
-                chatId
+                chatId,
+                chatflowid: chatflow.id,
+                chatflowId: chatflow.id,
+                chatflowName: chatflow.name,
+                user,
+                sessionId,
+                messageId: apiMessageId,
+                billingStripeCustomerId,
+                trackingMetadata: incomingInput.trackingMetadata
             })
             await analyticHandlers.init()
             parentTraceIds = await analyticHandlers.onChainStart(
@@ -2009,6 +2022,7 @@ export const executeAgentFlow = async ({
         }
     } catch (error) {
         logger.error(`[server]: Error initializing analytic handlers: ${getErrorMessage(error)}`)
+        logger.error(`[server]: Analytics stack trace:`, error)
     }
 
     while (nodeExecutionQueue.length > 0 && status === 'INPROGRESS') {


### PR DESCRIPTION
## Summary

- Enriches `AnalyticHandler.getInstance` options in `buildAgentflow.ts` with chatflow/user/billing context so agentflow Langfuse traces get the same rich metadata as chatflows
- Replaces hardcoded `metadata: { tags: ['openai-assistant'] }` in `onChainStart` with metadata built from `this.options`
- Adds `chatflow_id`, `chat_id`, `chatmessage_id` tags to all Langfuse traces (agentflows via onChainStart, chatflows/legacy via additionalCallbacks)

## Problem

Agentflow traces exist in Langfuse but are bare — no chatflowid, userId, organizationId, billing metadata, and empty tags. This makes them unfindable and unfilterable compared to chatflow traces which have rich metadata.

## Root Cause

1. `AnalyticHandler.getInstance` in `buildAgentflow.ts` received minimal options (only chatId, analytic config) — missing chatflowid, user, messageId, sessionId, billing
2. `AnalyticHandler.onChainStart` in `handler.ts` created traces with hardcoded `metadata: { tags: ['openai-assistant'] }` ignoring enriched options

## Changes

### `buildAgentflow.ts` (15 lines)
- Compute `billingStripeCustomerId` before analytics init block (copies existing pattern from follow-up prompts section)
- Add 8 fields to `AnalyticHandler.getInstance` options: chatflowid, chatflowId, chatflowName, user, sessionId, messageId, billingStripeCustomerId, trackingMetadata
- Add stack trace logging to analytics error catch block

### `handler.ts` (48 lines net)
- Replace `metadata: { tags: ['openai-assistant'] }` in onChainStart (2 trace creation paths) with rich metadata object
- Add `chatflow_id:`, `chat_id:`, `chatmessage_id:` tags to onChainStart traces
- Add same 3 tags to `additionalCallbacks` handlerConfig and `parentLangfuseTrace.update`

## After Deploy

Agentflow traces will have:
```
name:     "Kumello Agentic Search Prod"  (was "Agentflow")
metadata: { chatflowid, chatflowName, chatId, userId, organizationId, messageId, sessionId, stripeCustomerId }
tags:     [ "Name:...", "chatflow_id:...", "chat_id:...", "chatmessage_id:..." ]
```

Chatflow/legacy traces also get the 3 new ID tags via the additionalCallbacks change.