### PR TITLE
fix(documentstore): eliminate OOM during vectorstore upsert of large stores

### DIFF
--- a/packages/components/src/indexing.ts
+++ b/packages/components/src/indexing.ts
@@ -298,11 +298,16 @@ export async function index(args: IndexArgs): Promise<IndexingResult> {
 
         if (docsToIndex.length > 0) {
             await vectorStore.addDocuments(docsToIndex, { ids: uids })
-            const newDocs = docsToIndex.map((docs) => ({
-                pageContent: docs.pageContent,
-                metadata: docs.metadata
-            }))
-            addedDocs.push(...newDocs)
+            // Only keep first 4 docs as preview samples — accumulating all docs
+            // causes OOM on large stores (95k+ chunks = ~475MB just for addedDocs)
+            if (addedDocs.length < 4) {
+                const remaining = 4 - addedDocs.length
+                const sampleDocs = docsToIndex.slice(0, remaining).map((docs) => ({
+                    pageContent: docs.pageContent,
+                    metadata: docs.metadata
+                }))
+                addedDocs.push(...sampleDocs)
+            }
             numAdded += docsToIndex.length - seenDocs.size
             numUpdated += seenDocs.size
         }
@@ -342,7 +347,7 @@ export async function index(args: IndexArgs): Promise<IndexingResult> {
         }
     }
 
-    totalKeys = (await recordManager.listKeys({})).length
+    totalKeys = numAdded + numSkipped + numUpdated - numDeleted
 
     return {
         numAdded,

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1838,7 +1838,6 @@ const _insertIntoVectorStoreWorkerThread = async (
                         indexResult.numUpdated = (indexResult.numUpdated ?? 0) + (batchResult.numUpdated ?? 0)
                         indexResult.numSkipped = (indexResult.numSkipped ?? 0) + (batchResult.numSkipped ?? 0)
                         indexResult.totalKeys = batchResult.totalKeys ?? indexResult.totalKeys
-                        indexResult.addedDocs = [...(indexResult.addedDocs ?? []), ...(batchResult.addedDocs ?? [])]
                     }
                 }
 


### PR DESCRIPTION
## Summary

Fixes OOM crash during Pinecone upsert of large document stores (95k+ chunks). Memory climbed steadily from baseline to 2GB over ~1 hour until SIGKILL.

## Root Cause

Three compounding memory leaks during vectorstore upsert:

1. **addedDocs accumulation** (indexing.ts:305) — every batch pushed full Document objects into an array never freed. 95k chunks x ~5KB = ~475MB.
2. **indexResult.addedDocs spread** (documentstore/index.ts:1841) — each outer batch spread inner results into a growing array. Another ~475MB.
3. **totalKeys fetch** (indexing.ts:350) — loaded every record manager key into memory just to count them.

## Changes

- Cap addedDocs to 4 preview samples instead of accumulating all docs
- Remove addedDocs spread in worker thread (field is omitted from persisted result anyway)
- Replace listKeys({}).length with computed count

## Expected Impact

Memory during 95k upsert: ~2GB OOM → ~100-200MB steady-state.

Also scaled Render to Pro Plus (4GB) as belt-and-suspenders.

## Related

- KUMELLO-68
- Follow-up to PR #1029 (streaming sync fix)