### PR TITLE
fix(feedback): add error-path logging for DB failures on feedback submission

### DIFF
--- a/packages/server/src/services/feedback/index.ts
+++ b/packages/server/src/services/feedback/index.ts
@@ -31,6 +31,14 @@ const createChatMessageFeedbackForChatflow = async (requestBody: Partial<IChatMe
         const dbResponse = await utilAddChatMessageFeedback(requestBody)
         return dbResponse
     } catch (error) {
+        console.log('[FEEDBACK DEBUG] feedbackService.createChatMessageFeedbackForChatflow error:', JSON.stringify({
+            code: (error as any).code,
+            constraint: (error as any).constraint,
+            message: getErrorMessage(error),
+            messageId: (requestBody as any).messageId,
+            chatId: (requestBody as any).chatId,
+            rating: (requestBody as any).rating
+        }, null, 2))
         throw new InternalFlowiseError(
             StatusCodes.INTERNAL_SERVER_ERROR,
             `Error: feedbackService.createChatMessageFeedbackForChatflow - ${getErrorMessage(error)}`

--- a/packages/server/src/utils/addChatMessageFeedback.ts
+++ b/packages/server/src/utils/addChatMessageFeedback.ts
@@ -8,9 +8,22 @@ import { getRunningExpressApp } from '../utils/getRunningExpressApp'
  */
 
 export const utilAddChatMessageFeedback = async (chatMessageFeedback: Partial<IChatMessageFeedback>): Promise<ChatMessageFeedback> => {
-    const appServer = getRunningExpressApp()
-    const newChatMessageFeedback = new ChatMessageFeedback()
-    Object.assign(newChatMessageFeedback, chatMessageFeedback)
-    const feedback = await appServer.AppDataSource.getRepository(ChatMessageFeedback).create(newChatMessageFeedback)
-    return await appServer.AppDataSource.getRepository(ChatMessageFeedback).save(feedback)
+    try {
+        const appServer = getRunningExpressApp()
+        const newChatMessageFeedback = new ChatMessageFeedback()
+        Object.assign(newChatMessageFeedback, chatMessageFeedback)
+        const feedback = await appServer.AppDataSource.getRepository(ChatMessageFeedback).create(newChatMessageFeedback)
+        return await appServer.AppDataSource.getRepository(ChatMessageFeedback).save(feedback)
+    } catch (error) {
+        console.log('[FEEDBACK DEBUG] DB save error:', JSON.stringify({
+            code: (error as any).code,
+            detail: (error as any).detail,
+            constraint: (error as any).constraint,
+            driverError: (error as any).driverError?.message,
+            messageId: chatMessageFeedback.messageId,
+            chatId: chatMessageFeedback.chatId,
+            rating: chatMessageFeedback.rating
+        }, null, 2))
+        throw error
+    }
 }


### PR DESCRIPTION
## Summary

Adds error-path logging to the feedback service layer for debugging a 500 error on thumbs-down feedback with comments.

**Root cause confirmed**: PostgreSQL unique constraint violation `UQ_6352078b5a294f2d22179ea7956` found in Render logs. When a client retries feedback submission for the same message, it hits the `@Unique(['messageId'])` constraint and gets a 500.

**What this PR does**:
- `addChatMessageFeedback.ts`: adds try/catch with structured logging of PostgreSQL error code, constraint name, and request context
- `services/feedback/index.ts`: adds logging before wrapping DB errors as `InternalFlowiseError(500)`

**This is a diagnostic PR only.** No functional changes. Debug logging will be removed after root cause is confirmed via reproduction.

Superseded by #1036.