### PR TITLE
fix(chat): filter message fetch by chatId to isolate conversations

### DIFF
--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -1359,7 +1359,8 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
                         setFormDescription(startNode.data.inputs?.formDescription)
                     }
 
-                    getAllExecutionsApi.request({ agentflowId: chatflowid })
+                    const storedSessionId = getLocalStorageChatflow(chatflowid)?.chatId
+                    getAllExecutionsApi.request({ agentflowId: chatflowid, ...(storedSessionId && { sessionId: storedSessionId }) })
                 }
             }
 
@@ -1465,8 +1466,10 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
 
     useEffect(() => {
         if (open && chatflowid) {
-            // API request
-            getChatmessageApi.request(chatflowid)
+            const storedChatId = getLocalStorageChatflow(chatflowid)?.chatId
+            if (storedChatId) {
+                getChatmessageApi.request(chatflowid, { chatId: storedChatId })
+            }
             getIsChatflowStreamingApi.request(chatflowid)
             getAllowChatFlowUploads.request(chatflowid)
             getChatflowConfig.request(chatflowid)


### PR DESCRIPTION
## Summary

The internal chat pane (Flowise canvas) was loading **all messages for a chatflow across all conversations** instead of only the current session. Opening the chat pane for any chatflow would surface messages from every prior conversation, and subsequent messages would all pile into the oldest session's chatId — causing full chat history bleed between sessions.

Root cause: `getChatmessageApi.request(chatflowid)` had no `chatId` filter, and the returned data's first chatId was then used to overwrite the fresh `uuidv4()` session. LLM memory also bled because `getSessionChatHistory` uses `sessionId` which defaults to `chatId`.

## Changes

- **`packages/ui/src/views/chatmessage/ChatMessage.jsx`** — 2 targeted edits:
  1. Gate `getChatmessageApi.request` behind `storedChatId` from `localStorage`. Only called when a prior session exists; fresh sessions skip the fetch and start clean.
  2. Spread `sessionId` onto `getAllExecutionsApi.request` so agentflow execution history is also scoped per conversation.

No server-side changes needed — `utilGetChatMessage` already supports `chatId` filtering when provided.

## Linear Ticket

Closes [KUMELLO-39](https://linear.app/the-answer/issue/KUMELLO-39)

## Testing

- [x] Bug reproduced on staging via Playwright: opening an agent's canvas chat pane loaded messages from prior sessions
- [x] Fix verified locally on `http://localhost:4000` via Playwright:
  - Fresh session: chat pane shows only "Hi there! How can I help?" — no old messages loaded ✅
  - Continued session: network request confirmed as `/api/v1/internal-chatmessage/{id}?chatId={storedId}` — filter sent correctly ✅
- [x] No server-side changes
- [x] No schema changes
- [x] No migrations

## Screenshots

**Before (bug on staging):** All prior conversation messages loaded into every new chat pane open — messages from unrelated sessions all visible simultaneously.

**After (fix on localhost):** Chat pane opens with only greeting. Network request includes `chatId` filter — only the current session's messages are fetched.

## Review Focus

- `ChatMessage.jsx:1466-1476` — The `open && chatflowid` useEffect: `storedChatId` gates the fetch
- `ChatMessage.jsx:1362-1363` — The `getChatflowConfig.data` useEffect: `storedSessionId` scoped executions
- Both reads use `getLocalStorageChatflow(chatflowid)?.chatId` consistently
- `ViewMessagesDialog.jsx` intentionally NOT changed — admin history view should still show all conversations