### PR TITLE
fix(chat): restore chatId/sessionId filtering lost during Flowise 3.0.11 merge

### DIFF
--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -1362,7 +1362,8 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
                         setFormDescription(startNode.data.inputs?.formDescription)
                     }
 
-                    getAllExecutionsApi.request({ agentflowId: chatflowid })
+                    const storedSessionId = getLocalStorageChatflow(chatflowid)?.chatId
+                    getAllExecutionsApi.request({ agentflowId: chatflowid, ...(storedSessionId && { sessionId: storedSessionId }) })
                 }
             }
 
@@ -1468,8 +1469,10 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
 
     useEffect(() => {
         if (open && chatflowid) {
-            // API request
-            getChatmessageApi.request(chatflowid)
+            const storedChatId = getLocalStorageChatflow(chatflowid)?.chatId
+            if (storedChatId) {
+                getChatmessageApi.request(chatflowid, { chatId: storedChatId })
+            }
             getIsChatflowStreamingApi.request(chatflowid)
             getAllowChatFlowUploads.request(chatflowid)
             getChatflowConfig.request(chatflowid)


### PR DESCRIPTION
## Summary

Restores two critical filtering parameters that were **lost during the Flowise 3.0.11 upgrade merge** (`ac844f5996`, Jan 4 2026, PR #726). This caused all agent chat history to load as a single session instead of per-conversation.

## Root Cause

During the large merge for the Flowise 3.0.11 upgrade (#726), two filtering parameters were dropped from `ChatMessage.jsx` during conflict resolution:

1. **`chatId` filter on message fetch** (~line 1468): Upstream Flowise passes `{ chatId: storedChatId }` to `getChatmessageApi.request()` to scope messages to the current conversation. Our merge dropped this parameter, causing the API to return **all messages across all conversations** for the chatflow.

2. **`sessionId` scope on execution fetch** (~line 1362): Upstream passes `sessionId` conditionally to `getAllExecutionsApi.request()` to scope agentflow executions. Our merge dropped this, loading **all executions** regardless of session.

The server-side (`utilGetChatMessage`) already supports `chatId` filtering when provided — the frontend was simply not sending it.

## What This Fixes

- Each chat conversation now has its own isolated history
- History from one conversation does not bleed into another
- Agentflow execution history is scoped per session
- Works correctly in the default workspace

## Changes

**`packages/ui/src/views/chatmessage/ChatMessage.jsx`** — 2 targeted edits restoring upstream behavior:

1. **Line ~1469**: Gate `getChatmessageApi.request` behind `storedChatId` from `localStorage`. Fresh sessions start clean; returning sessions fetch only their own messages.
2. **Line ~1363**: Spread `sessionId` onto `getAllExecutionsApi.request` so agentflow execution history is also scoped per conversation.

## Verification

| Check | Result |
|-------|--------|
| Upstream Flowise has this filtering | ✅ Confirmed — lines 1366 and 1474 of upstream `ChatMessage.jsx` |
| Our fix matches upstream exactly | ✅ Same pattern: `getLocalStorageChatflow(chatflowid)?.chatId` |
| Server-side changes needed | ❌ None — `utilGetChatMessage` already supports `chatId` param |
| Schema/migration changes | ❌ None |
| `ViewMessagesDialog.jsx` affected | ❌ Intentionally untouched — admin view should show all conversations |

## Linear Ticket

Closes [KUMELLO-39](https://linear.app/answeragent/issue/KUMELLO-39/agent-chat-history-saving-as-single-session-instead-of-per)

## Review Focus

- `ChatMessage.jsx:1469-1475` — The `open && chatflowid` useEffect: `storedChatId` gates the fetch
- `ChatMessage.jsx:1363-1364` — The `getChatflowConfig.data` useEffect: `storedSessionId` scoped executions
- Both reads use `getLocalStorageChatflow(chatflowid)?.chatId` consistently