### PR TITLE
fix(auth): preserve server-enriched auth fields in PermissionProvider merge

### DIFF
--- a/packages-answers/ui/src/PermissionProvider.tsx
+++ b/packages-answers/ui/src/PermissionProvider.tsx
@@ -13,21 +13,33 @@ const PermissionContext = React.createContext<PermissionContextValue | undefined
 
 const mergeUsers = (initialUser?: Partial<User>, runtimeUser?: Partial<User> | null): Partial<User> => {
     const merged: Record<string, unknown> = {}
+
+    // Start with initialUser (server-enriched data from /api/v1/auth/me)
     if (initialUser) {
         Object.entries(initialUser).forEach(([key, value]) => {
             if (value !== undefined) merged[key] = value
         })
     }
+
+    // Merge runtimeUser but preserve critical auth fields from server
     if (runtimeUser) {
+        // Fields that MUST come from server enrichment, never from client
+        // These are set by the backend based on Auth0 roles and should not be overwritten
+        const preservedFields = ['roles', 'permissions', 'features', 'org_id', 'organizationId']
+
         Object.entries(runtimeUser).forEach(([key, value]) => {
             if (value === undefined) return
-            if (key === 'roles' && Array.isArray(merged[key]) && Array.isArray(value)) {
-                merged[key] = Array.from(new Set([...(merged[key] as unknown[]), ...value]))
-                return
+
+            // Don't overwrite server-enriched auth fields
+            if (preservedFields.includes(key) && merged[key] !== undefined) {
+                return  // Keep server value
             }
+
+            // Allow runtime updates for non-auth fields (name, email, picture, etc.)
             merged[key] = value
         })
     }
+
     return merged as Partial<User>
 }
 

--- a/packages-answers/ui/src/PermissionProvider.tsx
+++ b/packages-answers/ui/src/PermissionProvider.tsx
@@ -32,7 +32,7 @@ const mergeUsers = (initialUser?: Partial<User>, runtimeUser?: Partial<User> | n
 
             // Don't overwrite server-enriched auth fields
             if (preservedFields.includes(key) && merged[key] !== undefined) {
-                return  // Keep server value
+                return // Keep server value
             }
 
             // Allow runtime updates for non-auth fields (name, email, picture, etc.)

--- a/packages-answers/utils/src/auth/enrichSession.ts
+++ b/packages-answers/utils/src/auth/enrichSession.ts
@@ -89,8 +89,18 @@ export async function enrichSessionWithFlowise(session: any, options: EnrichSess
             const enrichedUser = data.user || data
 
             if (enrichedUser) {
+                // Save Auth0 roles before merge — the ID token carries https://theanswer.ai/roles
+                // but the access token (used by Flowise) often does not, so Flowise returns roles: []
+                const auth0Roles = session.user?.['https://theanswer.ai/roles']
+
                 // Merge Auth0 user with Flowise enriched data (Flowise takes priority)
                 session.user = { ...session.user, ...enrichedUser }
+
+                // Restore Auth0 roles if Flowise couldn't extract them from the access token
+                if (auth0Roles?.length && (!session.user.roles || session.user.roles.length === 0)) {
+                    session.user.roles = Array.isArray(auth0Roles) ? auth0Roles : [auth0Roles]
+                }
+
                 console.debug('[AAI enrichSession] User enriched successfully with fields:', Object.keys(enrichedUser).join(', '))
             }
         } else {


### PR DESCRIPTION
## Summary
Fixes the visibility controls issue where Admin users could not click or toggle chatflow visibility checkboxes. The root cause was a two-layer problem in the auth enrichment pipeline.

## Root Cause

**The real bug is in `enrichSessionWithFlowise` (`packages-answers/utils/src/auth/enrichSession.ts`).**

The Auth0 **access token** does not carry the `https://theanswer.ai/roles` custom claim — only the **ID token** does. When `enrichSessionWithFlowise` calls Flowise `/api/v1/auth/me`, Flowise's `verifyAAIToken` extracts roles from the access token and gets `roles = []`. It then returns `roles: []`, `permissions: []`, `features: {}` for the user.

The merge `session.user = { ...session.user, ...enrichedUser }` then overwrites the correct `roles: ['Admin']` (from the ID token session) with `roles: []`. This is what `useUser()` returns to `PermissionProvider` as `runtimeUser`, breaking `hasFeature('org:manage')` for Admins.

This was introduced by the 3.0.11 merge (Jan 4, 2026) which added the custom `/api/auth/me` handler with `enrichSessionWithFlowise`. Before that, `useUser()` returned the raw Auth0 session (ID token claims only) — no Flowise overwrite, roles were always correct.

## Changes

### Fix 1 — Root cause: `packages-answers/utils/src/auth/enrichSession.ts`
Before the Flowise merge, captures `https://theanswer.ai/roles` from the Auth0 session (always reliable, from the ID token). After the merge, restores it if Flowise returned empty roles.

### Fix 2 — Defensive layer: `packages-answers/ui/src/PermissionProvider.tsx`
Modified `mergeUsers()` to add a `preservedFields` guard — server-enriched fields (`roles`, `permissions`, `features`, `org_id`, `organizationId`) in `initialUser` are never overwritten by `runtimeUser`. This is a second layer of protection that makes `PermissionProvider` resilient regardless of what `useUser()` returns.

## Impact
- **Fixes**: Visibility controls for Admin users (reported by Bisma in Slack)
- **Affects**: Permission system across the application
- **No breaking changes**: Only fixes the broken permission propagation
- **Backward compatible**: Other user roles (Member, Builder) unaffected

## Long-term recommendation
Add `https://theanswer.ai/roles` to the **access token** (not just the ID token) via an Auth0 Action. This fixes the root cause at the Auth0 level — `verifyAAIToken` would then extract roles correctly and the entire enrichment chain would work without workarounds.

## Test plan
- [ ] Deploy to staging environment
- [ ] Log in as Admin user (Bisma or equivalent)
- [ ] Check Network tab → `/api/auth/me` response — confirm `roles: ['Admin']` is present
- [ ] Navigate to chatflow visibility settings
- [ ] Verify "Browser Extension", "Organization", and "Marketplace" checkboxes are enabled and clickable
- [ ] Verify clicking checkboxes updates visibility state
- [ ] Verify changes persist after saving
- [ ] Test with Member and Builder roles to ensure they still have correct restrictions
- [ ] Verify `hasFeature('org:manage')` returns true for Admin users in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)