### PR TITLE
fix(permissions): restore visibility controls in Flowise canvas for admin users

### DIFF
--- a/packages/ui/src/App.jsx
+++ b/packages/ui/src/App.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 
 import { ThemeProvider } from '@mui/material/styles'
-import { Button, CssBaseline, StyledEngineProvider } from '@mui/material'
+import { CssBaseline, StyledEngineProvider } from '@mui/material'
 
 // routing
 import Routes from '@/routes'
@@ -13,39 +13,19 @@ import themes from '@/themes'
 
 // project imports
 import NavigationScroll from '@/layout/NavigationScroll'
-import { useAuth0 } from '@auth0/auth0-react'
 import useNotifyParentOfNavigation from './utils/useNotifyParentOfNavigation'
 
 // ==============================|| APP ||============================== //
 
 const App = () => {
     const customization = useSelector((state) => state.customization)
-    const { user, isLoading, getAccessTokenSilently, error, signinWithRedirect } = useAuth0()
+    const user = useSelector((state) => state.auth.user)
     useNotifyParentOfNavigation()
     React.useEffect(() => {
         if (user?.chatflowDomain) {
             sessionStorage.setItem('baseURL', user.chatflowDomain.replace('8080', '4000'))
         }
     }, [user?.chatflowDomain])
-    React.useEffect(() => {
-        ;(async () => {
-            try {
-                // console.log('user', { user, isLoading })
-                if (!user && !isLoading) {
-                    await signinWithRedirect()
-                } else if (user) {
-                    const newToken = await getAccessTokenSilently({
-                        authorizationParams: {
-                            // scope: 'write:admin'
-                        }
-                    })
-                    sessionStorage.setItem('access_token', newToken)
-                }
-            } catch (err) {
-                console.log(err)
-            }
-        })()
-    }, [user, isLoading, getAccessTokenSilently, signinWithRedirect])
 
     return (
         <StyledEngineProvider injectFirst>
@@ -54,12 +34,6 @@ const App = () => {
                 <NavigationScroll>
                     <Routes />
                 </NavigationScroll>
-                {error && (
-                    <>
-                        <h1>{error.message}</h1>
-                        <Button onClick={() => loginWithRedirect()}>Try Again</Button>
-                    </>
-                )}
             </ThemeProvider>
         </StyledEngineProvider>
     )

--- a/packages/ui/src/hooks/usePermissions.js
+++ b/packages/ui/src/hooks/usePermissions.js
@@ -1,9 +1,9 @@
-import { useAuth0 } from '@auth0/auth0-react'
+import { useSelector } from 'react-redux'
 import { useMemo } from 'react'
 import { createPermissionManager } from 'utils/src/auth/permissions'
 
 export const usePermissions = () => {
-    const { user } = useAuth0()
+    const user = useSelector((state) => state.auth.user)
     return useMemo(() => createPermissionManager(user ?? {}), [user])
 }
 


### PR DESCRIPTION
## Summary

- **Fix visibility controls for admin users in Flowise canvas** — \`usePermissions.js\` was importing \`useAuth0\` from \`@auth0/auth0-react\`, a package with no \`Auth0Provider\` in the component tree, silently returning \`undefined\` user and disabling all visibility checkboxes for everyone
- **Harden the auth enrichment chain** — restore Auth0 roles in \`enrichSession\` when the access token lacks the claim; preserve server-enriched fields in \`PermissionProvider\` so client-side Auth0 data cannot overwrite them
- **Clean up broken legacy entry point** — remove dead \`useAuth0\` token management code from \`App.jsx\` (disabled Vite-only path, never reached in production)

## Root Cause

The Flowise canvas (\`packages/ui\`) wraps its tree with \`<UserProvider>\` from \`@auth0/nextjs-auth0/client\` — **not** \`<Auth0Provider>\` from \`@auth0/auth0-react\`. Calling \`useAuth0()\` from the wrong package silently returns \`{ user: undefined }\` because no matching provider exists in the tree.

\`createPermissionManager(undefined ?? {})\` produces an empty permission set → \`hasFeature('org:manage')\` = false → \`Organization\` and \`Browser Extension\` visibility checkboxes permanently disabled for every user, including admins.

The correct source is \`state.auth.user\` from Redux, populated by \`useAuth0Setup\` after fetching \`/auth/me\` and dispatching \`loginSuccess\`. This object contains server-enriched \`roles\` and \`permissions\` and is backed by \`localStorage\` for instant availability on returning sessions.

This fix also covers agentflows — both canvases share the same \`CanvasHeader\` → \`ChatflowConfigurationDialog\` → \`VisibilitySettings\` → \`usePermissions\` path.

## Changes

| File | Change |
|------|--------|
| \`packages/ui/src/hooks/usePermissions.js\` | Replace \`useAuth0()\` from wrong package with \`useSelector((state) => state.auth.user)\` |
| \`packages/ui/src/App.jsx\` | Remove broken \`useAuth0\` import and dead token management \`useEffect\` from legacy Vite entry |
| \`packages-answers/ui/src/PermissionProvider.tsx\` | Preserve \`roles\`, \`permissions\`, \`features\`, \`org_id\`, \`organizationId\` from server — prevent client-side Auth0 data from overwriting them |
| \`packages-answers/utils/src/auth/enrichSession.ts\` | Restore Auth0 roles from ID token when Flowise access token lacks the \`https://theanswer.ai/roles\` claim |

## Test plan

- [x] ESLint: \`cd packages/ui && npx eslint src/hooks/usePermissions.js src/App.jsx\` — no errors
- [ ] Log in as Admin → open chatflow canvas → Configuration → Visibility tab → **Organization** and **Browser Extension** checkboxes are enabled
- [ ] Select **Organization**, click Save → success toast appears, chatflow reloads with visibility persisted
- [ ] Repeat on an agentflow canvas — same checkboxes enabled
- [ ] Log in as Member role → verify Organization/Browser Extension checkboxes remain disabled (correct restriction)
- [ ] Verify no regressions in credentials dialog, variables dialog (both use \`usePermissions\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)