### PR TITLE
fix(security): mitigate CVE-2026-40933 Flowise MCP stdio RCE bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,115 @@ There are two main ways to get started with TheAnswer: local development setup a
     cd theanswer
     ```
 
-3. Open [http://localhost:3000](http://localhost:3000)
+    **Alternative:** If you already cloned without submodules:
+
+    ```bash
+    git clone https://github.com/the-answerai/theanswer.git
+    cd theanswer
+    git submodule update --init
+    ```
+
+2. **Set up environment variables:**
+
+    - Create a `.env` file in the root directory
+    - If `.env.example` files are not available, contact The AnswerAI team for required environment variables
+    - Use `API_HOST` to specify your API server host. All API requests automatically include the `/api/v1` prefix.
+    - `API_BASE_URL` is deprecated and should not be used.
+    - **Note:** For local development, you'll need Auth0 development team access (Member role or above)
+
+3. **Verify submodules are initialized:**
+
+    ```bash
+    git submodule status
+    ```
+
+    You should see output like:
+
+    ```
+    +050ca236891420946884c68ff8d74cbeb0cbe7ef packages/embed (aai-embed@3.0.3-23-g050ca23)
+    ```
+
+    **If submodules are not initialized** (empty directories or missing files), or if you need to update to the correct version, run:
+
+    ```bash
+    # This will initialize, update, and force reset submodules to the correct commits
+    pnpm submodule:init
+    ```
+
+    **For a complete reset** (if you're having persistent issues):
+
+    ```bash
+    # Remove and reinitialize all submodules
+    pnpm submodule:reset
+    ```
+
+    **Note:** This repository uses git submodules. The `packages/embed` submodule contains the chat embed functionality. See [CONTRIBUTING.md](CONTRIBUTING.md#git-submodules) for detailed submodule management instructions.
+
+4. **Install dependencies:**
+
+    ```bash
+    pnpm install
+    ```
+
+5. **Install Docker Desktop:**
+
+    - Download and install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+    - Ensure Docker is running before proceeding
+
+6. **Set up database and redis locally:**
+
+    ```bash
+    pnpm dev-docker
+    ```
+
+7. **Optional: Install database tool**
+
+    - Install [DBeaver](https://dbeaver.io/) for database management
+    - Connect to PostgreSQL: localhost, example_user, example_password
+
+8. **Build and migrate the initial database:**
+
+    ```bash
+    pnpm build && pnpm db:migrate
+    ```
+
+9. **Run the application:**
+
+    ```bash
+    pnpm start
+    ```
+
+10. **Access TheAnswer:**
+
+    - After the build completes and the app starts, you should see logs stating that the server started on 'http://localhost:3000'
+    - Open [http://localhost:3000](http://localhost:3000) in your browser
+    - Verify you can login and access the application
+
+11. **For development:**
+    - After initial setup, you can fast reload to test your changes using:
+    ```bash
+    pnpm dev
+    ```
+
+### Deploy on Render (Recommended for Easy Setup)
+
+For a quick and easy setup, we recommend deploying TheAnswer on Render:
+
+1. Click the "Deploy to Render" button below:
+
+    [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/the-answerai/theanswer)
+
+2. Follow the prompts on Render to complete the deployment process.
+
+3. Once deployed, you'll receive a URL to access your TheAnswer instance.
+
+For detailed instructions on both local development and Render deployment, please refer to our [documentation](https://docs.theanswer.ai/).
+
+Note: The standalone TheAnswer CLI tool is currently under development. Stay tuned for updates on its release and installation process.
+
+Note: The TheAnswer package is currently under development and not yet published to npm. Stay tuned for updates on when it will be available as a standalone CLI tool.
+
+4. Open [http://localhost:3000](http://localhost:3000)
 
 ## 🐳 Docker
 

--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -261,6 +261,45 @@ export const validateCommandInjection = (args: string[]): void => {
     }
 }
 
+/**
+ * Security hardening for CVE-2026-40933 (Flowise MCP stdio RCE).
+ *
+ * The CVE exploits the fact that allowlisted commands (npx, node, python, python3)
+ * all support "inline code execution" flags that accept an arbitrary string and
+ * execute it as code or as a shell command. The existing shell-metacharacter check
+ * in validateCommandInjection does not trigger on a payload like:
+ *
+ *   { "command": "npx", "args": ["-c", "touch /tmp/pwn"] }
+ *
+ * because "-c" and "touch /tmp/pwn" each contain no metacharacters on their own.
+ * npx then interprets -c/--call as "execute the following string as a shell command",
+ * resulting in RCE.
+ *
+ * This validator rejects any argument list that contains one of these inline-exec
+ * flags as a standalone argument, which is the only way these flags can be invoked.
+ * Legitimate MCP server configs (e.g. `npx -y @modelcontextprotocol/server-filesystem`)
+ * do not use any of these flags, so this is non-breaking for normal usage.
+ *
+ * Flags blocked:
+ *   -c / --call   : npx, python, python3 (execute string as code/shell)
+ *   -e / --eval   : node (evaluate string as JavaScript)
+ *   -p / --print  : node (evaluate and print - equivalent to --eval for RCE)
+ *   --exec        : docker exec-style (defense-in-depth)
+ */
+export const validateInlineExecFlags = (args: string[]): void => {
+    const forbiddenFlags = new Set(['-c', '--call', '-e', '--eval', '-p', '--print', '--exec'])
+
+    for (const arg of args) {
+        if (typeof arg !== 'string') continue
+
+        if (forbiddenFlags.has(arg.toLowerCase())) {
+            throw new Error(
+                `Argument "${arg}" is an inline code-execution flag and is not permitted in MCP server configurations (CVE-2026-40933 mitigation).`
+            )
+        }
+    }
+}
+
 export const validateEnvironmentVariables = (env: Record<string, any>): void => {
     const dangerousEnvVars = ['PATH', 'LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH']
 
@@ -292,6 +331,9 @@ export const validateMCPServerConfig = (serverParams: any): void => {
     if (serverParams.args && Array.isArray(serverParams.args)) {
         validateArgsForLocalFileAccess(serverParams.args)
         validateCommandInjection(serverParams.args)
+        // CVE-2026-40933: reject inline code-execution flags (-c, --call, -e, --eval, -p, --print, --exec)
+        // that bypass the shell-metacharacter check by wrapping arbitrary code in a separate argument.
+        validateInlineExecFlags(serverParams.args)
     }
 
     // Validate environment variables

--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -264,38 +264,81 @@ export const validateCommandInjection = (args: string[]): void => {
 /**
  * Security hardening for CVE-2026-40933 (Flowise MCP stdio RCE).
  *
- * The CVE exploits the fact that allowlisted commands (npx, node, python, python3)
- * all support "inline code execution" flags that accept an arbitrary string and
- * execute it as code or as a shell command. The existing shell-metacharacter check
- * in validateCommandInjection does not trigger on a payload like:
+ * The CVE exploits the fact that several allowlisted interpreters (npx, node,
+ * python, python3) support "inline code execution" flags that accept an arbitrary
+ * string and execute it as code or as a shell command. The existing
+ * shell-metacharacter check in validateCommandInjection does not trigger on a
+ * payload like:
  *
  *   { "command": "npx", "args": ["-c", "touch /tmp/pwn"] }
  *
- * because "-c" and "touch /tmp/pwn" each contain no metacharacters on their own.
- * npx then interprets -c/--call as "execute the following string as a shell command",
- * resulting in RCE.
+ * because "-c" and "touch /tmp/pwn" each contain no metacharacters on their
+ * own. npx then interprets -c/--call as "execute the following string as a
+ * shell command", resulting in RCE.
  *
- * This validator rejects any argument list that contains one of these inline-exec
- * flags as a standalone argument, which is the only way these flags can be invoked.
- * Legitimate MCP server configs (e.g. `npx -y @modelcontextprotocol/server-filesystem`)
- * do not use any of these flags, so this is non-breaking for normal usage.
+ * This validator rejects any argument list that contains an inline-exec flag
+ * in any of the common argv forms (the CLIs we care about accept all three):
  *
- * Flags blocked:
- *   -c / --call   : npx, python, python3 (execute string as code/shell)
- *   -e / --eval   : node (evaluate string as JavaScript)
- *   -p / --print  : node (evaluate and print - equivalent to --eval for RCE)
- *   --exec        : docker exec-style (defense-in-depth)
+ *   -c cmd             // separate-argument form
+ *   -ccmd              // adjacent value (short flag only)
+ *   --call=cmd         // attached value (long flag)
+ *   --call cmd         // separate-argument long form (caught by exact match)
+ *
+ * The blocklist is keyed by command, because the same short flag has very
+ * different semantics in different CLIs. For example, `-e` is a code-eval
+ * flag for node but is the standard env-var flag for docker (`docker run -e
+ * API_TOKEN`). Blocking -e globally would break legitimate docker-based MCP
+ * configs, including the documented CustomMCP example.
+ *
+ * Per-command inline-exec flags:
+ *   node            : -e / --eval, -p / --print
+ *   npx             : -c / --call
+ *   python, python3 : -c
+ *   docker          : (none at the docker CLI level)
+ *
+ * Legitimate MCP server configs (e.g. `npx -y @modelcontextprotocol/server-filesystem`,
+ * `docker run -i --rm -e API_TOKEN image`) do not use any of the blocked flags,
+ * so this is non-breaking for normal usage.
  */
-export const validateInlineExecFlags = (args: string[]): void => {
-    const forbiddenFlags = new Set(['-c', '--call', '-e', '--eval', '-p', '--print', '--exec'])
+export const validateInlineExecFlags = (command: string | undefined, args: string[]): void => {
+    const inlineExecFlagsByCommand: Record<string, string[]> = {
+        node: ['-e', '--eval', '-p', '--print'],
+        npx: ['-c', '--call'],
+        python: ['-c'],
+        python3: ['-c']
+    }
+
+    const forbiddenFlags = inlineExecFlagsByCommand[command ?? '']
+    if (!forbiddenFlags || forbiddenFlags.length === 0) return
+
+    const matchesFlag = (arg: string, flag: string): boolean => {
+        const lower = arg.toLowerCase()
+
+        // Exact match: "-c" or "--call"
+        if (lower === flag) return true
+
+        // Attached value with "=": "--call=evil" or "-c=evil"
+        if (lower.startsWith(flag + '=')) return true
+
+        // Adjacent value on a short flag (no space/equals): "-ccmd", "-ecode"
+        // Only applies to single-char short flags to avoid false positives on
+        // long flags such as "--eval-something" (not a real flag but safer).
+        if (flag.length === 2 && flag.startsWith('-') && !flag.startsWith('--')) {
+            if (lower.startsWith(flag) && lower.length > flag.length) return true
+        }
+
+        return false
+    }
 
     for (const arg of args) {
         if (typeof arg !== 'string') continue
 
-        if (forbiddenFlags.has(arg.toLowerCase())) {
-            throw new Error(
-                `Argument "${arg}" is an inline code-execution flag and is not permitted in MCP server configurations (CVE-2026-40933 mitigation).`
-            )
+        for (const flag of forbiddenFlags) {
+            if (matchesFlag(arg, flag)) {
+                throw new Error(
+                    `Argument "${arg}" is an inline code-execution flag for "${command}" and is not permitted in MCP server configurations (CVE-2026-40933 mitigation).`
+                )
+            }
         }
     }
 }
@@ -331,9 +374,11 @@ export const validateMCPServerConfig = (serverParams: any): void => {
     if (serverParams.args && Array.isArray(serverParams.args)) {
         validateArgsForLocalFileAccess(serverParams.args)
         validateCommandInjection(serverParams.args)
-        // CVE-2026-40933: reject inline code-execution flags (-c, --call, -e, --eval, -p, --print, --exec)
-        // that bypass the shell-metacharacter check by wrapping arbitrary code in a separate argument.
-        validateInlineExecFlags(serverParams.args)
+        // CVE-2026-40933: reject inline code-execution flags (-c / --call / -e / --eval / -p / --print
+        // and their --flag=value / -fvalue variants) that bypass the shell-metacharacter check by
+        // wrapping arbitrary code in a separate or attached argument. Command-aware so docker's -e
+        // (env var) flag and other legitimate uses are not falsely blocked.
+        validateInlineExecFlags(serverParams.command, serverParams.args)
     }
 
     // Validate environment variables


### PR DESCRIPTION
## Summary

Patches **CVE-2026-40933** (Flowise MCP Remote Command Execution) against our fork, which currently runs Flowise **3.0.11** (within the vulnerable `<= 3.0.13` range).

The existing MCP command-injection validator in [`packages/components/nodes/tools/MCP/core.ts`](packages/components/nodes/tools/MCP/core.ts) checks each argument for shell metacharacters in isolation, but does not reject inline code-execution flags (`-c`, `--call`, `-e`, `--eval`, `-p`, `--print`, `--exec`) that allow an allowlisted command (`npx`, `node`, `python`, `python3`) to execute a subsequent argument as arbitrary code / shell.

### Reported CVE payload

```json
{
  "command": "npx",
  "args": ["-c", "touch /tmp/pwn"]
}
```

Both `"-c"` and `"touch /tmp/pwn"` individually pass the existing metacharacter check, but together they instruct `npx` to run the second argument as a shell command, yielding **authenticated RCE** via the Custom MCP node in the chatflow canvas.

## Why we are not upgrading to Flowise 3.1.0

The upstream 3.1.0 release is a breaking major release (LangChain v1 migration, AgentFlow SDK rename, HTTP security defaults, 200+ PRs). A full upgrade of this heavily customized fork would require weeks of work and extensive regression testing. That effort is being tracked as a separate roadmap item -- this PR provides the targeted hotfix in the meantime.

## Changes

- [`packages/components/nodes/tools/MCP/core.ts`](packages/components/nodes/tools/MCP/core.ts):
  - Adds `validateInlineExecFlags()` that rejects any argument list containing one of the forbidden flags as a standalone argument, with inline JSDoc referencing CVE-2026-40933.
  - Wires it into `validateMCPServerConfig()` alongside the existing `validateArgsForLocalFileAccess` and `validateCommandInjection` checks.

## Why this is non-breaking

- Legitimate MCP server configs such as `npx -y @modelcontextprotocol/server-filesystem /allowed/path` do not use any of the blocked flags.
- Only two callers of `validateMCPServerConfig` exist: `CustomMCP` and `Supergateway`. Neither uses inline-exec flags as part of normal operation.
- The 15+ pre-built MCP adapters (Github, Slack, Jira, Confluence, Linear, Atlassian, etc.) do not go through the validator at all -- they use hardcoded `command`/`args` and are unaffected.
- TypeScript type-check passes with no new errors.

## Explicitly NOT changing

- `CUSTOM_MCP_PROTOCOL=sse` is a valid nuclear-option mitigation that disables stdio transport entirely in [`CustomMCP.ts`](packages/components/nodes/tools/MCP/CustomMCP/CustomMCP.ts), but was not flipped here because without tenant-usage visibility it could silently break customer chatflows that rely on legitimate stdio Custom MCP configs. Code-level hardening was chosen to target the specific CVE bypass without collateral breakage. The env var remains available as defense-in-depth if needed.
- No version bump (still `3.0.11`). A fork-versioning strategy (e.g., `3.0.11-aai.1`) should be addressed in its own PR since it touches multiple packages, deploy configs, and version-comparison scripts.

## Test plan

- [ ] Smoke test on staging: load a chatflow containing a Custom MCP node with a benign config (e.g., `npx -y @modelcontextprotocol/server-filesystem`) and confirm it still lists actions correctly.
- [ ] Smoke test on staging: attempt the CVE payload `{"command":"npx","args":["-c","touch /tmp/pwn"]}` in a Custom MCP node and confirm it is rejected with the `inline code-execution flag` error.
- [ ] Verify other MCP-backed chatflows (Slack / Jira / Github / etc.) load tools normally -- they should not be affected at all.
- [ ] If staging smoke test passes, merge to `staging` and then to `prod`.

## References

- Upwind Security advisory: https://x.com/UpwindMDR/status/2044857553415491857
- Internal Slack escalation from Mark Lukowski re: ias-aai-prod-flowise-Service-OWMAlRszsOn0
- Upstream patch in Flowise 3.1.0: https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.1.0