### PR TITLE
hotfix(security): mitigate CVE-2026-40933 Flowise MCP stdio RCE bypass

### DIFF
--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -245,6 +245,45 @@ export const validateCommandInjection = (args: string[]): void => {
     }
 }
 
+/**
+ * Security hardening for CVE-2026-40933 (Flowise MCP stdio RCE).
+ *
+ * The CVE exploits the fact that allowlisted commands (npx, node, python, python3)
+ * all support "inline code execution" flags that accept an arbitrary string and
+ * execute it as code or as a shell command. The existing shell-metacharacter check
+ * in validateCommandInjection does not trigger on a payload like:
+ *
+ *   { "command": "npx", "args": ["-c", "touch /tmp/pwn"] }
+ *
+ * because "-c" and "touch /tmp/pwn" each contain no metacharacters on their own.
+ * npx then interprets -c/--call as "execute the following string as a shell command",
+ * resulting in RCE.
+ *
+ * This validator rejects any argument list that contains one of these inline-exec
+ * flags as a standalone argument, which is the only way these flags can be invoked.
+ * Legitimate MCP server configs (e.g. `npx -y @modelcontextprotocol/server-filesystem`)
+ * do not use any of these flags, so this is non-breaking for normal usage.
+ *
+ * Flags blocked:
+ *   -c / --call   : npx, python, python3 (execute string as code/shell)
+ *   -e / --eval   : node (evaluate string as JavaScript)
+ *   -p / --print  : node (evaluate and print - equivalent to --eval for RCE)
+ *   --exec        : docker exec-style (defense-in-depth)
+ */
+export const validateInlineExecFlags = (args: string[]): void => {
+    const forbiddenFlags = new Set(['-c', '--call', '-e', '--eval', '-p', '--print', '--exec'])
+
+    for (const arg of args) {
+        if (typeof arg !== 'string') continue
+
+        if (forbiddenFlags.has(arg.toLowerCase())) {
+            throw new Error(
+                `Argument "${arg}" is an inline code-execution flag and is not permitted in MCP server configurations (CVE-2026-40933 mitigation).`
+            )
+        }
+    }
+}
+
 export const validateEnvironmentVariables = (env: Record<string, any>): void => {
     const dangerousEnvVars = ['PATH', 'LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH']
 
@@ -276,6 +315,9 @@ export const validateMCPServerConfig = (serverParams: any): void => {
     if (serverParams.args && Array.isArray(serverParams.args)) {
         validateArgsForLocalFileAccess(serverParams.args)
         validateCommandInjection(serverParams.args)
+        // CVE-2026-40933: reject inline code-execution flags (-c, --call, -e, --eval, -p, --print, --exec)
+        // that bypass the shell-metacharacter check by wrapping arbitrary code in a separate argument.
+        validateInlineExecFlags(serverParams.args)
     }
 
     // Validate environment variables


### PR DESCRIPTION
## ⚠️ Production Hotfix -- Targets `main` directly

This is a **security hotfix** cherry-picked onto `main` so it can ship to prod immediately without waiting for the full `staging` backlog to be released.

**Companion PR against `staging`:** #1056 (same commit, same fix).

## Summary

Patches **CVE-2026-40933** (Flowise MCP Remote Command Execution) against our fork, which currently runs Flowise **3.0.11** (within the vulnerable `<= 3.0.13` range).

The existing MCP command-injection validator in [`packages/components/nodes/tools/MCP/core.ts`](packages/components/nodes/tools/MCP/core.ts) checks each argument for shell metacharacters in isolation, but does not reject inline code-execution flags (`-c`, `--call`, `-e`, `--eval`, `-p`, `--print`, `--exec`) that allow an allowlisted command (`npx`, `node`, `python`, `python3`) to execute a subsequent argument as arbitrary code / shell.

### Reported CVE payload

```json
{
  "command": "npx",
  "args": ["-c", "touch /tmp/pwn"]
}
```

Both `"-c"` and `"touch /tmp/pwn"` individually pass the existing metacharacter check, but together they instruct `npx` to run the second argument as a shell command, yielding **authenticated RCE** via the Custom MCP node in the chatflow canvas.

## Why direct-to-main and not the normal staging → main flow

Staging currently has a large set of unrelated in-flight changes that are not ready for production release. Waiting for staging to be promoted would leave the production ECS service (`ias-aai-prod-flowise-Service-OWMAlRszsOn0`) exposed to the CVE for an unacceptable window. This PR ships ONLY the security fix directly to `main` as a hotfix, leaving all other staging work untouched.

## Why we are not upgrading to Flowise 3.1.0

The upstream 3.1.0 release is a breaking major release (LangChain v1 migration, AgentFlow SDK rename, HTTP security defaults, 200+ PRs). A full upgrade of this heavily customized fork would require weeks of work and extensive regression testing. That effort is being tracked as a separate roadmap item -- this PR provides the targeted hotfix in the meantime.

## Changes

- [`packages/components/nodes/tools/MCP/core.ts`](packages/components/nodes/tools/MCP/core.ts):
  - Adds `validateInlineExecFlags()` that rejects any argument list containing one of the forbidden flags as a standalone argument, with inline JSDoc referencing CVE-2026-40933.
  - Wires it into `validateMCPServerConfig()` alongside the existing `validateArgsForLocalFileAccess` and `validateCommandInjection` checks.

**Single-file change, 42 insertions, zero deletions.** Identical to the staging PR (#1056).

## Why this is non-breaking

- Legitimate MCP server configs such as `npx -y @modelcontextprotocol/server-filesystem /allowed/path` do not use any of the blocked flags.
- Only two callers of `validateMCPServerConfig` exist: `CustomMCP` and `Supergateway`. Neither uses inline-exec flags as part of normal operation.
- The 15+ pre-built MCP adapters (Github, Slack, Jira, Confluence, Linear, Atlassian, etc.) do not go through the validator at all -- they use hardcoded `command`/`args` and are unaffected.
- TypeScript type-check on the MCP files passes cleanly (pre-existing unrelated TS errors in Qdrant / handler / storageUtils on `main` are not introduced by this PR).

## Explicitly NOT changing

- `CUSTOM_MCP_PROTOCOL=sse` is a valid nuclear-option mitigation that disables stdio transport entirely, but was not flipped here because without tenant-usage visibility it could silently break customer chatflows that rely on legitimate stdio Custom MCP configs.
- No version bump (still `3.0.11`).
- No deploy config changes.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Deploy to production via normal `copilot svc deploy` / release flow
- [ ] Smoke test on prod: load an existing chatflow containing a Custom MCP node and confirm it still lists actions correctly (no regression on legitimate configs).
- [ ] Smoke test on prod: attempt the CVE payload `{"command":"npx","args":["-c","touch /tmp/pwn"]}` in a Custom MCP node and confirm it is rejected with the `inline code-execution flag` error referencing CVE-2026-40933.
- [ ] Verify other MCP-backed chatflows (Slack / Jira / Github / etc.) continue to load tools normally.

## References

- Upwind Security advisory: https://x.com/UpwindMDR/status/2044857553415491857
- Internal Slack escalation from Mark Lukowski re: `ias-aai-prod-flowise-Service-OWMAlRszsOn0`
- Companion staging PR: #1056
- Upstream patch context in Flowise 3.1.0: https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.1.0