### PR TITLE
chore(llmchain): drop noisy *****FINAL RESULT***** console output

### DIFF
--- a/packages/components/nodes/chains/LLMChain/LLMChain.ts
+++ b/packages/components/nodes/chains/LLMChain/LLMChain.ts
@@ -150,10 +150,6 @@ class LLMChain_Chains implements INode {
         }
         promptValues = injectOutputParser(this.outputParser, chain, promptValues)
         const res = await runPrediction(inputVariables, chain, input, promptValues, options, nodeData)
-        // eslint-disable-next-line no-console
-        console.log('\x1b[93m\x1b[1m\n*****FINAL RESULT*****\n\x1b[0m\x1b[0m')
-        // eslint-disable-next-line no-console
-        console.log(res)
         return res
     }
 }


### PR DESCRIPTION
## Summary

`LLMChain.run` was logging the raw prediction result to stdout for **every** chain invocation:

```
*****FINAL RESULT*****
{ json: { ... } }
```

That is fine for one-off local debugging but spams server logs in any chatflow that uses an LLM Chain — most visibly during CSV transformer cron runs that invoke the chain once per row. Removed both `console.log` lines (and their `eslint-disable` markers) from `packages/components/nodes/chains/LLMChain/LLMChain.ts`.

## Why

Surfaced while triaging the CSV cron output (PR #1062) — every processed row was emitting two stdout lines from the LLM Chain node, drowning the structured logger output and making the cron logs hard to read.

## Test plan

- [ ] Build succeeds (`pnpm --filter flowise-components build`).
- [ ] Run a chatflow that uses an `LLMChain` node and confirm the `*****FINAL RESULT*****` block no longer appears in server logs.
- [ ] CSV transformer cron run logs are now clean of the raw `{ json: { ... } }` dumps for each row.