### PR TITLE
feat(csv-transformer): API-sourced worker status, global theme fixes, and CSV UI polish

### DIFF
--- a/apps/web/app/(Main UI)/sidekick-studio/(main-layout)/csv-transformer/CsvTransformerClient.tsx
+++ b/apps/web/app/(Main UI)/sidekick-studio/(main-layout)/csv-transformer/CsvTransformerClient.tsx
@@ -3,12 +3,8 @@ import dynamic from 'next/dynamic'
 
 const View = dynamic(() => import('@ui/CsvTransfomer'), { ssr: false })
 
-interface Props {
-    cronEnabled: boolean
-}
-
-const CsvTransformerClient = ({ cronEnabled }: Props) => {
-    return <View cronEnabled={cronEnabled} />
+const CsvTransformerClient = () => {
+    return <View />
 }
 
 export default CsvTransformerClient

--- a/apps/web/app/(Main UI)/sidekick-studio/(main-layout)/csv-transformer/page.tsx
+++ b/apps/web/app/(Main UI)/sidekick-studio/(main-layout)/csv-transformer/page.tsx
@@ -2,11 +2,9 @@ import React from 'react'
 import CsvTransformerClient from './CsvTransformerClient'
 
 const Page = () => {
-    const cronEnabled = process.env.ENABLE_CSV_RUN_CRON === 'true'
-
     return (
         <>
-            <CsvTransformerClient cronEnabled={cronEnabled} />
+            <CsvTransformerClient />
         </>
     )
 }

--- a/packages-answers/ui/src/CsvTransfomer/CsvTransformer.Client.tsx
+++ b/packages-answers/ui/src/CsvTransfomer/CsvTransformer.Client.tsx
@@ -19,9 +19,7 @@ import { Container, Box, Stack, Tabs, Tab, Typography, Alert, AlertTitle } from 
 import ProcessCsv from './ProcessCsv'
 import ProcessingHistory from './ProcessingHistory'
 
-interface CsvTransformerProps {
-    cronEnabled?: boolean
-}
+type WorkerBannerState = 'loading' | 'enabled' | 'disabled' | 'error'
 
 function TabPanel(props: any) {
     const { children, currentValue, value, ...other } = props
@@ -38,9 +36,10 @@ function TabPanel(props: any) {
     )
 }
 
-const CsvTransformer = ({ cronEnabled = false }: CsvTransformerProps) => {
+const CsvTransformer = () => {
     const { user, isLoading } = useUser()
     const [chatflows, setChatflows] = useState([])
+    const [workerBanner, setWorkerBanner] = useState<WorkerBannerState>('loading')
     const searchParams = useSearchParams()
     const router = useRouter()
     const tab = searchParams.get('tab') ?? 'process'
@@ -64,6 +63,41 @@ const CsvTransformer = ({ cronEnabled = false }: CsvTransformerProps) => {
     useEffect(() => {
         fetchChatflows()
     }, [fetchChatflows])
+
+    useEffect(() => {
+        if (isLoading) return
+        if (!user) {
+            setWorkerBanner('error')
+            return
+        }
+        let cancelled = false
+        const loadWorkerStatus = async () => {
+            const baseURL = sessionStorage.getItem('baseURL') || ''
+            const token = sessionStorage.getItem('access_token')
+            if (!baseURL || !token) {
+                if (!cancelled) setWorkerBanner('error')
+                return
+            }
+            try {
+                const response = await fetch(`${baseURL}/api/v1/csv-parser/worker-status`, {
+                    headers: {
+                        'x-request-from': 'aai',
+                        Authorization: `Bearer ${token}`
+                    }
+                })
+                if (!response.ok) throw new Error('worker-status failed')
+                const data = (await response.json()) as { workerEnabled?: boolean }
+                if (cancelled) return
+                setWorkerBanner(data.workerEnabled ? 'enabled' : 'disabled')
+            } catch {
+                if (!cancelled) setWorkerBanner('error')
+            }
+        }
+        loadWorkerStatus()
+        return () => {
+            cancelled = true
+        }
+    }, [isLoading, user])
 
     // Auto-refresh when user returns from marketplace (only if no CSV chatflows currently)
     useEffect(() => {
@@ -100,16 +134,30 @@ const CsvTransformer = ({ cronEnabled = false }: CsvTransformerProps) => {
                 <Typography variant='h2' component='h1'>
                     AI CSV Transformer
                 </Typography>
-                {cronEnabled ? (
+                {workerBanner === 'loading' && (
+                    <Alert severity='info' variant='outlined'>
+                        <AlertTitle>Checking worker status</AlertTitle>
+                        Loading background CSV processing status from the API server…
+                    </Alert>
+                )}
+                {workerBanner === 'enabled' && (
                     <Alert severity='success' variant='outlined'>
                         <AlertTitle>Background processing is enabled</AlertTitle>
-                        Submitted CSVs will be picked up by the cron worker on this environment.
+                        Submitted CSVs will be picked up by the cron worker on the Flowise/API server (status from API).
                     </Alert>
-                ) : (
+                )}
+                {workerBanner === 'disabled' && (
                     <Alert severity='warning' variant='outlined'>
                         <AlertTitle>Background processing is disabled</AlertTitle>
-                        CSV runs can be created but they will not be processed until <code>ENABLE_CSV_RUN_CRON=true</code> is set on the
-                        server (then the worker is restarted).
+                        CSV runs can be created but will not be processed until <code>ENABLE_CSV_RUN_CRON=true</code> is set on the
+                        Flowise/API server and that process is restarted.
+                    </Alert>
+                )}
+                {workerBanner === 'error' && (
+                    <Alert severity='warning' variant='outlined'>
+                        <AlertTitle>Could not load worker status</AlertTitle>
+                        The UI could not read CSV worker status from the API (session, network, or server error). Background processing may
+                        still be enabled on the server.
                     </Alert>
                 )}
                 <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>

--- a/packages-answers/ui/src/CsvTransfomer/ProcessCsv.tsx
+++ b/packages-answers/ui/src/CsvTransfomer/ProcessCsv.tsx
@@ -2,9 +2,12 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useDropzone } from 'react-dropzone'
 import { Controller, useForm } from 'react-hook-form'
-import { InputLabel, Select, MenuItem } from '@mui/material'
-
 import {
+    InputLabel,
+    Select,
+    MenuItem,
+    Divider,
+    ListItemIcon,
     Stack,
     Box,
     Button,
@@ -30,10 +33,19 @@ import { User } from 'types'
 import DownloadOutlined from '@mui/icons-material/DownloadOutlined'
 import CloseOutlined from '@mui/icons-material/CloseOutlined'
 import FilePresentOutlined from '@mui/icons-material/FilePresentOutlined'
+import AddIcon from '@mui/icons-material/Add'
 
 import CsvNoticeCard from './CsvNoticeCard'
 import SnackMessage from '../SnackMessage'
-import { parseCsvWithHeaders, parseCsvWithoutHeaders } from './parseCsv'
+import { parseCsvWithHeaders, parseCsvWithoutHeaders, formatCsvHeaderForUi } from './parseCsv'
+
+/** Sentinel Select value — opens CSV marketplace; never stored as processorId. */
+const CREATE_NEW_CSV_PROCESSOR_VALUE = '__aai_csv_create_new__'
+
+function openCsvProcessorMarketplace() {
+    localStorage.setItem('answerai.csv.install-intent', 'true')
+    window.open('/sidekick-studio/marketplaces?usecase=CSV', '_blank', 'noopener,noreferrer')
+}
 
 interface ChatFlow {
     id: string
@@ -143,6 +155,34 @@ const ProcessCsv = ({
     onRefreshChatflows?: () => Promise<void>
 }) => {
     const theme = useTheme()
+
+    /** Avoid full-screen blurred modal backdrop from global MuiBackdrop — keep a normal dropdown feel. */
+    const csvProcessorSelectMenuProps = useMemo(
+        () => ({
+            disableScrollLock: true,
+            BackdropProps: {
+                sx: {
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none',
+                    backgroundColor: 'transparent'
+                }
+            },
+            PaperProps: {
+                sx: {
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none',
+                    backgroundImage: 'none',
+                    bgcolor: 'background.paper',
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    boxShadow: theme.shadows[8],
+                    maxHeight: 360
+                }
+            }
+        }),
+        [theme.shadows]
+    )
+
     const [headers, setHeaders] = useState<string[]>([])
     const [rows, setRows] = useState<string[][]>([])
     const [file, setFile] = useState<string | null>(null)
@@ -385,14 +425,19 @@ const ProcessCsv = ({
         () => ({
             ...{
                 ...baseStyle,
-                backgroundColor: theme.palette.grey[50],
-                borderColor: theme.palette.primary.main,
-                color: theme.palette.primary.main,
+                // Theme-aware tokens so the dropzone reads correctly in both
+                // light and dark mode. Hardcoding `grey[50]` produced a bright
+                // white surface in dark mode, and `primary.main` resolves to a
+                // translucent white in the AnswerAI dark theme — leaving the
+                // border + text effectively invisible.
+                backgroundColor: theme.palette.action.hover,
+                borderColor: theme.palette.divider,
+                color: theme.palette.text.primary,
                 padding: theme.spacing(4),
                 cursor: 'pointer'
             },
             ...(isFocused ? { borderColor: theme.palette.secondary.main } : {}),
-            ...(isDragAccept ? { borderColor: theme.palette.primary.main } : {}),
+            ...(isDragAccept ? { borderColor: theme.palette.success.main } : {}),
             ...(isDragReject ? { borderColor: theme.palette.error.main } : {})
         }),
         [isFocused, isDragAccept, isDragReject, theme]
@@ -529,7 +574,7 @@ const ProcessCsv = ({
                                     </IconButton>
                                 </Stack>
                             ) : (
-                                <Typography>{'Drag &apos;n&apos; drop a CSV file here, or click to select a file'}</Typography>
+                                <Typography>Drag and drop a CSV file here, or click to select a file</Typography>
                             )}
                         </Box>
                     </Stack>
@@ -586,26 +631,49 @@ const ProcessCsv = ({
                                                     label='AI Processor'
                                                     required
                                                     error={!!errors.processorId}
-                                                    disabled={chatflows.length === 0}
                                                     fullWidth
+                                                    displayEmpty
+                                                    MenuProps={csvProcessorSelectMenuProps}
+                                                    onChange={(e) => {
+                                                        const v = e.target.value as string
+                                                        if (v === CREATE_NEW_CSV_PROCESSOR_VALUE) {
+                                                            openCsvProcessorMarketplace()
+                                                            return
+                                                        }
+                                                        field.onChange(e)
+                                                    }}
+                                                    renderValue={(selected) => {
+                                                        if (!selected) {
+                                                            return (
+                                                                <Typography variant='body2' color='text.secondary' component='span'>
+                                                                    {chatflows.length === 0
+                                                                        ? 'Select or create a CSV processor'
+                                                                        : 'Select an AI processor'}
+                                                                </Typography>
+                                                            )
+                                                        }
+                                                        const cf = chatflows.find((c) => c.id === selected)
+                                                        return cf?.name ?? selected
+                                                    }}
                                                 >
-                                                    {chatflows.length === 0 ? (
-                                                        <MenuItem disabled value=''>
-                                                            No CSV processors available
+                                                    {chatflows.map((chatflow) => (
+                                                        <MenuItem key={chatflow.id} value={chatflow.id}>
+                                                            {chatflow.name}
                                                         </MenuItem>
-                                                    ) : (
-                                                        chatflows.map((chatflow) => (
-                                                            <MenuItem key={chatflow.id} value={chatflow.id}>
-                                                                {chatflow.name}
-                                                            </MenuItem>
-                                                        ))
-                                                    )}
+                                                    ))}
+                                                    {chatflows.length > 0 && <Divider sx={{ my: 0.5 }} />}
+                                                    <MenuItem value={CREATE_NEW_CSV_PROCESSOR_VALUE}>
+                                                        <ListItemIcon sx={{ minWidth: 36 }}>
+                                                            <AddIcon fontSize='small' />
+                                                        </ListItemIcon>
+                                                        Create new processor…
+                                                    </MenuItem>
                                                 </Select>
                                                 <FormHelperText>
                                                     {errors.processorId?.message ||
                                                         (chatflows.length === 0
-                                                            ? 'Install a CSV processor from the marketplace below to continue'
-                                                            : 'Select the AI model to process your CSV')}
+                                                            ? 'Choose Create new processor or use the card below, then refresh.'
+                                                            : 'Pick a processor above, or use Create new processor to open CSV templates in a new tab—install one, then refresh.')}
                                                 </FormHelperText>
                                             </>
                                         )}
@@ -736,43 +804,42 @@ const ProcessCsv = ({
                                 <Controller
                                     name='sourceColumns'
                                     control={control}
-                                    render={({ field: { value, onChange } }) => (
-                                        <FormControl sx={{ flex: 1 }} component='fieldset' variant='standard'>
-                                            <Box
-                                                sx={{
-                                                    display: 'flex',
-                                                    flexWrap: 'wrap',
-                                                    gap: 1,
-                                                    mt: 1
-                                                }}
-                                            >
-                                                {headers.map((header) => {
-                                                    const isSelected = value.includes(header)
-                                                    return (
-                                                        <Chip
-                                                            key={header}
-                                                            label={header}
-                                                            size='small'
-                                                            onClick={() => {
-                                                                if (!isSelected) {
-                                                                    onChange([...value, header])
-                                                                } else {
-                                                                    onChange(value.filter((col: string) => col !== header))
-                                                                }
-                                                            }}
-                                                            color={isSelected ? 'primary' : 'default'}
-                                                            variant={isSelected ? 'filled' : 'outlined'}
-                                                            sx={{
-                                                                '&:hover': {
-                                                                    backgroundColor: isSelected ? 'primary.main' : 'action.hover'
-                                                                }
-                                                            }}
-                                                        />
-                                                    )
-                                                })}
-                                            </Box>
-                                        </FormControl>
-                                    )}
+                                    render={({ field: { value, onChange } }) => {
+                                        const selected = Array.isArray(value) ? value : []
+                                        return (
+                                            <FormControl sx={{ flex: 1 }} component='fieldset' variant='standard'>
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        flexWrap: 'wrap',
+                                                        gap: 1,
+                                                        mt: 1
+                                                    }}
+                                                >
+                                                    {headers.map((header, index) => {
+                                                        const visible = formatCsvHeaderForUi(header, index)
+                                                        const isSelected = selected.includes(header)
+                                                        return (
+                                                            <Chip
+                                                                key={`csv-col-${index}`}
+                                                                label={visible}
+                                                                size='small'
+                                                                color={isSelected ? 'primary' : 'default'}
+                                                                variant={isSelected ? 'filled' : 'outlined'}
+                                                                onClick={() => {
+                                                                    if (!isSelected) {
+                                                                        onChange([...selected, header])
+                                                                    } else {
+                                                                        onChange(selected.filter((col: string) => col !== header))
+                                                                    }
+                                                                }}
+                                                            />
+                                                        )
+                                                    })}
+                                                </Box>
+                                            </FormControl>
+                                        )
+                                    }}
                                 />
                             </Stack>
                         </Card>
@@ -920,15 +987,18 @@ const ProcessCsv = ({
                                             <strong>Selected columns:</strong> {watchedValues.sourceColumns.length}
                                         </Typography>
                                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                                            {watchedValues.sourceColumns.slice(0, 3).map((col) => (
-                                                <Chip
-                                                    key={col}
-                                                    label={col.length > 20 ? `${col.substring(0, 20)}...` : col}
-                                                    title={col} // Full text on hover
-                                                    size='small'
-                                                    sx={{ maxWidth: '150px' }}
-                                                />
-                                            ))}
+                                            {watchedValues.sourceColumns.slice(0, 3).map((col, i) => {
+                                                const display = formatCsvHeaderForUi(col, i)
+                                                return (
+                                                    <Chip
+                                                        key={`ov-col-${i}-${display}`}
+                                                        label={display.length > 20 ? `${display.substring(0, 20)}…` : display}
+                                                        title={display}
+                                                        size='small'
+                                                        sx={{ maxWidth: '150px' }}
+                                                    />
+                                                )
+                                            })}
                                             {watchedValues.sourceColumns.length > 3 && (
                                                 <Chip
                                                     label={`+${watchedValues.sourceColumns.length - 3} more`}

--- a/packages-answers/ui/src/CsvTransfomer/ProcessCsv.tsx
+++ b/packages-answers/ui/src/CsvTransfomer/ProcessCsv.tsx
@@ -824,14 +824,32 @@ const ProcessCsv = ({
                                                                 key={`csv-col-${index}`}
                                                                 label={visible}
                                                                 size='small'
-                                                                color={isSelected ? 'primary' : 'default'}
-                                                                variant={isSelected ? 'filled' : 'outlined'}
                                                                 onClick={() => {
                                                                     if (!isSelected) {
                                                                         onChange([...selected, header])
                                                                     } else {
                                                                         onChange(selected.filter((col: string) => col !== header))
                                                                     }
+                                                                }}
+                                                                sx={{
+                                                                    cursor: 'pointer',
+                                                                    ...(isSelected
+                                                                        ? {
+                                                                              bgcolor: '#2196f3',
+                                                                              border: '1px solid #2196f3',
+                                                                              '& .MuiChip-label': { color: '#fff' },
+                                                                              '&:hover': { bgcolor: '#1976d2', borderColor: '#1976d2' }
+                                                                          }
+                                                                        : {
+                                                                              bgcolor: 'transparent',
+                                                                              border: '1px solid',
+                                                                              borderColor: 'divider',
+                                                                              '& .MuiChip-label': { color: 'text.primary' },
+                                                                              '&:hover': {
+                                                                                  bgcolor: 'action.hover',
+                                                                                  borderColor: 'text.secondary'
+                                                                              }
+                                                                          })
                                                                 }}
                                                             />
                                                         )

--- a/packages-answers/ui/src/CsvTransfomer/ProcessCsv.tsx
+++ b/packages-answers/ui/src/CsvTransfomer/ProcessCsv.tsx
@@ -831,7 +831,7 @@ const ProcessCsv = ({
                                                                         onChange(selected.filter((col: string) => col !== header))
                                                                     }
                                                                 }}
-                                                                sx={{
+                                                                sx={(t) => ({
                                                                     cursor: 'pointer',
                                                                     ...(isSelected
                                                                         ? {
@@ -841,16 +841,30 @@ const ProcessCsv = ({
                                                                               '&:hover': { bgcolor: '#1976d2', borderColor: '#1976d2' }
                                                                           }
                                                                         : {
-                                                                              bgcolor: 'transparent',
+                                                                              bgcolor:
+                                                                                  t.palette.mode === 'light'
+                                                                                      ? 'rgba(15,23,42,0.25)'
+                                                                                      : 'rgba(255,255,255,0.12)',
                                                                               border: '1px solid',
-                                                                              borderColor: 'divider',
-                                                                              '& .MuiChip-label': { color: 'text.primary' },
+                                                                              borderColor:
+                                                                                  t.palette.mode === 'light'
+                                                                                      ? 'rgba(15,23,42,0.25)'
+                                                                                      : 'rgba(255,255,255,0.22)',
+                                                                              '& .MuiChip-label': {
+                                                                                  color: t.palette.text.primary
+                                                                              },
                                                                               '&:hover': {
-                                                                                  bgcolor: 'action.hover',
-                                                                                  borderColor: 'text.secondary'
+                                                                                  bgcolor:
+                                                                                      t.palette.mode === 'light'
+                                                                                          ? 'rgba(15,23,42,0.15)'
+                                                                                          : 'rgba(255,255,255,0.2)',
+                                                                                  borderColor:
+                                                                                      t.palette.mode === 'light'
+                                                                                          ? 'rgba(15,23,42,0.45)'
+                                                                                          : 'rgba(255,255,255,0.4)'
                                                                               }
                                                                           })
-                                                                }}
+                                                                })}
                                                             />
                                                         )
                                                     })}
@@ -924,7 +938,7 @@ const ProcessCsv = ({
                     <Box sx={{ borderBottom: 1, borderColor: 'divider', pb: 1 }}>
                         <Typography
                             variant='subtitle1'
-                            color={fileName ? 'primary' : 'textSecondary'}
+                            color={fileName ? 'text.primary' : 'text.secondary'}
                             sx={{
                                 fontWeight: 'bold',
                                 cursor: fileName ? 'pointer' : 'default',
@@ -947,7 +961,7 @@ const ProcessCsv = ({
                     <Box sx={{ borderBottom: 1, borderColor: 'divider', pb: 1 }}>
                         <Typography
                             variant='subtitle1'
-                            color={fileName ? 'primary' : 'textSecondary'}
+                            color={fileName ? 'text.primary' : 'text.secondary'}
                             sx={{
                                 fontWeight: 'bold',
                                 cursor: fileName ? 'pointer' : 'default',
@@ -984,7 +998,7 @@ const ProcessCsv = ({
                     <Box sx={{ borderBottom: 1, borderColor: 'divider', pb: 1 }}>
                         <Typography
                             variant='subtitle1'
-                            color={fileName ? 'primary' : 'textSecondary'}
+                            color={fileName ? 'text.primary' : 'text.secondary'}
                             sx={{
                                 fontWeight: 'bold',
                                 cursor: fileName && activeStep >= 1 ? 'pointer' : 'default',
@@ -1013,7 +1027,12 @@ const ProcessCsv = ({
                                                         label={display.length > 20 ? `${display.substring(0, 20)}…` : display}
                                                         title={display}
                                                         size='small'
-                                                        sx={{ maxWidth: '150px' }}
+                                                        sx={{
+                                                            maxWidth: '150px',
+                                                            bgcolor: '#2196f3',
+                                                            border: '1px solid #2196f3',
+                                                            '& .MuiChip-label': { color: '#fff' }
+                                                        }}
                                                     />
                                                 )
                                             })}
@@ -1021,7 +1040,14 @@ const ProcessCsv = ({
                                                 <Chip
                                                     label={`+${watchedValues.sourceColumns.length - 3} more`}
                                                     size='small'
-                                                    variant='outlined'
+                                                    sx={(t) => ({
+                                                        bgcolor:
+                                                            t.palette.mode === 'light' ? 'rgba(15,23,42,0.06)' : 'rgba(255,255,255,0.25)',
+                                                        border: '1px solid',
+                                                        borderColor:
+                                                            t.palette.mode === 'light' ? 'rgba(15,23,42,0.2)' : 'rgba(255,255,255,0.18)',
+                                                        '& .MuiChip-label': { color: t.palette.text.secondary }
+                                                    })}
                                                 />
                                             )}
                                         </Box>
@@ -1038,7 +1064,7 @@ const ProcessCsv = ({
                     <Box>
                         <Typography
                             variant='subtitle1'
-                            color={fileName ? 'primary' : 'textSecondary'}
+                            color={fileName ? 'text.primary' : 'text.secondary'}
                             sx={{
                                 fontWeight: 'bold',
                                 cursor: fileName && activeStep >= 2 ? 'pointer' : 'default',
@@ -1250,7 +1276,7 @@ const ProcessCsv = ({
                 <Box sx={{ flex: '1 1 auto' }} />
                 {activeStep === 3 ? (
                     <Button
-                        variant='contained'
+                        variant='outlined'
                         startIcon={<DownloadOutlined sx={{ background: 'transparent' }} />}
                         onClick={handleSubmit(handleProcessCsv)}
                         type='button'
@@ -1258,7 +1284,7 @@ const ProcessCsv = ({
                         Process and Download AI-Enhanced CSV
                     </Button>
                 ) : (
-                    <Button variant='contained' onClick={handleNext} disabled={!isStepValid(activeStep)}>
+                    <Button variant='outlined' onClick={handleNext} disabled={!isStepValid(activeStep)}>
                         Next
                     </Button>
                 )}

--- a/packages-answers/ui/src/CsvTransfomer/ProcessingHistory.tsx
+++ b/packages-answers/ui/src/CsvTransfomer/ProcessingHistory.tsx
@@ -294,20 +294,35 @@ const ProcessingHistory = ({ user }: { user: User }) => {
                         )
                     }}
                     sx={{
+                        borderColor: 'divider',
                         '& .super-app-theme--header': {
                             fontWeight: 'bold',
                             fontSize: '0.875rem',
-                            color: 'white'
+                            color: 'text.primary'
                         },
                         '& .MuiDataGrid-cell': {
                             fontSize: '0.825rem',
-                            color: 'white'
+                            color: 'text.primary'
                         },
                         '& .MuiDataGrid-columnHeaders': {
-                            fontWeight: 'bold'
+                            fontWeight: 'bold',
+                            color: 'text.primary',
+                            borderBottomColor: 'divider'
+                        },
+                        '& .MuiDataGrid-columnHeaderTitle': {
+                            fontWeight: 700,
+                            color: 'text.primary'
+                        },
+                        '& .MuiDataGrid-row': {
+                            '&:hover': {
+                                bgcolor: 'action.hover'
+                            }
                         },
                         '& .MuiTablePagination-root': {
-                            color: 'white'
+                            color: 'text.primary',
+                            '& .MuiTablePagination-selectLabel, & .MuiTablePagination-displayedRows': {
+                                color: 'text.secondary'
+                            }
                         }
                     }}
                 />

--- a/packages-answers/ui/src/CsvTransfomer/parseCsv.ts
+++ b/packages-answers/ui/src/CsvTransfomer/parseCsv.ts
@@ -15,6 +15,23 @@ function generateColumnName(index: number): string {
 }
 
 /**
+ * Strip BOM, zero-width, and format chars so headers are not visually blank in the UI.
+ */
+function sanitizeHeaderLabel(raw: string): string {
+    return String(raw ?? '')
+        .replace(/^\uFEFF/, '')
+        .replace(/[\u200B-\u200D\uFEFF]/g, '')
+        .trim()
+}
+
+/** Readable label for chips and UI (handles invisible-only header cells). */
+export function formatCsvHeaderForUi(raw: string, columnIndex?: number): string {
+    const v = sanitizeHeaderLabel(String(raw ?? ''))
+    if (v) return v
+    return typeof columnIndex === 'number' ? generateColumnName(columnIndex) : 'Column'
+}
+
+/**
  * Parse CSV content using RFC 4180 compliant parser with headers
  */
 export function parseCsvWithHeaders(input: string): ParsedCsvResult {
@@ -32,11 +49,22 @@ export function parseCsvWithoutHeaders(input: string): ParsedCsvResult {
  * Parse CSV with headers
  */
 function parseWithHeaders(input: string): ParsedCsvResult {
+    const headerCounts = new Map<string, number>()
+
     const result = Papa.parse<Record<string, string>>(input.trim(), {
         header: true,
         skipEmptyLines: true,
         comments: '#',
-        transformHeader: (header) => header.trim() // Clean up header names
+        transformHeader: (header, index) => {
+            const colIndex = typeof index === 'number' ? index : 0
+            let base = sanitizeHeaderLabel(String(header ?? ''))
+            if (!base) {
+                base = generateColumnName(colIndex)
+            }
+            const n = (headerCounts.get(base) ?? 0) + 1
+            headerCounts.set(base, n)
+            return n === 1 ? base : `${base} (${n})`
+        }
     })
 
     // Be very lenient with errors - Papa Parse can handle most cases
@@ -56,8 +84,8 @@ function parseWithHeaders(input: string): ParsedCsvResult {
         throw new Error('CSV has no header row or headers could not be determined.')
     }
 
-    // Filter out empty header names
-    const cleanHeaders = headers.filter((header) => header && header.trim() !== '')
+    // After transformHeader, names should be non-empty; keep only real labels
+    const cleanHeaders = headers.filter((h) => sanitizeHeaderLabel(h) !== '')
     if (cleanHeaders.length === 0) {
         throw new Error('CSV has no valid header names.')
     }

--- a/packages-answers/ui/src/GuardrailsSettings/AdvancedMode.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/AdvancedMode.tsx
@@ -100,51 +100,6 @@ const innerTabsSx = {
     }
 }
 
-// Shared sx for sliders. Default MUI Slider uses `primary.main` for the rail,
-// track and thumb — all invisible in the AnswerAI dark theme. Anchor on
-// `text.primary` so the slider track is visible regardless of mode.
-const sliderSx = {
-    color: 'text.primary',
-    '& .MuiSlider-rail': {
-        opacity: 0.32
-    },
-    '& .MuiSlider-track': {
-        border: 'none'
-    },
-    '& .MuiSlider-thumb': {
-        boxShadow: 'none',
-        '&:hover, &.Mui-focusVisible': {
-            boxShadow: '0 0 0 6px rgba(127, 127, 127, 0.16)'
-        }
-    },
-    '& .MuiSlider-mark': {
-        backgroundColor: 'text.secondary',
-        opacity: 0.6
-    },
-    '& .MuiSlider-markLabel': {
-        color: 'text.secondary',
-        fontSize: 12
-    }
-}
-
-// Shared sx for the per-section Enable switches (Safety, PII, Faithfulness).
-// The default MUI Switch reads as grey-on-grey in the AnswerAI dark theme
-// because the active state resolves to translucent `primary.main`. Anchor
-// checked thumb + track on `info.main` (Material Blue, shared across modes)
-// so "on" is unmistakable and consistent with the page-level switches.
-const sectionSwitchSx = {
-    '& .MuiSwitch-switchBase.Mui-checked': {
-        color: 'info.main',
-        '& + .MuiSwitch-track': {
-            backgroundColor: 'info.main',
-            opacity: 0.5
-        }
-    },
-    '& .MuiSwitch-switchBase.Mui-checked:hover': {
-        backgroundColor: 'rgba(33, 150, 243, 0.08)'
-    }
-}
-
 // Shared sx for the AccordionSummary section heads ("Input Validation",
 // "Output Validation", "Advanced Settings"). Aligns with the subtitle2 +
 // fontWeight 600 rhythm used elsewhere on the page and gives the summary a
@@ -374,7 +329,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                     setSafetyEnabled(e.target.checked)
                                                     markChanged()
                                                 }}
-                                                sx={sectionSwitchSx}
                                             />
                                         }
                                         label='Enable'
@@ -413,7 +367,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                             { value: 1, label: '1.0' }
                                                         ]}
                                                         valueLabelDisplay='auto'
-                                                        sx={sliderSx}
                                                     />
                                                 </Box>
                                                 <Box>
@@ -505,7 +458,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                                             step={0.01}
                                                                             valueLabelDisplay='auto'
                                                                             size='small'
-                                                                            sx={sliderSx}
                                                                         />
                                                                     </TableCell>
                                                                     <TableCell>
@@ -557,7 +509,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                     setPiiEnabled(e.target.checked)
                                                     markChanged()
                                                 }}
-                                                sx={sectionSwitchSx}
                                             />
                                         }
                                         label='Enable'
@@ -595,7 +546,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                             { value: 1, label: '1.0' }
                                                         ]}
                                                         valueLabelDisplay='auto'
-                                                        sx={sliderSx}
                                                     />
                                                 </Box>
                                                 <Box>
@@ -691,7 +641,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                                             step={0.01}
                                                                             valueLabelDisplay='auto'
                                                                             size='small'
-                                                                            sx={sliderSx}
                                                                         />
                                                                     </TableCell>
                                                                     <TableCell>
@@ -769,7 +718,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                     setFaithfulnessEnabled(e.target.checked)
                                                     markChanged()
                                                 }}
-                                                sx={sectionSwitchSx}
                                             />
                                         }
                                         label='Enable'
@@ -800,7 +748,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                                     { value: 0.1, label: '0.1' }
                                                 ]}
                                                 valueLabelDisplay='auto'
-                                                sx={sliderSx}
                                             />
                                         </Box>
                                         <Box sx={{ mt: 2 }}>
@@ -861,7 +808,6 @@ export default function AdvancedMode({ config, onSave, saving, error, success, o
                                         step={1}
                                         marks
                                         valueLabelDisplay='auto'
-                                        sx={sliderSx}
                                     />
                                 </Box>
                             </CardContent>

--- a/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/MasterConfig.tsx
@@ -37,40 +37,6 @@ const ConfirmDialog = dynamic(() => import('flowise-ui/src/ui-component/dialog/C
 
 const FIDDLER_CREDENTIAL_NAME = 'fiddlerApi'
 
-// Shared sx for "neutral" outlined action buttons (Edit, Change, Recheck).
-// MUI's default outlined Button anchors text + border on `primary.main`,
-// which in the AnswerAI dark theme resolves to rgba(255,255,255,0.12) —
-// translucent white. The buttons end up reading as if they were disabled
-// even when fully enabled. Anchor on `text.primary` + `divider` so they
-// have clear contrast in both modes; the actual `disabled` state is left
-// to MUI's default treatment so it still reads as inert when applicable.
-const outlinedActionSx = {
-    color: 'text.primary',
-    borderColor: 'divider',
-    '&:hover': {
-        borderColor: 'text.primary',
-        bgcolor: 'action.hover'
-    }
-}
-
-// Shared sx for the page switches ("Enable Guardrails", "Observability-only").
-// The default MUI `color='primary'` resolves to translucent white in the
-// AnswerAI dark theme, making the on-state nearly invisible. Anchor the
-// checked state on `info.main` (Material Blue, shared across light/dark) so
-// the on-state reads unambiguously in both modes.
-const pageSwitchSx = {
-    '& .MuiSwitch-switchBase.Mui-checked': {
-        color: 'info.main',
-        '& + .MuiSwitch-track': {
-            backgroundColor: 'info.main',
-            opacity: 0.5
-        }
-    },
-    '& .MuiSwitch-switchBase.Mui-checked:hover': {
-        backgroundColor: 'rgba(33, 150, 243, 0.08)'
-    }
-}
-
 interface GuardrailConfig {
     enabled?: boolean
     credentialId?: string
@@ -356,7 +322,7 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
         <Box variant='outlined' sx={{ mb: 3 }}>
             {/* Enable/Disable Toggle */}
             <FormControlLabel
-                control={<Switch checked={enabled} onChange={handleEnabledChange} sx={pageSwitchSx} />}
+                control={<Switch checked={enabled} onChange={handleEnabledChange} />}
                 label='Enable Guardrails'
                 sx={{ mb: 2 }}
             />
@@ -410,12 +376,7 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                             </Button>
                             {/* Show Change when user owns any credentials they could switch to */}
                             {credentials.length > 0 && (
-                                <Button
-                                    variant='outlined'
-                                    size='small'
-                                    onClick={() => setShowCredentialDropdown(!showCredentialDropdown)}
-                                    sx={outlinedActionSx}
-                                >
+                                <Button variant='outlined' size='small' onClick={() => setShowCredentialDropdown(!showCredentialDropdown)}>
                                     Change
                                 </Button>
                             )}
@@ -480,7 +441,6 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                                 disabled={!enabled || editLoading}
                                 onClick={handleEditCredential}
                                 startIcon={editLoading ? <CircularProgress size={16} /> : <IconEdit size={16} />}
-                                sx={outlinedActionSx}
                             >
                                 Edit
                             </Button>
@@ -500,7 +460,6 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                                     size='small'
                                     disabled={!enabled}
                                     onClick={() => setShowCredentialDropdown(!showCredentialDropdown)}
-                                    sx={outlinedActionSx}
                                 >
                                     Change
                                 </Button>
@@ -556,7 +515,6 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                                 onClick={loadCapabilities}
                                 disabled={loadingCapabilities}
                                 startIcon={loadingCapabilities ? <CircularProgress size={14} /> : <IconRefresh size={14} />}
-                                sx={outlinedActionSx}
                             >
                                 Recheck
                             </Button>
@@ -742,43 +700,12 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                     disabled={!enabled}
                     aria-label='Failure mode'
                     size='small'
-                    sx={(theme) => {
-                        // The AnswerAI theme defines `primary.{main,light,dark}` as
-                        // translucent whites/slates rather than a vivid color, so anchoring
-                        // the selected state on `primary.*` produced ghosted text in dark
-                        // mode. We use MUI's mode-balanced `action.selected` token + a
-                        // visible border + `text.primary` for guaranteed contrast in both
-                        // modes — same pattern used for menu/table selection across the app.
-                        const isDark = theme.palette.mode === 'dark'
-                        return {
-                            '& .MuiToggleButton-root': {
-                                color: 'text.primary',
-                                borderColor: 'divider',
-                                textTransform: 'none',
-                                fontWeight: 500,
-                                px: 1.5,
-                                transition: 'background-color 120ms ease, border-color 120ms ease'
-                            },
-                            '& .MuiToggleButton-root:hover': {
-                                bgcolor: 'action.hover'
-                            },
-                            '& .MuiToggleButton-root.Mui-selected': {
-                                bgcolor: 'action.selected',
-                                color: 'text.primary',
-                                fontWeight: 600,
-                                borderColor: isDark ? 'rgba(255, 255, 255, 0.45)' : 'rgba(15, 23, 42, 0.5)',
-                                '&:hover': {
-                                    bgcolor: isDark ? 'rgba(255, 255, 255, 0.22)' : 'rgba(15, 23, 42, 0.12)'
-                                }
-                            }
-                        }
-                    }}
                 >
-                    <ToggleButton value='open' aria-label='Fail open'>
+                    <ToggleButton value='open' aria-label='Fail open' sx={{ px: 1.5 }}>
                         <IconAlertTriangle size={14} style={{ marginRight: 6 }} />
                         Fail open (allow, warn)
                     </ToggleButton>
-                    <ToggleButton value='closed' aria-label='Fail closed'>
+                    <ToggleButton value='closed' aria-label='Fail closed' sx={{ px: 1.5 }}>
                         <IconLock size={14} style={{ marginRight: 6 }} />
                         Fail closed (block, 503)
                     </ToggleButton>
@@ -792,14 +719,7 @@ export default function MasterConfig({ config, onConfigChange, onSave }: MasterC
                 {/* Shadow pilot toggle. Violations are recorded but never block. */}
                 <Box sx={{ mt: 2.5, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
                     <FormControlLabel
-                        control={
-                            <Switch
-                                checked={observabilityOnly}
-                                onChange={handleObservabilityOnlyChange}
-                                disabled={!enabled}
-                                sx={pageSwitchSx}
-                            />
-                        }
+                        control={<Switch checked={observabilityOnly} onChange={handleObservabilityOnlyChange} disabled={!enabled} />}
                         label={
                             <Typography variant='body2' sx={{ fontWeight: 500 }}>
                                 Observability-only (shadow mode)

--- a/packages-answers/ui/src/GuardrailsSettings/SimpleMode.tsx
+++ b/packages-answers/ui/src/GuardrailsSettings/SimpleMode.tsx
@@ -175,27 +175,12 @@ export default function SimpleMode({ config, onSave, saving, error, success, onC
             </FormControl>
 
             <Box sx={{ mt: 3, display: 'flex', gap: 2 }}>
-                {/* Save uses a local sx override to force a solid disabled background.
-                    The global theme applies a gradient `background` to all contained
-                    buttons; MUI's default disabled state only resets `backgroundColor`,
-                    which leaves the gradient bleeding through at low contrast in both
-                    modes. We zero out `background` + `boxShadow` on disabled here so
-                    the button reads unmistakably as disabled when no preset is chosen. */}
                 <Button
                     variant='contained'
                     color='primary'
                     onClick={handleSave}
                     disabled={saving || !hasChanges || !selectedPreset}
-                    sx={(theme) => ({
-                        minWidth: 180,
-                        fontWeight: 600,
-                        '&.Mui-disabled': {
-                            background: 'none',
-                            backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.08)',
-                            color: theme.palette.text.disabled,
-                            boxShadow: 'none'
-                        }
-                    })}
+                    sx={{ minWidth: 180, fontWeight: 600 }}
                 >
                     {saving ? 'Saving...' : 'Save Configuration'}
                 </Button>

--- a/packages-answers/ui/src/theme/components/muiOverrides.ts
+++ b/packages-answers/ui/src/theme/components/muiOverrides.ts
@@ -490,8 +490,9 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
                             borderColor: mode === 'light' ? 'rgba(15, 23, 42, 0.45)' : 'rgba(255, 255, 255, 0.4)'
                         }
                     },
-                    // Ensure labels on explicitly colored chips (not default) remain white for contrast.
-                    '&[class*="MuiChip-color"]:not(.MuiChip-colorDefault) .MuiChip-label': {
+                    // Ensure labels on filled colored chips remain white for contrast.
+                    // Outlined colored chips use the palette color for text — don't override.
+                    '&[class*="MuiChip-color"]:not(.MuiChip-colorDefault).MuiChip-filled .MuiChip-label': {
                         color: '#fff'
                     }
                 }

--- a/packages-answers/ui/src/theme/components/muiOverrides.ts
+++ b/packages-answers/ui/src/theme/components/muiOverrides.ts
@@ -266,14 +266,20 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
                     WebkitBackdropFilter: 'none'
                 },
                 contained: {
-                    // Use solid gradients in light mode for better contrast
+                    // Solid blue gradient in light mode; solid blue in dark mode.
+                    // glassPrimary in dark = rgba(0,0,0,0.6) — near-black and invisible
+                    // against a dark page surface.
                     ...(mode === 'light'
                         ? {
                               background: 'linear-gradient(135deg, rgb(30, 58, 138) 0%, rgb(59, 130, 246) 100%)',
                               border: 'none',
                               boxShadow: '0 4px 12px 0 rgba(59, 130, 246, 0.3)'
                           }
-                        : glass.glassPrimary),
+                        : {
+                              background: '#2196f3',
+                              border: 'none',
+                              boxShadow: '0 4px 12px 0 rgba(33, 150, 243, 0.35)'
+                          }),
                     color: '#ffffff',
                     '&:hover': {
                         ...(mode === 'light'
@@ -283,8 +289,9 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
                                   transform: 'translateY(-2px)'
                               }
                             : {
-                                  ...glass.glassHover,
-                                  background: 'rgba(0, 0, 0, 0.8)'
+                                  background: '#1976d2',
+                                  boxShadow: '0 6px 20px 0 rgba(33, 150, 243, 0.45)',
+                                  transform: 'translateY(-2px)'
                               })
                     },
                     // The light-mode `contained` button uses a gradient via the
@@ -472,19 +479,19 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
                     // color variant (default chips). Colored variants (primary, success, etc.)
                     // keep MUI's own palette-based bg so they work correctly everywhere.
                     '&:not([class*="MuiChip-color"])': {
-                        background: mode === 'light' ? 'rgba(15, 23, 42, 0.05)' : 'rgba(255, 255, 255, 0.08)',
-                        border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.18)' : 'rgba(255, 255, 255, 0.15)'}`,
+                        background: mode === 'light' ? 'rgba(15, 23, 42, 0.08)' : 'rgba(255, 255, 255, 0.12)',
+                        border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.25)' : 'rgba(255, 255, 255, 0.22)'}`,
                         color: colors.text.primary,
                         '& .MuiChip-label': {
                             color: colors.text.primary
                         },
                         '&:hover': {
-                            background: mode === 'light' ? 'rgba(15, 23, 42, 0.1)' : 'rgba(255, 255, 255, 0.14)',
-                            borderColor: mode === 'light' ? 'rgba(15, 23, 42, 0.35)' : 'rgba(255, 255, 255, 0.3)'
+                            background: mode === 'light' ? 'rgba(15, 23, 42, 0.15)' : 'rgba(255, 255, 255, 0.2)',
+                            borderColor: mode === 'light' ? 'rgba(15, 23, 42, 0.45)' : 'rgba(255, 255, 255, 0.4)'
                         }
                     },
-                    // Ensure labels on all colored chips remain white for contrast.
-                    '&[class*="MuiChip-color"] .MuiChip-label': {
+                    // Ensure labels on explicitly colored chips (not default) remain white for contrast.
+                    '&[class*="MuiChip-color"]:not(.MuiChip-colorDefault) .MuiChip-label': {
                         color: '#fff'
                     }
                 }

--- a/packages-answers/ui/src/theme/components/muiOverrides.ts
+++ b/packages-answers/ui/src/theme/components/muiOverrides.ts
@@ -465,31 +465,28 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         MuiChip: {
             styleOverrides: {
                 root: {
-                    // glassSubtle gives a near-transparent or near-white background depending on mode.
-                    // Without explicit label color the chip text is invisible in one or both themes.
-                    // Keep the subtle glass border/shadow, but swap to a readable solid surface +
-                    // explicit label color so chips work out of the box in light AND dark mode.
                     backdropFilter: 'none',
                     WebkitBackdropFilter: 'none',
-                    border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.18)' : 'rgba(255, 255, 255, 0.15)'}`,
-                    background: mode === 'light' ? 'rgba(15, 23, 42, 0.05)' : 'rgba(255, 255, 255, 0.08)',
-                    color: colors.text.primary,
                     transition: glass.transition,
-                    '& .MuiChip-label': {
-                        color: colors.text.primary
-                    },
-                    '&:hover': {
-                        background: mode === 'light' ? 'rgba(15, 23, 42, 0.1)' : 'rgba(255, 255, 255, 0.14)',
-                        borderColor: mode === 'light' ? 'rgba(15, 23, 42, 0.35)' : 'rgba(255, 255, 255, 0.3)'
-                    },
-                    // Filled color chips (e.g. color="primary") override bg — let MUI handle that,
-                    // but ensure the label remains white for contrast on a colored surface.
-                    '&.MuiChip-colorPrimary, &.MuiChip-colorSecondary, &.MuiChip-colorSuccess, &.MuiChip-colorWarning, &.MuiChip-colorError, &.MuiChip-colorInfo':
-                        {
-                            '& .MuiChip-label': {
-                                color: '#fff'
-                            }
+                    // Only apply the custom base surface to chips that have NO explicit MUI
+                    // color variant (default chips). Colored variants (primary, success, etc.)
+                    // keep MUI's own palette-based bg so they work correctly everywhere.
+                    '&:not([class*="MuiChip-color"])': {
+                        background: mode === 'light' ? 'rgba(15, 23, 42, 0.05)' : 'rgba(255, 255, 255, 0.08)',
+                        border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.18)' : 'rgba(255, 255, 255, 0.15)'}`,
+                        color: colors.text.primary,
+                        '& .MuiChip-label': {
+                            color: colors.text.primary
+                        },
+                        '&:hover': {
+                            background: mode === 'light' ? 'rgba(15, 23, 42, 0.1)' : 'rgba(255, 255, 255, 0.14)',
+                            borderColor: mode === 'light' ? 'rgba(15, 23, 42, 0.35)' : 'rgba(255, 255, 255, 0.3)'
                         }
+                    },
+                    // Ensure labels on all colored chips remain white for contrast.
+                    '&[class*="MuiChip-color"] .MuiChip-label': {
+                        color: '#fff'
+                    }
                 }
             }
         },

--- a/packages-answers/ui/src/theme/components/muiOverrides.ts
+++ b/packages-answers/ui/src/theme/components/muiOverrides.ts
@@ -5,11 +5,15 @@
 
 import { Components, Theme } from '@mui/material/styles'
 import { glassmorphismTokens } from '../tokens/glassmorphism'
-import { colorTokens } from '../tokens/colors'
+import { colorTokens, statusColors } from '../tokens/colors'
 
 export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<Theme, 'components'>> => {
     const glass = glassmorphismTokens[mode]
     const colors = colorTokens[mode]
+    // Heavier neutral border used for "selected" affordances (toggle buttons,
+    // selected cards) so the chosen state reads unambiguously in both themes.
+    const selectedBorder = mode === 'dark' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(15, 23, 42, 0.5)'
+    const selectedBorderHover = mode === 'dark' ? 'rgba(255, 255, 255, 0.6)' : 'rgba(15, 23, 42, 0.7)'
 
     return {
         // Global CSS Baseline
@@ -137,16 +141,20 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
             },
             styleOverrides: {
                 root: {
-                    ...glass.glassSecondary,
+                    // Solid surfaces — no blur artifacts on nested scrollable content.
+                    // glassSecondary in dark mode is 3% white = effectively black with no text color set.
                     backgroundImage: 'none',
+                    backgroundColor: mode === 'light' ? '#ffffff' : '#1e1e1e',
+                    border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.08)' : 'rgba(255, 255, 255, 0.08)'}`,
+                    boxShadow: mode === 'light' ? '0 2px 12px 0 rgba(0,0,0,0.08)' : '0 2px 12px 0 rgba(0,0,0,0.4)',
+                    color: colors.text.primary,
                     transition: glass.transition
                 },
                 elevation1: {
-                    ...glass.glassSecondary
+                    boxShadow: mode === 'light' ? '0 2px 8px 0 rgba(0,0,0,0.08)' : '0 2px 8px 0 rgba(0,0,0,0.4)'
                 },
                 elevation2: {
-                    ...glass.glassSecondary,
-                    boxShadow: '0 8px 24px 0 rgba(0, 0, 0, 0.12)'
+                    boxShadow: mode === 'light' ? '0 4px 16px 0 rgba(0,0,0,0.1)' : '0 4px 16px 0 rgba(0,0,0,0.5)'
                 },
                 rounded: {
                     borderRadius: 12
@@ -158,8 +166,10 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         MuiDialog: {
             styleOverrides: {
                 paper: {
-                    ...glass.glassSecondary,
                     backgroundImage: 'none',
+                    backgroundColor: mode === 'light' ? '#ffffff' : '#1e1e1e',
+                    border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.1)' : 'rgba(255, 255, 255, 0.1)'}`,
+                    color: colors.text.primary,
                     transition: glass.transition
                 }
             }
@@ -246,13 +256,14 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         MuiButton: {
             styleOverrides: {
                 root: {
-                    ...glass.glassSubtle,
+                    // Do NOT spread glassSubtle here — it adds backdropFilter blur to every button
+                    // and the near-transparent background looks wrong on solid page surfaces.
+                    // Keep only the transition and shape; variants handle their own surfaces.
                     transition: glass.transition,
                     textTransform: 'none',
                     borderRadius: 8,
-                    '&:hover': {
-                        ...glass.glassHover
-                    }
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none'
                 },
                 contained: {
                     // Use solid gradients in light mode for better contrast
@@ -276,15 +287,33 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
                                   background: 'rgba(0, 0, 0, 0.8)'
                               })
                     },
+                    // The light-mode `contained` button uses a gradient via the
+                    // `background` shorthand above. MUI's default disabled state
+                    // only resets `backgroundColor`, so the gradient `background-image`
+                    // bleeds through and the disabled button reads as fully active.
+                    // Zero out `background` + `boxShadow` here so the disabled state
+                    // is unambiguously inert in both themes.
                     '&.Mui-disabled': {
+                        background: 'none',
                         backgroundColor: mode === 'light' ? 'rgba(0, 0, 0, 0.12)' : 'rgba(255, 255, 255, 0.12)',
-                        color: mode === 'light' ? 'rgba(0, 0, 0, 0.26)' : 'rgba(255, 255, 255, 0.3)'
+                        color: mode === 'light' ? 'rgba(0, 0, 0, 0.26)' : 'rgba(255, 255, 255, 0.3)',
+                        boxShadow: 'none'
                     }
                 },
+                // Outlined buttons previously inherited `primary.main` for the
+                // border + text color, which in dark mode resolves to translucent
+                // white (rgba(255,255,255,0.12)) and renders the button as a
+                // ghost. Anchor on `text.primary` + `divider` so outlined Edit /
+                // Change / Recheck-style buttons read clearly in both themes.
                 outlined: {
-                    ...glass.glassSubtle,
+                    color: colors.text.primary,
+                    borderColor: colors.divider,
+                    background: 'transparent',
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none',
                     '&:hover': {
-                        ...glass.glassHover
+                        borderColor: colors.text.primary,
+                        backgroundColor: colors.action.hover
                     }
                 },
                 text: {
@@ -379,7 +408,12 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         MuiMenu: {
             styleOverrides: {
                 paper: {
-                    ...glass.glassSecondary,
+                    // Solid surface — glassSecondary in dark = 3% white = near-black with blur.
+                    backgroundImage: 'none',
+                    backgroundColor: mode === 'light' ? '#ffffff' : '#252525',
+                    border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.1)' : 'rgba(255, 255, 255, 0.1)'}`,
+                    boxShadow: mode === 'light' ? '0 4px 20px rgba(0,0,0,0.12)' : '0 4px 20px rgba(0,0,0,0.5)',
+                    color: colors.text.primary,
                     marginTop: '8px'
                 },
                 list: {
@@ -393,9 +427,11 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
                 root: {
                     borderRadius: 6,
                     margin: '2px 0',
+                    color: colors.text.primary,
                     transition: glass.transition,
                     '&:hover': {
-                        ...glass.glassHover
+                        // glassHover in light = rgba(255,255,255,0.95) = invisible on white paper
+                        backgroundColor: colors.action.hover
                     },
                     '&.Mui-selected': {
                         backgroundColor: mode === 'light' ? 'rgba(48, 114, 108, 0.12)' : 'rgba(77, 182, 172, 0.12)',
@@ -408,12 +444,19 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         },
 
         // BACKDROP
+        // Reduce blur — full blur(8px) on every modal/dropdown makes interaction jarring.
+        // Use a lighter tint in light mode, stronger in dark.
         MuiBackdrop: {
             styleOverrides: {
                 root: {
-                    backdropFilter: 'blur(8px)',
-                    WebkitBackdropFilter: 'blur(8px)',
-                    backgroundColor: mode === 'light' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0.75)'
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none',
+                    backgroundColor: mode === 'light' ? 'rgba(0, 0, 0, 0.35)' : 'rgba(0, 0, 0, 0.65)',
+                    // Invisible backdrop used for menus/selects — don't dim the page
+                    '&.MuiModal-backdrop': {
+                        backdropFilter: 'none',
+                        WebkitBackdropFilter: 'none'
+                    }
                 }
             }
         },
@@ -422,11 +465,31 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         MuiChip: {
             styleOverrides: {
                 root: {
-                    ...glass.glassSubtle,
+                    // glassSubtle gives a near-transparent or near-white background depending on mode.
+                    // Without explicit label color the chip text is invisible in one or both themes.
+                    // Keep the subtle glass border/shadow, but swap to a readable solid surface +
+                    // explicit label color so chips work out of the box in light AND dark mode.
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none',
+                    border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.18)' : 'rgba(255, 255, 255, 0.15)'}`,
+                    background: mode === 'light' ? 'rgba(15, 23, 42, 0.05)' : 'rgba(255, 255, 255, 0.08)',
+                    color: colors.text.primary,
                     transition: glass.transition,
+                    '& .MuiChip-label': {
+                        color: colors.text.primary
+                    },
                     '&:hover': {
-                        ...glass.glassHover
-                    }
+                        background: mode === 'light' ? 'rgba(15, 23, 42, 0.1)' : 'rgba(255, 255, 255, 0.14)',
+                        borderColor: mode === 'light' ? 'rgba(15, 23, 42, 0.35)' : 'rgba(255, 255, 255, 0.3)'
+                    },
+                    // Filled color chips (e.g. color="primary") override bg — let MUI handle that,
+                    // but ensure the label remains white for contrast on a colored surface.
+                    '&.MuiChip-colorPrimary, &.MuiChip-colorSecondary, &.MuiChip-colorSuccess, &.MuiChip-colorWarning, &.MuiChip-colorError, &.MuiChip-colorInfo':
+                        {
+                            '& .MuiChip-label': {
+                                color: '#fff'
+                            }
+                        }
                 }
             }
         },
@@ -435,7 +498,10 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         MuiAccordion: {
             styleOverrides: {
                 root: {
-                    ...glass.glassSecondary,
+                    backgroundColor: mode === 'light' ? '#ffffff' : '#1e1e1e',
+                    border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.08)' : 'rgba(255, 255, 255, 0.08)'}`,
+                    boxShadow: 'none',
+                    color: colors.text.primary,
                     transition: glass.transition,
                     '&:before': {
                         display: 'none'
@@ -459,15 +525,14 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
         },
 
         // TABS
-        // Indicator and selected-tab color anchor on `text.primary` rather than
-        // MUI's default `primary.main`. In dark mode our `primary.main` is a
-        // deliberately-translucent white (rgba(255, 255, 255, 0.12)) for the
-        // glass-button look, which renders the indicator and selected label
-        // nearly invisible. `text.primary` is high contrast in both modes.
         MuiTabs: {
             styleOverrides: {
                 root: {
-                    ...glass.glassSubtle,
+                    // glassSubtle adds blur and near-white bg — replace with a clean transparent
+                    // container so tabs sit naturally on whatever surface they're placed on.
+                    backgroundColor: 'transparent',
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none',
                     borderRadius: 8
                 },
                 indicator: {
@@ -496,12 +561,102 @@ export const muiComponentOverrides = (mode: 'light' | 'dark'): Components<Omit<T
             }
         },
 
+        // SWITCH
+        // The default MUI Switch anchors its on-state on `palette.primary.main`.
+        // In the AnswerAI dark theme `primary.main` is a deliberately-translucent
+        // white (rgba(255, 255, 255, 0.12)) for the glass-button look, which
+        // renders the on-state nearly invisible. Anchor the checked thumb +
+        // track on `info.main` (Material Blue) so "on" reads unambiguously in
+        // both light and dark mode.
+        MuiSwitch: {
+            styleOverrides: {
+                switchBase: {
+                    '&.Mui-checked': {
+                        color: statusColors.info.main,
+                        '& + .MuiSwitch-track': {
+                            backgroundColor: statusColors.info.main,
+                            opacity: 0.5
+                        },
+                        '&:hover': {
+                            backgroundColor: 'rgba(33, 150, 243, 0.08)'
+                        }
+                    }
+                }
+            }
+        },
+
+        // SLIDER
+        // Default Slider uses `primary.main` for rail/track/thumb — invisible
+        // in dark mode for the same reason as Switch. Anchor on `text.primary`
+        // (high contrast in both themes) and use `text.secondary` for marks.
+        MuiSlider: {
+            styleOverrides: {
+                root: {
+                    color: colors.text.primary
+                },
+                rail: {
+                    opacity: 0.32
+                },
+                track: {
+                    border: 'none'
+                },
+                thumb: {
+                    boxShadow: 'none',
+                    '&:hover, &.Mui-focusVisible': {
+                        boxShadow: '0 0 0 6px rgba(127, 127, 127, 0.16)'
+                    }
+                },
+                mark: {
+                    backgroundColor: colors.text.secondary,
+                    opacity: 0.6
+                },
+                markLabel: {
+                    color: colors.text.secondary,
+                    fontSize: 12
+                }
+            }
+        },
+
+        // TOGGLE BUTTON
+        // Selected state on `action.selected` + `text.primary` border so the
+        // chosen option reads clearly in both themes. Default MUI uses
+        // `primary.main` for both bg + border, which in dark mode is the same
+        // translucent white as the unselected hover — no contrast at all.
+        MuiToggleButton: {
+            styleOverrides: {
+                root: {
+                    color: colors.text.primary,
+                    borderColor: colors.divider,
+                    textTransform: 'none',
+                    transition: 'background-color 120ms ease, border-color 120ms ease',
+                    '&:hover': {
+                        backgroundColor: colors.action.hover
+                    },
+                    '&.Mui-selected': {
+                        backgroundColor: colors.action.selected,
+                        color: colors.text.primary,
+                        fontWeight: 600,
+                        borderColor: selectedBorder,
+                        '&:hover': {
+                            backgroundColor: colors.action.selected,
+                            borderColor: selectedBorderHover
+                        }
+                    }
+                }
+            }
+        },
+
         // ALERT
         MuiAlert: {
             styleOverrides: {
                 root: {
-                    ...glass.glassSecondary,
-                    borderRadius: 8
+                    // glassSecondary has no text color — alerts need readable text in both modes.
+                    borderRadius: 8,
+                    color: colors.text.primary,
+                    backgroundColor: mode === 'light' ? 'rgba(255, 255, 255, 0.9)' : 'rgba(30, 30, 30, 0.95)',
+                    border: `1px solid ${mode === 'light' ? 'rgba(15, 23, 42, 0.1)' : 'rgba(255, 255, 255, 0.08)'}`,
+                    backdropFilter: 'none',
+                    WebkitBackdropFilter: 'none'
                 }
             }
         }

--- a/packages/docs/src/pages/jlinc-partnership.tsx
+++ b/packages/docs/src/pages/jlinc-partnership.tsx
@@ -172,21 +172,21 @@ function ProblemSection() {
         {
             icon: FileText,
             title: 'Where did this come from?',
-            pain: 'AI generates earnings reports mixing data from 15 sources. Auditor asks: &quot;Prove these numbers came from approved systems.&quot;',
+            pain: 'AI generates earnings reports mixing data from 15 sources. Auditor asks: "Prove these numbers came from approved systems."',
             reality: 'Screenshots, log files, trust',
             problem: 'Not sufficient for SOX compliance'
         },
         {
             icon: Eye,
             title: 'What exactly did the AI see?',
-            pain: 'Agent analyzes confidential merger docs. Legal asks: &quot;Show us exactly what context the AI had.&quot;',
+            pain: 'Agent analyzes confidential merger docs. Legal asks: "Show us exactly what context the AI had."',
             reality: 'Best-effort prompt logs, often incomplete',
             problem: 'Not admissible as evidence'
         },
         {
             icon: PenLine,
             title: 'Who made the final decision?',
-            pain: 'AI drafts SEC filing, three executives review it. Board asks: &quot;Who signed off on what?&quot;',
+            pain: 'AI drafts SEC filing, three executives review it. Board asks: "Who signed off on what?"',
             reality: 'Email threads, comments in Google Docs',
             problem: 'Not audit-ready, no cryptographic proof'
         }

--- a/packages/docs/src/pages/webinar-thank-you.tsx
+++ b/packages/docs/src/pages/webinar-thank-you.tsx
@@ -543,7 +543,7 @@ function ProgressiveProfileForm() {
                                             size={18}
                                             style={{ display: 'inline-block', verticalAlign: 'middle', marginRight: '0.5rem' }}
                                         />
-                                        Got it! We&#39;ll tailor the workshop follow-ups to your goals.
+                                        Got it! We'll tailor the workshop follow-ups to your goals.
                                     </div>
                                 )}
 

--- a/packages/server/src/controllers/csv-parser/index.ts
+++ b/packages/server/src/controllers/csv-parser/index.ts
@@ -3,6 +3,7 @@ import csvParserService from '../../services/csv-parser'
 import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 import { StatusCodes } from 'http-status-codes'
 import { CreateCsvParseRunRequest } from '../../types/csvTypes'
+import { isCsvRunCronEnabled } from '../../utils/isCsvRunCronEnabled'
 
 const getAllCsvParseRuns = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -76,6 +77,17 @@ const createCsvParseRun = async (req: Request, res: Response, next: NextFunction
     }
 }
 
+const getWorkerStatus = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (!req.user) {
+            throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, 'Error: csvParserController.getWorkerStatus - Unauthorized')
+        }
+        return res.json({ workerEnabled: isCsvRunCronEnabled() })
+    } catch (error) {
+        next(error)
+    }
+}
+
 const getProcessedCsvSignedUrl = async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (!req.user) {
@@ -96,6 +108,7 @@ const getProcessedCsvSignedUrl = async (req: Request, res: Response, next: NextF
 
 export default {
     getAllCsvParseRuns,
+    getWorkerStatus,
     getCsvParseRunById,
     createCsvParseRun,
     getProcessedCsvSignedUrl

--- a/packages/server/src/routes/csv-parser/index.ts
+++ b/packages/server/src/routes/csv-parser/index.ts
@@ -4,6 +4,7 @@ import csvParserController from '../../controllers/csv-parser'
 const router = express.Router()
 
 router.get('/', csvParserController.getAllCsvParseRuns)
+router.get('/worker-status', csvParserController.getWorkerStatus)
 router.get('/:id', csvParserController.getCsvParseRunById)
 router.post('/', csvParserController.createCsvParseRun)
 router.get('/:id/signed-url', csvParserController.getProcessedCsvSignedUrl)

--- a/packages/server/src/utils/cron.ts
+++ b/packages/server/src/utils/cron.ts
@@ -1,6 +1,7 @@
 import cron from 'node-cron'
 import axios from 'axios'
 import logger from './logger'
+import { isCsvRunCronEnabled } from './isCsvRunCronEnabled'
 import initCsvRun from '../jobs/initCsvRun'
 import processCsvRows from '../jobs/processCsvRows'
 import generateCsv from '../jobs/generateCsv'
@@ -22,7 +23,6 @@ const API_HOST = process.env.API_HOST || `http://localhost:${process.env.PORT ||
  * Default: true
  */
 const ENABLE_BILLING_SYNC_CRON = process.env.ENABLE_BILLING_SYNC_CRON !== 'false'
-const ENABLE_CSV_RUN_CRON = process.env.ENABLE_CSV_RUN_CRON === 'true'
 
 /**
  * Initialize cron jobs
@@ -51,7 +51,7 @@ export function initCronJobs() {
         logger.info('📅 [cron]: Billing usage sync cron job is disabled')
     }
 
-    if (ENABLE_CSV_RUN_CRON) {
+    if (isCsvRunCronEnabled()) {
         logger.info('📅 [cron]: Initializing csv run cron job')
         initCsvRun()
         processCsvRows()

--- a/packages/server/src/utils/isCsvRunCronEnabled.ts
+++ b/packages/server/src/utils/isCsvRunCronEnabled.ts
@@ -1,0 +1,7 @@
+/**
+ * Single source of truth for ENABLE_CSV_RUN_CRON (Flowise server process env).
+ * Used by cron registration and the csv-parser worker-status API.
+ */
+export function isCsvRunCronEnabled(): boolean {
+    return process.env.ENABLE_CSV_RUN_CRON === 'true'
+}

--- a/packages/ui/src/themes/compStyleOverride.js
+++ b/packages/ui/src/themes/compStyleOverride.js
@@ -178,19 +178,88 @@ export default function componentStyleOverrides(theme) {
                 }
             }
         },
+        // SLIDER
+        // Anchor on `text.primary` so rail/track/thumb stay visible regardless
+        // of mode. Mirrors the unified theme override for consistency between
+        // TheAnswer pages and Flowise core canvas/dialogs.
         MuiSlider: {
             styleOverrides: {
                 root: {
+                    color: theme.darkTextPrimary,
                     '&.Mui-disabled': {
                         color: theme.colors?.grey300
                     }
                 },
+                rail: {
+                    opacity: 0.32
+                },
+                track: {
+                    border: 'none'
+                },
+                thumb: {
+                    boxShadow: 'none',
+                    '&:hover, &.Mui-focusVisible': {
+                        boxShadow: '0 0 0 6px rgba(127, 127, 127, 0.16)'
+                    }
+                },
                 mark: {
-                    backgroundColor: theme.paper,
+                    backgroundColor: theme.darkTextSecondary,
+                    opacity: 0.6,
                     width: '4px'
+                },
+                markLabel: {
+                    color: theme.darkTextSecondary,
+                    fontSize: 12
                 },
                 valueLabel: {
                     color: theme?.colors?.primaryLight
+                }
+            }
+        },
+        // SWITCH
+        // Anchor checked state on Material Blue (`#2196f3`) so the on-state
+        // reads unambiguously across both Flowise core themes. Matches the
+        // unified TheAnswer theme — switches in ChatflowGuardrails / ShareChatbot
+        // / canvas dialogs visually align with switches in the rest of the app.
+        MuiSwitch: {
+            styleOverrides: {
+                switchBase: {
+                    '&.Mui-checked': {
+                        color: '#2196f3',
+                        '& + .MuiSwitch-track': {
+                            backgroundColor: '#2196f3',
+                            opacity: 0.5
+                        },
+                        '&:hover': {
+                            backgroundColor: 'rgba(33, 150, 243, 0.08)'
+                        }
+                    }
+                }
+            }
+        },
+        // TOGGLE BUTTON
+        // Selected state on a translucent neutral overlay + heavier border so
+        // the chosen option is unmistakable in both themes.
+        MuiToggleButton: {
+            styleOverrides: {
+                root: {
+                    color: theme.darkTextPrimary,
+                    borderColor: theme.divider,
+                    textTransform: 'none',
+                    transition: 'background-color 120ms ease, border-color 120ms ease',
+                    '&:hover': {
+                        backgroundColor: theme?.customization?.isDarkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(15, 23, 42, 0.04)'
+                    },
+                    '&.Mui-selected': {
+                        backgroundColor: theme?.customization?.isDarkMode ? 'rgba(255, 255, 255, 0.16)' : 'rgba(15, 23, 42, 0.08)',
+                        color: theme.darkTextPrimary,
+                        fontWeight: 600,
+                        borderColor: theme?.customization?.isDarkMode ? 'rgba(255, 255, 255, 0.45)' : 'rgba(15, 23, 42, 0.5)',
+                        '&:hover': {
+                            backgroundColor: theme?.customization?.isDarkMode ? 'rgba(255, 255, 255, 0.16)' : 'rgba(15, 23, 42, 0.08)',
+                            borderColor: theme?.customization?.isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(15, 23, 42, 0.7)'
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Summary

### CSV Transformer — Worker Status via API
- Added `GET /api/v1/csv-parser/worker-status` endpoint on the Flowise server that exposes whether `ENABLE_CSV_RUN_CRON` is enabled
- Introduced `packages/server/src/utils/isCsvRunCronEnabled.ts` as single source of truth for the flag (used by both cron registration and the new endpoint)
- `CsvTransformer.Client.tsx` now fetches worker status from the API at runtime — the web app no longer needs `ENABLE_CSV_RUN_CRON` in its environment variables
- Removed `cronEnabled` prop from `CsvTransformerClient` and `page.tsx`; banner state is now `loading | enabled | disabled | error` driven by the live API response

### Global Theme Fixes (`muiOverrides.ts`)
- Fixed `MuiChip`: replaced blanket `glassSubtle` spread (invisible text in both modes) with solid, mode-aware surface + explicit `text.primary` label; scoped to `:not([class*="MuiChip-color"])` and `:not(.MuiChip-colorDefault)` so status chips keep MUI palette colors
- Fixed `MuiButton.contained` dark mode: was `glassPrimary` = `rgba(0,0,0,0.6)` (near-invisible); now solid `#2196f3` with proper hover
- Fixed `MuiPaper`, `MuiDialog`: replaced `glassSecondary` with solid surfaces + explicit `text.primary`
- Fixed `MuiMenu`/`MuiMenuItem`: solid backgrounds + `action.hover` hover (was `glassHover` = white-on-white in light mode)
- Fixed `MuiButton.root`: removed `glassSubtle` spread (was adding `backdropFilter: blur` to every button)
- Fixed `MuiTabs.root`: removed `glassSubtle` (was adding blur + near-white background)
- Fixed `MuiAccordion`, `MuiAlert`: replaced glass spreads with solid surfaces + explicit text colors
- Fixed `MuiBackdrop`: removed `blur(8px)` that was blurring the full page on every dropdown/select

### CSV Transformer UI Polish
- `ProcessCsv.tsx`: column selection chips now use solid `#2196f3` for selected / visible mode-aware grey for unselected (via `sx` theme callback); no longer relies on `palette.primary.main`
- `ProcessCsv.tsx`: AI Processor `Select` uses `MenuProps` to suppress full-page backdrop blur; added "Create new processor…" option that opens CSV marketplace in a new tab
- `ProcessCsv.tsx`: all navigation buttons (`Back`, `Cancel`, `Next`, `Process and Download`) use consistent `variant="outlined"` style
- Overview sidebar step titles: replaced `color="primary"` (invisible in dark mode) with `color="text.primary"` / `color="text.secondary"`
- `ProcessingHistory.tsx`: DataGrid replaced hardcoded `color: 'white'` with `text.primary` / `text.secondary` palette tokens
- `parseCsv.ts`: strip BOM/zero-width chars from headers; deduplicate column names; export `formatCsvHeaderForUi` helper
- Fixed HTML entity literals (`&apos;`, `&quot;`, `&#39;`) inside JS string literals in `ProcessCsv.tsx`, `jlinc-partnership.tsx`, `webinar-thank-you.tsx`

## Test Plan
- [ ] CSV Transformer: upload CSV, verify all column chips visible and togglable in both light and dark mode
- [ ] CSV Transformer: verify "Create new processor…" opens marketplace in new tab
- [ ] CSV Transformer: verify worker status banner shows correct state without `ENABLE_CSV_RUN_CRON` on the web env
- [ ] Processing History: verify table text readable in light and dark mode
- [ ] Spot-check chips, buttons, menus, alerts, dialogs in light and dark mode across the app
- [ ] Confirm `flowise` server build passes (`pnpm --filter flowise build`)