### PR TITLE
fix: truncate long chat titles in sidebar with ellipsis

### DIFF
--- a/packages-answers/ui/src/ChatDrawer.tsx
+++ b/packages-answers/ui/src/ChatDrawer.tsx
@@ -154,7 +154,16 @@ export default function ChatDrawer({ journeys: _journeys, chats: _chats, default
                                 <ListItemButton selected={pathname === `/chat/${chat.id}`} href={`/chat/${chat.id}`} component={NextLink}>
                                     <ListItemText
                                         secondary={chat.title}
-                                        sx={pathname === `/chat/${chat.id}` ? { '.MuiListItemText-secondary': { color: 'white' } } : {}}
+                                        sx={{
+                                            overflow: 'hidden',
+                                            '.MuiListItemText-secondary': {
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                                display: 'block',
+                                                ...(pathname === `/chat/${chat.id}` ? { color: 'white' } : {})
+                                            }
+                                        }}
                                     />
                                 </ListItemButton>
                             </ListItem>


### PR DESCRIPTION
## Summary
- Long chat titles (e.g. CSV header rows used as chat names) were overflowing the sidebar list item container and breaking the layout
- Added `overflow: hidden`, `textOverflow: 'ellipsis'`, and `whiteSpace: 'nowrap'` to the `ListItemText` secondary typography in `ChatDrawer.tsx`
- Merged with the existing conditional `color: white` style for the selected chat item

## Change
Single file: `packages-answers/ui/src/ChatDrawer.tsx`

## Test plan
- [ ] Open app with a chat whose title is a long CSV header string or any long text
- [ ] Confirm the sidebar title is truncated with `…` and does not overflow its container
- [ ] Confirm selected chat still shows white text