### PR TITLE
fix: reload page after bulk chatflow update and show in-progress state

### DIFF
--- a/packages-answers/ui/src/Admin/Chatflows/index.tsx
+++ b/packages-answers/ui/src/Admin/Chatflows/index.tsx
@@ -91,6 +91,7 @@ const AdminChatflows = () => {
     // Bulk update confirmation dialog state
     const [bulkUpdateDialogOpen, setBulkUpdateDialogOpen] = useState(false)
     const [bulkUpdateIncludeName, setBulkUpdateIncludeName] = useState(false)
+    const [bulkUpdateInProgress, setBulkUpdateInProgress] = useState(false)
 
     // Versioning state
     const [versionModalOpen, setVersionModalOpen] = useState(false)
@@ -1030,7 +1031,7 @@ const AdminChatflows = () => {
                                 <Button
                                     variant='contained'
                                     size='small'
-                                    disabled={selectedForUpdate.length === 0}
+                                    disabled={selectedForUpdate.length === 0 || bulkUpdateInProgress}
                                     onClick={() => {
                                         setBulkUpdateIncludeName(false)
                                         setBulkUpdateDialogOpen(true)
@@ -1047,7 +1048,9 @@ const AdminChatflows = () => {
                                         }
                                     }}
                                 >
-                                    Update Selected ({selectedForUpdate.length})
+                                    {bulkUpdateInProgress
+                                        ? `Updating ${selectedForUpdate.length}…`
+                                        : `Update Selected (${selectedForUpdate.length})`}
                                 </Button>
                             </Box>
                         </Box>
@@ -1087,18 +1090,18 @@ const AdminChatflows = () => {
                                 </Button>
                                 <Button
                                     variant='contained'
+                                    disabled={bulkUpdateInProgress}
                                     onClick={async () => {
                                         setBulkUpdateDialogOpen(false)
+                                        setBulkUpdateInProgress(true)
                                         try {
-                                            const response = await chatflowsApi.bulkUpdateChatflows(selectedForUpdate, {
+                                            await chatflowsApi.bulkUpdateChatflows(selectedForUpdate, {
                                                 updateName: bulkUpdateIncludeName
                                             })
-                                            if (response.updated > 0) {
-                                                window.location.reload()
-                                            }
-                                            setSelectedForUpdate([])
+                                            window.location.reload()
                                         } catch (error) {
                                             console.error('Bulk update failed:', error)
+                                            setBulkUpdateInProgress(false)
                                         }
                                     }}
                                     sx={{
@@ -1107,7 +1110,9 @@ const AdminChatflows = () => {
                                         '&:hover': { bgcolor: alpha(theme.palette.warning.main, 0.9) }
                                     }}
                                 >
-                                    Update {selectedForUpdate.length} Chatflow{selectedForUpdate.length !== 1 ? 's' : ''}
+                                    {bulkUpdateInProgress
+                                        ? `Updating ${selectedForUpdate.length} Chatflow${selectedForUpdate.length !== 1 ? 's' : ''}…`
+                                        : `Update ${selectedForUpdate.length} Chatflow${selectedForUpdate.length !== 1 ? 's' : ''}`}
                                 </Button>
                             </DialogActions>
                         </Dialog>


### PR DESCRIPTION
## Summary

Patch for the Admin Chatflows bulk update UX:

1. **Page didn't reload after update** — The previous code gated `window.location.reload()` on `response.updated > 0`, but the axios client wraps the body in `.data`, so `response.updated` was always `undefined` and the condition never fired. Fixed by removing the condition and always reloading on success.

2. **No in-progress feedback** — The button showed no indication the update was running. Added `bulkUpdateInProgress` state that disables both the trigger button and the dialog confirm button, and changes their labels to `Updating N…` while the request is in-flight. On error, the state resets so the admin can retry.

## Changes

`packages-answers/ui/src/Admin/Chatflows/index.tsx` only — no server changes.

## Test Plan

- [ ] Click "Update Selected", confirm dialog, verify button switches to "Updating N…" and is disabled
- [ ] After update completes, verify page reloads and outdated badges are gone
- [ ] Simulate a network error and verify the button re-enables for retry