### PR TITLE
fix: apply admin workspace bypass to updateChatflow

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -211,7 +211,9 @@ const updateChatflow = async (req: Request, res: Response, next: NextFunction) =
                 `Error: chatflowsController.saveChatflow - workspace ${workspaceId} not found!`
             )
         }
-        const chatflow = await chatflowsService.getChatflowById(req.params.id, workspaceId)
+        // Admins can update chatflows across their org regardless of active workspace
+        const isAdmin = req.user?.roles?.includes('Admin') || req.user?.permissions?.includes('org:manage')
+        const chatflow = await chatflowsService.getChatflowById(req.params.id, isAdmin ? undefined : workspaceId)
         if (!chatflow) {
             return res.status(404).send(`Chatflow ${req.params.id} not found`)
         }


### PR DESCRIPTION
## Root Cause

Same class of bug as PR #1075 but in `updateChatflow`.

The controller calls `getChatflowById(id, req.user.activeWorkspaceId)` before saving. The admin's `activeWorkspaceId` is their Personal Workspace — the template source chatflow lives in the Default Workspace — so the service query returns null and throws "not found in the database", blocking the save.

## Fix

One line: admins skip the workspace filter in the lookup, same pattern as the GET controller.

```typescript
const isAdmin = req.user?.roles?.includes('Admin') || req.user?.permissions?.includes('org:manage')
const chatflow = await chatflowsService.getChatflowById(req.params.id, isAdmin ? undefined : workspaceId)
```

The service still does org-scoped access — it just doesn't add a workspace filter to the SQL query for admins.

## Test Plan

- [ ] As an admin, open the default template canvas and save a change — should succeed
- [ ] As a non-admin, saving a chatflow in a workspace they don't belong to should still be blocked