### PR TITLE
fix(s3): use AWS SDK default credential chain when explicit keys are absent

### DIFF
--- a/packages/server/src/services/csv-parser/index.ts
+++ b/packages/server/src/services/csv-parser/index.ts
@@ -79,13 +79,23 @@ const createCsvParseRun = async (user: IUser, body: any) => {
             const fileBuffer = Buffer.from(base64Data, 'base64')
 
             // Upload file to S3
-            const s3 = new S3Client({
-                region: process.env.S3_STORAGE_REGION ?? 'us-east-1',
-                credentials: {
-                    accessKeyId: process.env.S3_STORAGE_ACCESS_KEY_ID ?? '',
-                    secretAccessKey: process.env.S3_STORAGE_SECRET_ACCESS_KEY ?? ''
+            const s3Config: any = {
+                region: process.env.S3_STORAGE_REGION ?? 'us-east-1'
+            }
+            // Only set explicit credentials when present — otherwise the AWS SDK
+            // falls through to the default credential chain (IAM roles, ECS task
+            // roles, Copilot-injected env, etc.)
+            if (process.env.S3_STORAGE_ACCESS_KEY_ID && process.env.S3_STORAGE_SECRET_ACCESS_KEY) {
+                s3Config.credentials = {
+                    accessKeyId: process.env.S3_STORAGE_ACCESS_KEY_ID,
+                    secretAccessKey: process.env.S3_STORAGE_SECRET_ACCESS_KEY
                 }
-            })
+            }
+            if (process.env.S3_ENDPOINT_URL) {
+                s3Config.endpoint = process.env.S3_ENDPOINT_URL
+                s3Config.forcePathStyle = true
+            }
+            const s3 = new S3Client(s3Config)
             await s3.send(
                 new PutObjectCommand({
                     Bucket: process.env.S3_STORAGE_BUCKET_NAME ?? '',


### PR DESCRIPTION
## Problem

Four places in the codebase were building S3 clients with:

\`\`\`ts
credentials: {
    accessKeyId: process.env.S3_STORAGE_ACCESS_KEY_ID ?? '',
    secretAccessKey: process.env.S3_STORAGE_SECRET_ACCESS_KEY ?? ''
}
\`\`\`

Passing an **empty string** is not the same as omitting `credentials`. AWS SDK v3 sees a credential object with an empty AKID and immediately throws:

> The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.

This breaks any deployment that relies on IAM instance roles, ECS task roles, or Copilot-injected credentials rather than explicit env vars.

## Fix

Only attach `credentials` when **both** env vars are non-empty — otherwise omit them entirely so the AWS SDK falls through to its default credential chain (IAM roles, ECS/Copilot task roles, `~/.aws/credentials`, etc.).

This is the same pattern already used by `chatflow-storage`, `video-generator`, `dalle-image`, `dalle-image-upload`, and the logger throughout the repo.

## Files changed

| File | Issue |
|------|-------|
| `packages/server/src/services/csv-parser/index.ts` | Inline `new S3Client` with `?? ''` on both keys |
| `packages-answers/scripts/generateCsv.ts` | Top-level `new S3` with `?? ''` on both keys |
| `packages-answers/scripts/initCsvRun.ts` | Top-level `new S3` with `?? ''` on both keys |
| `packages-answers/utils/src/ingest/document.ts` | `new S3Client` inside function — already had an early-exit guard but still passed potentially-empty strings into `credentials` |

## Test plan
- [ ] Deploy to an environment using IAM/Copilot credentials (no explicit `S3_STORAGE_ACCESS_KEY_ID`) — CSV upload and processing should succeed
- [ ] Deploy with explicit `S3_STORAGE_ACCESS_KEY_ID` / `S3_STORAGE_SECRET_ACCESS_KEY` — still works as before