### PR TITLE
fix(s3): use AWS SDK default credential chain in standalone scripts and ingest util

### DIFF
--- a/packages-answers/scripts/generateCsv.ts
+++ b/packages-answers/scripts/generateCsv.ts
@@ -4,13 +4,16 @@ import { parse } from 'csv-parse/sync'
 import { AppCsvParseRuns } from '../db/generated/prisma-client'
 import { prisma } from '../db/src/client'
 
-const s3 = new S3({
-    region: process.env.S3_STORAGE_REGION ?? 'us-east-1',
-    credentials: {
-        accessKeyId: process.env.S3_STORAGE_ACCESS_KEY_ID ?? '',
-        secretAccessKey: process.env.S3_STORAGE_SECRET_ACCESS_KEY ?? ''
+const s3Config: any = {
+    region: process.env.S3_STORAGE_REGION ?? 'us-east-1'
+}
+if (process.env.S3_STORAGE_ACCESS_KEY_ID && process.env.S3_STORAGE_SECRET_ACCESS_KEY) {
+    s3Config.credentials = {
+        accessKeyId: process.env.S3_STORAGE_ACCESS_KEY_ID,
+        secretAccessKey: process.env.S3_STORAGE_SECRET_ACCESS_KEY
     }
-})
+}
+const s3 = new S3(s3Config)
 
 function collectAllColumnKeys(rows: Array<Record<string, unknown>>): string[] {
     const seen = new Set<string>()

--- a/packages-answers/scripts/initCsvRun.ts
+++ b/packages-answers/scripts/initCsvRun.ts
@@ -4,13 +4,16 @@ import { parse } from 'csv-parse/sync'
 import { AppCsvParseRuns } from '../db/generated/prisma-client'
 import { prisma } from '../db/src/client'
 
-const s3 = new S3({
-    region: process.env.S3_STORAGE_REGION ?? 'us-east-1',
-    credentials: {
-        accessKeyId: process.env.S3_STORAGE_ACCESS_KEY_ID ?? '',
-        secretAccessKey: process.env.S3_STORAGE_SECRET_ACCESS_KEY ?? ''
+const s3Config: any = {
+    region: process.env.S3_STORAGE_REGION ?? 'us-east-1'
+}
+if (process.env.S3_STORAGE_ACCESS_KEY_ID && process.env.S3_STORAGE_SECRET_ACCESS_KEY) {
+    s3Config.credentials = {
+        accessKeyId: process.env.S3_STORAGE_ACCESS_KEY_ID,
+        secretAccessKey: process.env.S3_STORAGE_SECRET_ACCESS_KEY
     }
-})
+}
+const s3 = new S3(s3Config)
 
 const initCsvRun = async (csvParseRun: AppCsvParseRuns) => {
     try {

--- a/packages-answers/utils/src/ingest/document.ts
+++ b/packages-answers/utils/src/ingest/document.ts
@@ -320,10 +320,10 @@ export const processDocument: EventVersionHandler<{
 
         const s3Client = new S3Client({
             region: AWS_S3_REGION,
-            credentials: {
-                accessKeyId: S3_STORAGE_ACCESS_KEY_ID,
-                secretAccessKey: S3_STORAGE_SECRET_ACCESS_KEY
-            }
+            credentials:
+                S3_STORAGE_ACCESS_KEY_ID && S3_STORAGE_SECRET_ACCESS_KEY
+                    ? { accessKeyId: S3_STORAGE_ACCESS_KEY_ID, secretAccessKey: S3_STORAGE_SECRET_ACCESS_KEY }
+                    : undefined
         })
 
         const command = new GetObjectCommand({


### PR DESCRIPTION
## Problem

Three more files had the same `?? ''` S3 credential bug fixed in #1079 — passes empty strings when env vars are absent, breaking IAM/Copilot/ECS deployments.

## Files changed

| File | Issue |
|------|-------|
| `packages-answers/scripts/generateCsv.ts` | Top-level `new S3` with `?? ''` on both keys |
| `packages-answers/scripts/initCsvRun.ts` | Top-level `new S3` with `?? ''` on both keys |
| `packages-answers/utils/src/ingest/document.ts` | `new S3Client` with explicit credentials passed unconditionally |

## Fix

Same pattern as #1079 — only attach `credentials` when both env vars are non-empty; otherwise omit and let the AWS SDK default credential chain handle it (IAM, ECS task roles, Copilot, Render env vars, etc.).

## Test plan
- [ ] Verify CSV standalone scripts work in IAM-based env (no explicit S3 keys)
- [ ] Verify document ingest works in IAM-based env
- [ ] Confirm Render (explicit env vars) still works as before