### PR TITLE
fix: raise answeragent-mcp timeout and batch vectorstore chunk lookup

### DIFF
--- a/packages/components/nodes/tools/MCP/AnswerAgent/AnswerAgentMCP.ts
+++ b/packages/components/nodes/tools/MCP/AnswerAgent/AnswerAgentMCP.ts
@@ -132,7 +132,9 @@ class AnswerAgent_MCP implements INode {
             args: [packagePath],
             env: {
                 ANSWERAGENT_AI_API_BASE_URL: apiHost,
-                ANSWERAGENT_AI_API_TOKEN: apiKey
+                ANSWERAGENT_AI_API_TOKEN: apiKey,
+                // Subprocess does not inherit process.env; without this the axios client defaults to a 5s timeout
+                API_TIMEOUT: process.env.ANSWERAGENT_MCP_API_TIMEOUT || '30000'
             }
         }
 

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1989,12 +1989,18 @@ const queryVectorStore = async (data: ICommonObject, workspaceId: string) => {
                 id: uuidv4()
             }
         })
-        // query our document store chunk with the storeId and pageContent
-        for (const doc of docs) {
-            const documentStoreChunk = await appServer.AppDataSource.getRepository(DocumentStoreFileChunk).findOneBy({
-                storeId: data.storeId,
-                pageContent: doc.pageContent
+        // Backfill chunk id/chunkNo with a single batched query instead of one lookup per doc
+        const chunkByContent = new Map<string, DocumentStoreFileChunk>()
+        if (docs.length > 0) {
+            const documentStoreChunks = await appServer.AppDataSource.getRepository(DocumentStoreFileChunk).find({
+                where: { storeId: data.storeId, pageContent: In(docs.map((doc: any) => doc.pageContent)) }
             })
+            for (const chunk of documentStoreChunks) {
+                if (!chunkByContent.has(chunk.pageContent)) chunkByContent.set(chunk.pageContent, chunk)
+            }
+        }
+        for (const doc of docs) {
+            const documentStoreChunk = chunkByContent.get(doc.pageContent)
             if (documentStoreChunk) {
                 doc.id = documentStoreChunk.id
                 doc.chunkNo = documentStoreChunk.chunkNo


### PR DESCRIPTION
## Problem

The MCP `query_vector_store` / `query_vector_store_with_filter` tools (used by the Kumello agent) intermittently fail with `MCP error -32603: timeout of 5000ms exceeded`.

Two separate root causes:

1. **5s client timeout with no margin.** `@answerai/answeragent-mcp`'s axios client defaults to `timeout: 5000`. The `AnswerAgentMCP` node spawns the MCP as a stdio subprocess, and `MCP/core.ts` spawns it with `env: { ...serverParams.env, PATH }` — the subprocess does **not** inherit `process.env`, so setting `API_TIMEOUT` on the service has no effect.
2. **A slow post-query loop.** `queryVectorStore` reports only `retriever.invoke()` as `timeTaken` (~0.3–0.5s), but then runs one `DocumentStoreFileChunk.findOneBy({ storeId, pageContent })` per result doc — N unindexed lookups on a `text` column. The full request takes 1–4s and the tail crosses 5s under load.

## Changes

- **`AnswerAgentMCP.ts`** — pass `API_TIMEOUT` into the subprocess `env` (default `30000`, overridable via the `ANSWERAGENT_MCP_API_TIMEOUT` service env var). 30s is below the MCP SDK's 60s request timeout, so a genuinely slow call still fails cleanly.
- **`documentstore/index.ts` (`queryVectorStore`)** — replace the per-doc lookup loop with a single batched `In()` query, guarded against an empty `docs` array (`In([])` is undefined behavior in TypeORM). Behavior-equivalent; `In` was already imported.

## Verification

- `pnpm --filter flowise-components build` ✅
- `pnpm --filter flowise build` (server) ✅
- Behavior-equivalent: `doc.id` / `doc.chunkNo` outcomes unchanged, including the `else` fallback branch.
- `doc.id` / `doc.chunkNo` are consumed only by the Flowise UI "Test Query" view — the MCP/agent path never reads them, so the loop change cannot alter agent behavior.

## Risk

Low and contained. Edit 1 only supplies a value to an already-supported knob and only affects the AnswerAgent MCP subprocess. Edit 2 only touches data used by an internal UI view, never the agent path.

## Deploy

Requires a redeploy of the Kumello Flowise service after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
