### PR TITLE
feat(docs): 301 redirect docs.theanswer.ai root to /docs/intro

### DIFF
--- a/packages/docs/vercel.json
+++ b/packages/docs/vercel.json
@@ -27,6 +27,19 @@
             ]
         }
     ],
+    "redirects": [
+        {
+            "source": "/",
+            "has": [
+                {
+                    "type": "host",
+                    "value": "docs.theanswer.ai"
+                }
+            ],
+            "destination": "https://docs.theanswer.ai/docs/intro",
+            "statusCode": 301
+        }
+    ],
     "rewrites": [
         {
             "source": "/sitemap.xml",


### PR DESCRIPTION
## Summary
- Adds a Vercel edge `redirect` in `packages/docs/vercel.json` so that hitting the root of `docs.theanswer.ai` issues a **301** to `https://docs.theanswer.ai/docs/intro`.
- Host-scoped via a `has` host condition to `docs.theanswer.ai`, so the `answeragent.ai` marketing landing page at `/` is unaffected.
- Uses `"statusCode": 301` explicitly (Vercel's `"permanent": true` emits a 308, not a 301).

## Context
The docs site is a Docusaurus static build deployed on Vercel. Vercel `redirects` are handled at the routing/edge layer and apply to static deployments, so no app-level code is needed.

## Caveat / assumption
This only takes effect if `docs.theanswer.ai` is a domain attached to **this** Vercel project (the `packages/docs` build). If that domain is served by a separate project or a DNS/proxy-level redirect, this config won't apply and the redirect should be configured there instead.

## Test plan
- [ ] After deploy, `curl -I https://docs.theanswer.ai/` returns `301` with `location: https://docs.theanswer.ai/docs/intro`.
- [ ] `curl -I https://answeragent.ai/` is unchanged (still 200, no redirect).
- [ ] Deep links like `https://docs.theanswer.ai/docs/intro` and other docs paths are unaffected.