### PR TITLE
fix(ContentfulLoader): only apply sys.archivedAt filter on Preview API

### DIFF
--- a/packages/components/nodes/documentloaders/Contentful/Contentful.ts
+++ b/packages/components/nodes/documentloaders/Contentful/Contentful.ts
@@ -548,8 +548,14 @@ class ContentfulLoader extends BaseDocumentLoader {
     private async runQuery(): Promise<Document[]> {
         let query: any = this.metadata || {}
 
-        // Explicitly exclude archived entries
-        query['sys.archivedAt[exists]'] = false
+        // sys.archivedAt is only a valid query property on the Preview API.
+        // The Delivery (CDN) API rejects it with a 400 because published entries
+        // can never be archived, so only apply the filter for preview requests.
+        // (Archived entries are never returned by the Delivery API anyway, and the
+        // post-fetch sys.archivedVersion filter below remains as a safety net.)
+        if (this.host === 'preview.contentful.com') {
+            query['sys.archivedAt[exists]'] = false
+        }
 
         if (this.limit) {
             query.limit = this.limit


### PR DESCRIPTION
## Summary
The Contentful document loader unconditionally added `sys.archivedAt[exists]=false` to every query in `runQuery()`. This property is only valid on the **Preview API**. The **Delivery (CDN) API** rejects it with:

```
400 Bad Request
The property "sys.archivedAt" is invalid when querying a published Entry
```

because published entries can never be archived. As a result, any document store backed by the Delivery API fails to refresh/upsert.

## Fix
Scope the `sys.archivedAt[exists]=false` filter to the Preview API host (`preview.contentful.com`). The Delivery API never returns archived entries anyway, and the existing post-fetch `sys.archivedVersion` filter is left in place as a safety net.

```ts
if (this.host === 'preview.contentful.com') {
    query['sys.archivedAt[exists]'] = false
}
```

## Impact
- Delivery-API-backed document stores can refresh/upsert again.
- Preview-API behavior is unchanged (archived entries still excluded).

## Test plan
- [ ] Refresh a document store configured against the Delivery API (`cdn.contentful.com`) and confirm it completes without the 400.
- [ ] Refresh a document store configured against the Preview API and confirm archived entries remain excluded.