### PR TITLE
fix(ui): remove phantom sidebar offset causing main content overflow

### DIFF
--- a/packages/ui/src/layout/MainLayout/index.jsx
+++ b/packages/ui/src/layout/MainLayout/index.jsx
@@ -8,7 +8,6 @@ import { styled, useTheme } from '@mui/material/styles'
 import { AppBar, Box, CssBaseline, useMediaQuery } from '@mui/material'
 
 // project imports
-import { drawerWidth } from '@/store/constant'
 import { SET_MENU } from '@/store/actions'
 import PropTypes from 'prop-types'
 
@@ -23,21 +22,16 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(({
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen
         }),
+        // The in-layout <Sidebar /> drawer is not rendered (the studio uses its own AppDrawer),
+        // so do not offset the content by drawerWidth here or it overflows / shifts off-screen.
+        marginLeft: 0,
         marginRight: 0,
-        [theme.breakpoints.up('md')]: {
-            marginLeft: -drawerWidth,
-            width: `calc(100% - ${drawerWidth}px)`
-        },
+        width: '100%',
         [theme.breakpoints.down('md')]: {
-            marginLeft: '20px',
-            width: `calc(100% - ${drawerWidth}px)`,
             padding: '16px'
         },
         [theme.breakpoints.down('sm')]: {
-            marginLeft: '10px',
-            width: `calc(100% - ${drawerWidth}px)`,
-            padding: '16px',
-            marginRight: '10px'
+            padding: '16px'
         }
     }),
     ...(open && {


### PR DESCRIPTION
## Summary
- `MainLayout`'s main content area offset itself by `drawerWidth` (260px) whenever the menu state was "closed" (the default below the `lg` breakpoint), via `margin-left: -260px` and `width: calc(100% - 260px)`.
- The in-layout `<Sidebar />` drawer it was compensating for is commented out (the studio renders its own `AppDrawer`), so this offset was phantom: it shifted content off-screen and shrank its width by 260px, breaking responsiveness on sub-`lg` widths.
- The `!open` branch now uses `margin-left: 0`, `width: 100%`, keeping only the responsive `padding`. Removed the now-unused `drawerWidth` import.

This is the permanent equivalent of "unchecking" `margin-left: -260px` (and reclaiming the lost 260px of width) that was confirmed to fix the layout in devtools.

## Test plan
- [ ] Load a `sidekick-studio` page (e.g. `/sidekick-studio/admin/guardrails`)
- [ ] Resize the viewport below ~1200px (lg) and confirm content is no longer shifted off-screen or horizontally overflowing
- [ ] Confirm layout is unchanged at >= lg widths