### PR TITLE
fix(ui): guard error.response in api client interceptor

### DIFF
--- a/packages/ui/src/api/client.js
+++ b/packages/ui/src/api/client.js
@@ -29,7 +29,7 @@ apiClient.interceptors.response.use(
         return response
     },
     async (error) => {
-        if (error.response.status === 401) {
+        if (error.response?.status === 401) {
             // check if refresh is needed
             if (error.response.data.message === ErrorMessage.TOKEN_EXPIRED && error.response.data.retry === true) {
                 const originalRequest = error.config


### PR DESCRIPTION
## Summary
- Harden the shared axios response interceptor in `packages/ui/src/api/client.js` to use optional chaining (`error.response?.status`) instead of `error.response.status`.
- On network failures, CORS-blocked responses, and gateway timeouts (e.g. a `504 Gateway Timeout` returned by the ALB with no `Access-Control-Allow-Origin` header), `error.response` is `undefined`. The previous code threw `Cannot read properties of undefined (reading 'status')`, which aborted the interceptor and masked the real failure across the whole app.
- With this guard, such errors now fall through to the existing `return Promise.reject(error)`, so callers' `.catch` handlers run and the actual error message surfaces.

### Context
Surfaced while diagnosing the Guardrails Settings page: `GET /api/v1/guardrails/selftest` was returning a `504` (backend can't reach the Fiddler VPC endpoint outside the VPN), and the resulting CORS/`ERR_FAILED` rejection had no `error.response`, triggering the `reading 'status'` crash shown in the Plan capabilities panel. This change does not fix the underlying Fiddler reachability (infra/VPC endpoint work); it only makes the client fail gracefully.

### Risk
Behavior is unchanged for any real HTTP response (including the 401 / token-refresh flow, which still has `error.response`). The optional chaining only adds graceful handling for the previously-crashing no-response case.

## Test plan
- [ ] Trigger an API call that fails with no response (e.g. network offline / 504 from gateway) and confirm the UI shows a real error instead of `Cannot read properties of undefined (reading 'status')`.
- [ ] Confirm a genuine 401 still triggers token refresh / redirect to login as before.