### PR TITLE
feat(apikey): track per-key usage and fix API Keys columns

### DIFF
--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -513,7 +513,9 @@ export interface IApiKey {
     keyName: string
     apiKey: string
     apiSecret: string
+    createdAt?: Date
     updatedDate: Date
+    usageCount?: number
     organizationId: string
     userId: string
     lastUsedAt?: Date

--- a/packages/server/src/database/entities/ApiKey.ts
+++ b/packages/server/src/database/entities/ApiKey.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm'
+import { Column, CreateDateColumn, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm'
 import { IApiKey, IApiKeyMetadata } from '../../Interface'
 
 @Entity('apikey')
@@ -16,8 +16,15 @@ export class ApiKey implements IApiKey {
     keyName: string
 
     @Column({ type: 'timestamp' })
+    @CreateDateColumn()
+    createdAt: Date
+
+    @Column({ type: 'timestamp' })
     @UpdateDateColumn()
     updatedDate: Date
+
+    @Column({ type: 'int', default: 0 })
+    usageCount: number
 
     @Column({ type: 'uuid' })
     organizationId: string

--- a/packages/server/src/database/migrations/postgres/aai/1770000000004-AddApiKeyUsageTracking.ts
+++ b/packages/server/src/database/migrations/postgres/aai/1770000000004-AddApiKeyUsageTracking.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddApiKeyUsageTracking1770000000004 implements MigrationInterface {
+    name = 'AddApiKeyUsageTracking1770000000004'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "apikey" ADD COLUMN IF NOT EXISTS "createdAt" TIMESTAMP`)
+        await queryRunner.query(`ALTER TABLE "apikey" ADD COLUMN IF NOT EXISTS "usageCount" integer NOT NULL DEFAULT 0`)
+
+        // Backfill createdAt for existing rows using updatedDate as the best available approximation
+        await queryRunner.query(`UPDATE "apikey" SET "createdAt" = "updatedDate" WHERE "createdAt" IS NULL`)
+
+        // Enforce default + not null now that existing rows are backfilled
+        await queryRunner.query(`ALTER TABLE "apikey" ALTER COLUMN "createdAt" SET DEFAULT now()`)
+        await queryRunner.query(`ALTER TABLE "apikey" ALTER COLUMN "createdAt" SET NOT NULL`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "apikey" DROP COLUMN IF EXISTS "usageCount"`)
+        await queryRunner.query(`ALTER TABLE "apikey" DROP COLUMN IF EXISTS "createdAt"`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -99,6 +99,7 @@ import { MoveDefaultChatflowsToPersonalWorkspace1770000000000 } from './aai/1770
 import { NormalizeLegacyCredentialNames1770000000001 } from './aai/1770000000001-NormalizeLegacyCredentialNames'
 import { FixBulkUpdateChatflowWorkspace1770000000002 } from './aai/1770000000002-FixBulkUpdateChatflowWorkspace'
 import { FixTemplateSourceChatflowWorkspace1770000000003 } from './aai/1770000000003-FixTemplateSourceChatflowWorkspace'
+import { AddApiKeyUsageTracking1770000000004 } from './aai/1770000000004-AddApiKeyUsageTracking'
 
 export const postgresMigrations = [
     Init1693891895163,
@@ -202,5 +203,7 @@ export const postgresMigrations = [
     // AAI: Fix chatflows re-assigned to Default Workspace by bulkUpdateChatflows workspace leak
     FixBulkUpdateChatflowWorkspace1770000000002,
     // AAI: Move INITIAL_CHATFLOW_IDS source templates to Default Workspace for consistent admin access
-    FixTemplateSourceChatflowWorkspace1770000000003
+    FixTemplateSourceChatflowWorkspace1770000000003,
+    // AAI: Track per-key API usage (usageCount, lastUsedAt) and add createdAt to apikey
+    AddApiKeyUsageTracking1770000000004
 ]

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -34,6 +34,7 @@ import { Workspace } from './enterprise/database/entities/workspace.entity'
 import { Organization } from './enterprise/database/entities/organization.entity'
 import { GeneralRole, Role } from './enterprise/database/entities/role.entity'
 import { migrateApiKeysFromJsonToDb } from './utils/apiKey'
+import apikeyService from './services/apikey'
 import { ExpressAdapter } from '@bull-board/express'
 
 import { createRedisStore } from './AppConfig'
@@ -278,6 +279,11 @@ export class App {
                 if (!isValid || !apiKey) {
                     return res.status(401).json({ error: 'Unauthorized Access' })
                 }
+
+                // Record usage (increment usageCount + set lastUsedAt) without blocking the request
+                apikeyService.recordApiKeyUsage(apiKey.id).catch((error: unknown) => {
+                    logger.error(`[server]: Failed to record API key usage: ${error instanceof Error ? error.message : error}`)
+                })
 
                 // Find workspace
                 const workspace = await this.AppDataSource.getRepository(Workspace).findOne({

--- a/packages/server/src/middlewares/authentication/index.ts
+++ b/packages/server/src/middlewares/authentication/index.ts
@@ -107,6 +107,11 @@ const tryApiKeyAuth = async (
         return null
     }
 
+    // Record usage (increment usageCount + set lastUsedAt) without blocking the request
+    apikeyService.recordApiKeyUsage(apiKeyData.id).catch((error) => {
+        console.error('[Auth] Failed to record API key usage:', error instanceof Error ? error.message : error)
+    })
+
     // Return user with API key's org/workspace context (may differ from user's current org)
     return {
         user,

--- a/packages/server/src/services/apikey/index.ts
+++ b/packages/server/src/services/apikey/index.ts
@@ -206,6 +206,7 @@ const importKeys = async (body: any) => {
                         currentKey.workspaceId = workspaceId
                         currentKey.organizationId = organizationId
                         currentKey.userId = userId
+                        if (key.createdAt) currentKey.createdAt = new Date(key.createdAt)
                         await appServer.AppDataSource.getRepository(ApiKey).save(currentKey)
                         break
                     }
@@ -230,6 +231,7 @@ const importKeys = async (body: any) => {
                 newKey.workspaceId = workspaceId
                 newKey.organizationId = organizationId
                 newKey.userId = userId
+                if (key.createdAt) newKey.createdAt = new Date(key.createdAt)
                 const newKeyEntity = appServer.AppDataSource.getRepository(ApiKey).create(newKey)
                 await appServer.AppDataSource.getRepository(ApiKey).save(newKeyEntity)
             }
@@ -237,6 +239,25 @@ const importKeys = async (body: any) => {
         return await getAllApiKeysFromDB(workspaceId)
     } catch (error) {
         throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Error: apikeyService.importKeys - ${getErrorMessage(error)}`)
+    }
+}
+
+// Record a single use of an API key: increment usage counter and update lastUsedAt.
+// Intended to be called fire-and-forget from the auth middleware so it never adds request latency.
+const recordApiKeyUsage = async (id: string): Promise<void> => {
+    try {
+        const appServer = getRunningExpressApp()
+        await appServer.AppDataSource.getRepository(ApiKey)
+            .createQueryBuilder()
+            .update(ApiKey)
+            .set({ usageCount: () => '"usageCount" + 1', lastUsedAt: () => 'now()' })
+            .where('id = :id', { id })
+            .execute()
+    } catch (error) {
+        throw new InternalFlowiseError(
+            StatusCodes.INTERNAL_SERVER_ERROR,
+            `Error: apikeyService.recordApiKeyUsage - ${getErrorMessage(error)}`
+        )
     }
 }
 
@@ -269,6 +290,7 @@ export default {
     getAllApiKeys,
     updateApiKey,
     verifyApiKey,
+    recordApiKeyUsage,
     getApiKey,
     getApiKeyById,
     importKeys

--- a/packages/ui/src/views/apikey/index.jsx
+++ b/packages/ui/src/views/apikey/index.jsx
@@ -132,7 +132,11 @@ function APIKeyRow(props) {
                         </IconButton>
                     )}
                 </StyledTableCell>
-                <StyledTableCell>{moment(props.apiKey.createdAt).format('MMMM Do, YYYY')}</StyledTableCell>
+                <StyledTableCell>{props.apiKey.usageCount ?? 0}</StyledTableCell>
+                <StyledTableCell>
+                    {props.apiKey.lastUsedAt ? moment(props.apiKey.lastUsedAt).format('MMMM Do, YYYY') : 'Never'}
+                </StyledTableCell>
+                <StyledTableCell>{props.apiKey.createdAt ? moment(props.apiKey.createdAt).format('MMMM Do, YYYY') : '-'}</StyledTableCell>
                 <Available permission={'apikeys:update,apikeys:create'}>
                     <StyledTableCell>
                         <IconButton title='Edit' color='primary' onClick={props.onEditClick}>
@@ -150,7 +154,7 @@ function APIKeyRow(props) {
             </TableRow>
             {open && (
                 <TableRow sx={{ '& td': { border: 0 } }}>
-                    <StyledTableCell sx={{ p: 2 }} colSpan={6}>
+                    <StyledTableCell sx={{ p: 2 }} colSpan={8}>
                         <Collapse in={open} timeout='auto' unmountOnExit>
                             <Box sx={{ borderRadius: 2, border: 1, borderColor: theme.palette.grey[900] + 25, overflow: 'hidden' }}>
                                 <Table aria-label='chatflow table'>
@@ -445,8 +449,10 @@ const APIKey = () => {
                                             <TableRow>
                                                 <StyledTableCell>Key Name</StyledTableCell>
                                                 <StyledTableCell>API Key</StyledTableCell>
-                                                <StyledTableCell>Usage</StyledTableCell>
-                                                <StyledTableCell>Updated</StyledTableCell>
+                                                <StyledTableCell>Connected</StyledTableCell>
+                                                <StyledTableCell>API Calls</StyledTableCell>
+                                                <StyledTableCell>Last Used</StyledTableCell>
+                                                <StyledTableCell>Created</StyledTableCell>
                                                 <Available permission={'apikeys:update,apikeys:create'}>
                                                     <StyledTableCell> </StyledTableCell>
                                                 </Available>
@@ -471,6 +477,12 @@ const APIKey = () => {
                                                         <StyledTableCell>
                                                             <Skeleton variant='text' />
                                                         </StyledTableCell>
+                                                        <StyledTableCell>
+                                                            <Skeleton variant='text' />
+                                                        </StyledTableCell>
+                                                        <StyledTableCell>
+                                                            <Skeleton variant='text' />
+                                                        </StyledTableCell>
                                                         <Available permission={'apikeys:update,apikeys:create'}>
                                                             <StyledTableCell> </StyledTableCell>
                                                         </Available>
@@ -479,6 +491,12 @@ const APIKey = () => {
                                                         </Available>
                                                     </StyledTableRow>
                                                     <StyledTableRow>
+                                                        <StyledTableCell>
+                                                            <Skeleton variant='text' />
+                                                        </StyledTableCell>
+                                                        <StyledTableCell>
+                                                            <Skeleton variant='text' />
+                                                        </StyledTableCell>
                                                         <StyledTableCell>
                                                             <Skeleton variant='text' />
                                                         </StyledTableCell>


### PR DESCRIPTION
## Summary

Fixes two bugs on the API Keys page (`/sidekick-studio/apikey`) and adds real per-key usage tracking.

- **"Updated" always showed today** — the UI read `apiKey.createdAt`, which the server never sent, so `moment(undefined)` rendered as the current date.
- **"Usage" always 0** — that column was really `chatFlows.length` (connected chatflows); there was no API-call counter at all.

### Changes
**Server**
- `ApiKey` entity + `IApiKey`: add `createdAt` (`@CreateDateColumn`) and `usageCount` (int, default 0).
- New Postgres migration `1770000000004-AddApiKeyUsageTracking` — adds both columns and backfills `createdAt` from `updatedDate` for existing rows.
- New `apikeyService.recordApiKeyUsage(id)` — atomic `usageCount + 1` and `lastUsedAt = now()`.
- Wired fire-and-forget into the API-key auth chokepoint (`handleApiKeyAuth` in `index.ts`) so every authenticated request with a key is counted without adding latency.
- `importKeys` now persists the imported `createdAt` (previously validated then discarded).

**UI** (`packages/ui/src/views/apikey/index.jsx`)
- Replaced the conflated columns with: **Connected | API Calls | Last Used | Created** (dropped the buggy "Updated"). Updated skeleton rows and the collapsible `colSpan`.

### Notes
- Migration is **Postgres-only** (the deployment DB). Can add mysql/mariadb/sqlite parity if desired.
- Dropped "Updated" in favor of "Created"; easy to restore both if preferred.

## Test plan

Verified live against the dev stack + real Postgres:
- [x] Migration applies; `apikey` gains `createdAt` (not null) and `usageCount` (default 0); existing key backfilled to its real created date.
- [x] **API Calls**: 3 authenticated requests → `usageCount` 0→3 (further list calls increment as expected).
- [x] **Last Used**: `lastUsedAt` null → updates on each use.
- [x] **Created**: shows real creation date (May 4), not today.
- [x] **Connected**: linking a chatflow via `apikeyid` shows count 1 with flow details (test row cleaned up).
- [x] `GET /api/v1/apikey` payload includes `createdAt`, `usageCount`, `lastUsedAt`.
- [x] UI renders all columns correctly (Connected, API Calls, Last Used = June 3rd 2026, Created = May 4th 2026).